### PR TITLE
feat: wire LiveContextManager into Stream turn loop

### DIFF
--- a/silas/core/turn_context.py
+++ b/silas/core/turn_context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from silas.protocols.audit import AuditLog
 from silas.protocols.chronicle import ChronicleStore
@@ -13,6 +13,9 @@ from silas.protocols.proactivity import AutonomyCalibrator, SuggestionEngine
 from silas.protocols.skills import SkillLoader, SkillResolver
 from silas.protocols.work import WorkItemExecutor
 
+if TYPE_CHECKING:
+    from silas.core.context_manager import LiveContextManager
+
 
 class StructuredAgentRunner(Protocol):
     async def run(self, prompt: str) -> object: ...
@@ -22,6 +25,7 @@ class StructuredAgentRunner(Protocol):
 class TurnContext:
     scope_id: str = "owner"
     context_manager: ContextManager | None = None
+    live_context_manager: LiveContextManager | None = None
     memory_store: MemoryStore | None = None
     chronicle_store: ChronicleStore | None = None
     proxy: StructuredAgentRunner | None = None

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -28,11 +28,16 @@ class TestModel:
         self.message_prefix = message_prefix
 
     async def run(self, prompt: str) -> RunResult:
+        user_prompt = prompt
+        marker = "\n\n[USER MESSAGE]\n"
+        if marker in prompt:
+            user_prompt = prompt.split(marker, 1)[1]
+
         decision = RouteDecision(
             route="direct",
             reason="test_model",
             response=AgentResponse(
-                message=f"{self.message_prefix} {prompt}",
+                message=f"{self.message_prefix} {user_prompt}",
                 needs_approval=False,
             ),
             interaction_register=InteractionRegister.status,


### PR DESCRIPTION
## What
Integrates LiveContextManager into the Stream turn loop (Phase 2 Brain wiring).

## Changes
- **main.py**: Creates LiveContextManager from config token_budget + HeuristicTokenCounter
- **stream.py**: Context rendering before proxy call (`[CONTEXT]`/`[USER MESSAGE]` markers), budget enforcement after response with eviction auditing
- **turn_context.py**: Added `live_context_manager` typed field
- **web.py**: Replaced `StaticFiles` mount with manual static file serving (fixes ASGI transport hang in tests)
- **fakes.py**: FakeProxy extracts user message from new prompt format

## Tests
190 passed in 0.71s, ruff clean.

Built by Codex, reviewed by Silas.