### PR TITLE
fix: lazy imports in silas.core.__init__ to prevent test hangs

### DIFF
--- a/silas/core/__init__.py
+++ b/silas/core/__init__.py
@@ -1,7 +1,13 @@
+"""Core module — lightweight re-exports only.
+
+Stream is NOT imported here to avoid pulling in FastAPI/WebChannel
+at import time (breaks test isolation).  Import Stream directly:
+    from silas.core.stream import Stream
+"""
+
 from silas.core.context_manager import LiveContextManager
 from silas.core.plan_parser import MarkdownPlanParser
-from silas.core.stream import Stream
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.core.turn_context import TurnContext
 
-__all__ = ["HeuristicTokenCounter", "LiveContextManager", "MarkdownPlanParser", "Stream", "TurnContext"]
+__all__ = ["HeuristicTokenCounter", "LiveContextManager", "MarkdownPlanParser", "TurnContext"]


### PR DESCRIPTION
## Problem
`silas/core/__init__.py` eagerly imported `Stream`, which imports `FastAPI`/`WebChannel`. Any test importing `TurnContext` (via conftest) dragged in the entire web stack, causing pytest to hang indefinitely.

## Fix
Removed `Stream` from `silas/core/__init__.py`. Stream should be imported directly: `from silas.core.stream import Stream`.

## Result
- All 190 tests pass in 0.69s (previously hung indefinitely)
- ruff clean
- Both Codex sessions were blocked on this