### PR TITLE
feat: proxy routing + output gate enforcement

### DIFF
--- a/config/silas.yaml
+++ b/config/silas.yaml
@@ -23,6 +23,7 @@ silas:
       coding: { chronicle_pct: 0.20, memory_pct: 0.20, workspace_pct: 0.40 }
       research: { chronicle_pct: 0.20, memory_pct: 0.40, workspace_pct: 0.20 }
       support: { chronicle_pct: 0.40, memory_pct: 0.25, workspace_pct: 0.15 }
+      planning: { chronicle_pct: 0.15, memory_pct: 0.25, workspace_pct: 0.35 }
 
   skills:
     shipped_dir: "./silas/skills/shipped"

--- a/silas/agents/prompts/proxy_system.md
+++ b/silas/agents/prompts/proxy_system.md
@@ -1,7 +1,23 @@
 You are the Silas Proxy agent.
 
-Phase 1a constraints:
-- Always return route="direct".
-- Produce a valid `RouteDecision` object.
-- Set `interaction_register`, `interaction_mode`, and `context_profile` explicitly.
-- Do not produce planner routes in this phase.
+Return a valid `RouteDecision` object for every request.
+
+Routing criteria:
+- Use `route="direct"` for simple questions, greetings, factual lookups, and single-step tasks that can be answered immediately.
+- Use `route="planner"` for multi-step tasks, tasks requiring tools/skills, and tasks with dependencies or sequencing.
+
+Output contract:
+- For `route="direct"`:
+  - Set `response.message` to the user-facing answer.
+  - Keep planning fields empty (`response.plan_action = null`).
+- For `route="planner"`:
+  - Set `response = null`.
+  - Do not provide the final execution answer in this stage; the planner stage will create plan actions.
+- Always set `reason`, `interaction_register`, `interaction_mode`, and `context_profile`.
+
+Context profile guidance:
+- `conversation`: general dialogue, greetings, simple Q&A
+- `coding`: code changes, debugging, implementation requests
+- `research`: investigations, comparisons, source-heavy lookups
+- `support`: troubleshooting/helpdesk-style guidance
+- `planning`: explicit planning/orchestration requests with multiple dependent steps

--- a/silas/config.py
+++ b/silas/config.py
@@ -9,6 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from silas.models.agents import RouteDecision
 from silas.models.context import ContextProfile, TokenBudget
+from silas.models.gates import Gate
 
 
 class ModelsConfig(BaseModel):
@@ -87,6 +88,7 @@ class SilasSettings(BaseSettings):
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     context: ContextConfig = Field(default_factory=ContextConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
+    output_gates: list[Gate] = Field(default_factory=list)
 
     model_config = SettingsConfigDict(
         env_prefix="SILAS_",

--- a/silas/gates/__init__.py
+++ b/silas/gates/__init__.py
@@ -1,0 +1,3 @@
+from silas.gates.output import OutputGateRunner
+
+__all__ = ["OutputGateRunner"]

--- a/silas/gates/output.py
+++ b/silas/gates/output.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import re
+
+from silas.core.token_counter import HeuristicTokenCounter
+from silas.models.gates import Gate, GateLane, GateResult, GateTrigger
+from silas.models.messages import TaintLevel
+
+_EMAIL_PATTERN = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_PATTERN = re.compile(
+    r"\b(?:\+?\d{1,2}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b"
+)
+_TAINT_ORDER = {
+    TaintLevel.owner: 0,
+    TaintLevel.auth: 1,
+    TaintLevel.external: 2,
+}
+
+
+class OutputGateRunner:
+    """Deterministic output-gate evaluator for the Stream response path."""
+
+    def __init__(
+        self,
+        gates: list[Gate],
+        token_counter: HeuristicTokenCounter | None = None,
+    ) -> None:
+        self._gates = list(gates)
+        self._token_counter = token_counter or HeuristicTokenCounter()
+
+    def evaluate(
+        self,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+    ) -> tuple[str, list[GateResult]]:
+        working_response = response_text
+        results: list[GateResult] = []
+
+        for gate in self._gates:
+            result = self._evaluate_gate(
+                gate=gate,
+                response_text=working_response,
+                response_taint=response_taint,
+                sender_id=sender_id,
+            )
+            results.append(result)
+
+            updated_response = self._extract_response_mutation(result)
+            if updated_response is not None:
+                working_response = updated_response
+
+        return working_response, results
+
+    def _evaluate_gate(
+        self,
+        gate: Gate,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+    ) -> GateResult:
+        if gate.on != GateTrigger.every_agent_response:
+            return self._continue_result(
+                gate_name=gate.name,
+                reason=f"skipped trigger={gate.on.value}",
+            )
+
+        check_name = self._check_name(gate)
+        if check_name == "taint_ceiling":
+            return self._taint_ceiling(gate, response_taint)
+        if check_name == "length_limit":
+            return self._length_limit(gate, response_text)
+        if check_name == "pii_marker":
+            return self._pii_marker(gate, response_text)
+
+        return self._continue_result(
+            gate_name=gate.name,
+            reason=f"unknown output gate check: {check_name}",
+            flags=["warn", "unknown_output_gate"],
+            value=sender_id,
+        )
+
+    def _taint_ceiling(self, gate: Gate, response_taint: TaintLevel) -> GateResult:
+        raw_threshold = (
+            gate.config.get("threshold")
+            or gate.config.get("max_taint")
+            or gate.config.get("taint_ceiling")
+            or TaintLevel.external.value
+        )
+        threshold = self._to_taint(raw_threshold)
+        if threshold is None:
+            return self._continue_result(
+                gate_name=gate.name,
+                reason=f"invalid taint threshold: {raw_threshold!r}",
+                flags=["warn", "invalid_gate_config"],
+            )
+
+        taint_rank = _TAINT_ORDER[response_taint]
+        threshold_rank = _TAINT_ORDER[threshold]
+        if taint_rank > threshold_rank:
+            return GateResult(
+                gate_name=gate.name,
+                lane=GateLane.policy,
+                action="block",
+                reason=(
+                    f"response taint {response_taint.value} exceeds threshold {threshold.value}"
+                ),
+                value=response_taint.value,
+            )
+
+        return self._continue_result(
+            gate_name=gate.name,
+            reason=f"response taint {response_taint.value} within threshold {threshold.value}",
+            value=response_taint.value,
+        )
+
+    def _length_limit(self, gate: Gate, response_text: str) -> GateResult:
+        raw_limit = gate.config.get("max_tokens")
+        if not isinstance(raw_limit, int) or raw_limit <= 0:
+            return self._continue_result(
+                gate_name=gate.name,
+                reason=f"invalid max_tokens: {raw_limit!r}",
+                flags=["warn", "invalid_gate_config"],
+            )
+
+        token_count = self._token_counter.count(response_text)
+        if token_count <= raw_limit:
+            return self._continue_result(
+                gate_name=gate.name,
+                reason=f"response length {token_count} <= limit {raw_limit}",
+                value=float(token_count),
+            )
+
+        mode = str(gate.config.get("mode", "truncate")).strip().lower()
+        if mode == "warn":
+            return self._continue_result(
+                gate_name=gate.name,
+                reason=f"response length {token_count} exceeds limit {raw_limit}",
+                flags=["warn", "length_exceeded"],
+                value=float(token_count),
+            )
+
+        truncated = self._truncate_to_token_limit(response_text, raw_limit)
+        return self._continue_result(
+            gate_name=gate.name,
+            reason=f"response length {token_count} truncated to <= {raw_limit} tokens",
+            flags=["warn", "length_exceeded", "truncated"],
+            value=float(token_count),
+            modified_context={"response": truncated},
+        )
+
+    def _pii_marker(self, gate: Gate, response_text: str) -> GateResult:
+        has_email = bool(_EMAIL_PATTERN.search(response_text))
+        has_phone = bool(_PHONE_PATTERN.search(response_text))
+
+        if not has_email and not has_phone:
+            return self._continue_result(
+                gate_name=gate.name,
+                reason="no PII marker detected",
+            )
+
+        flags = ["warn", "pii_detected"]
+        kinds: list[str] = []
+        if has_email:
+            flags.append("pii_email")
+            kinds.append("email")
+        if has_phone:
+            flags.append("pii_phone")
+            kinds.append("phone")
+
+        return self._continue_result(
+            gate_name=gate.name,
+            reason=f"PII markers detected: {', '.join(kinds)}",
+            flags=flags,
+            value=", ".join(kinds),
+        )
+
+    def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:
+        if self._token_counter.count(text) <= max_tokens:
+            return text
+
+        max_chars = max(int(max_tokens * 3.5), 1)
+        truncated = text[:max_chars]
+        while truncated and self._token_counter.count(truncated) > max_tokens:
+            truncated = truncated[:-1]
+        return truncated
+
+    def _extract_response_mutation(self, result: GateResult) -> str | None:
+        if not isinstance(result.modified_context, dict):
+            return None
+        candidate = result.modified_context.get("response")
+        if isinstance(candidate, str):
+            return candidate
+        return None
+
+    def _continue_result(
+        self,
+        gate_name: str,
+        reason: str,
+        *,
+        flags: list[str] | None = None,
+        value: str | float | None = None,
+        modified_context: dict[str, object] | None = None,
+    ) -> GateResult:
+        return GateResult(
+            gate_name=gate_name,
+            lane=GateLane.policy,
+            action="continue",
+            reason=reason,
+            value=value,
+            flags=flags or [],
+            modified_context=modified_context,
+        )
+
+    def _check_name(self, gate: Gate) -> str:
+        source = gate.check or gate.name
+        return source.strip().lower().replace("-", "_").replace(" ", "_")
+
+    def _to_taint(self, raw: object) -> TaintLevel | None:
+        if isinstance(raw, TaintLevel):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return TaintLevel(raw.strip().lower())
+            except ValueError:
+                return None
+        return None
+
+
+__all__ = ["OutputGateRunner"]

--- a/silas/main.py
+++ b/silas/main.py
@@ -15,6 +15,7 @@ from silas.core.context_manager import LiveContextManager
 from silas.core.stream import Stream
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.core.turn_context import TurnContext
+from silas.gates import OutputGateRunner
 from silas.memory.sqlite_store import SQLiteMemoryStore
 from silas.persistence.chronicle_store import SQLiteChronicleStore
 from silas.persistence.migrations import run_migrations
@@ -56,6 +57,11 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         token_budget=settings.context.as_token_budget(),
         token_counter=token_counter,
     )
+    output_gate_runner = (
+        OutputGateRunner(settings.output_gates, token_counter=token_counter)
+        if settings.output_gates
+        else None
+    )
 
     turn_context = TurnContext(
         scope_id=settings.owner_id,
@@ -74,6 +80,7 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         context_manager=context_manager,
         owner_id=settings.owner_id,
         default_context_profile=settings.context.default_profile,
+        output_gate_runner=output_gate_runner,
     )
     return stream, channel
 

--- a/silas/models/agents.py
+++ b/silas/models/agents.py
@@ -111,6 +111,7 @@ class RouteDecision(BaseModel):
         "coding",
         "research",
         "support",
+        "planning",
     }
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from tests.fakes import (
 
 @pytest.fixture(autouse=True)
 def configure_route_profiles() -> None:
-    RouteDecision.configure_profiles({"conversation", "coding", "research", "support"})
+    RouteDecision.configure_profiles({"conversation", "coding", "research", "support", "planning"})
 
 
 @pytest.fixture

--- a/tests/test_output_gates.py
+++ b/tests/test_output_gates.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from silas.core.token_counter import HeuristicTokenCounter
+from silas.gates.output import OutputGateRunner
+from silas.models.gates import Gate, GateTrigger
+from silas.models.messages import TaintLevel
+
+
+def _output_gate(name: str, check: str, config: dict[str, object] | None = None) -> Gate:
+    return Gate(
+        name=name,
+        on=GateTrigger.every_agent_response,
+        check=check,
+        config=config or {},
+    )
+
+
+def test_taint_ceiling_gate_blocks_high_taint_responses() -> None:
+    runner = OutputGateRunner(
+        [_output_gate("taint_guard", "taint_ceiling", {"threshold": "auth"})]
+    )
+    rewritten, results = runner.evaluate(
+        response_text="sensitive response",
+        response_taint=TaintLevel.external,
+        sender_id="customer-1",
+    )
+
+    assert rewritten == "sensitive response"
+    assert len(results) == 1
+    assert results[0].action == "block"
+    assert "exceeds threshold" in results[0].reason
+
+
+def test_length_limit_gate_truncates_long_responses() -> None:
+    runner = OutputGateRunner(
+        [_output_gate("length_guard", "length_limit", {"max_tokens": 8, "mode": "truncate"})]
+    )
+    response_text = "A" * 200
+
+    rewritten, results = runner.evaluate(
+        response_text=response_text,
+        response_taint=TaintLevel.owner,
+        sender_id="owner",
+    )
+
+    assert len(results) == 1
+    assert results[0].action == "continue"
+    assert "truncated" in results[0].flags
+    assert rewritten != response_text
+    assert results[0].modified_context == {"response": rewritten}
+    assert HeuristicTokenCounter().count(rewritten) <= 8
+
+
+def test_pii_marker_gate_flags_email_and_phone() -> None:
+    runner = OutputGateRunner([_output_gate("pii_guard", "pii_marker")])
+    response_text = "Contact me at silas@example.com or +1 (212) 555-0100."
+
+    rewritten, results = runner.evaluate(
+        response_text=response_text,
+        response_taint=TaintLevel.owner,
+        sender_id="owner",
+    )
+
+    assert rewritten == response_text
+    assert len(results) == 1
+    assert results[0].action == "continue"
+    assert "warn" in results[0].flags
+    assert "pii_detected" in results[0].flags
+    assert "pii_email" in results[0].flags
+    assert "pii_phone" in results[0].flags
+
+
+def test_gate_pipeline_passes_clean_response_unchanged() -> None:
+    runner = OutputGateRunner(
+        [
+            _output_gate("taint_guard", "taint_ceiling", {"threshold": "external"}),
+            _output_gate("length_guard", "length_limit", {"max_tokens": 200, "mode": "truncate"}),
+            _output_gate("pii_guard", "pii_marker"),
+        ]
+    )
+    response_text = "Everything is ready. The build passed and tests are green."
+
+    rewritten, results = runner.evaluate(
+        response_text=response_text,
+        response_taint=TaintLevel.owner,
+        sender_id="owner",
+    )
+
+    assert rewritten == response_text
+    assert len(results) == 3
+    assert all(result.action == "continue" for result in results)
+    assert all("warn" not in result.flags for result in results)

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+from silas.agents.proxy import ProxyAgent
+from silas.config import SilasSettings
+from silas.main import build_stream
+from silas.models.agents import (
+    AgentResponse,
+    InteractionMode,
+    InteractionRegister,
+    RouteDecision,
+)
+from silas.models.gates import GateTrigger
+
+from tests.fakes import TestModel
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_direct_route_for_simple_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailingAgent:
+        def __init__(self, **_: object) -> None:
+            raise RuntimeError("llm unavailable")
+
+    monkeypatch.setattr("silas.agents.proxy.Agent", FailingAgent)
+    proxy = ProxyAgent(model="test-model", default_context_profile="conversation")
+
+    result = await proxy.run("hello")
+
+    assert result.output.route == "direct"
+    assert result.output.response is not None
+    assert result.output.response.message == "hello"
+    assert result.output.context_profile == "conversation"
+
+
+def test_build_stream_configures_route_profiles_from_settings(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SilasSettings.model_validate(
+        {
+            "data_dir": str(tmp_path / "data"),
+            "context": {
+                "default_profile": "conversation",
+                "profiles": {
+                    "conversation": {"chronicle_pct": 0.45, "memory_pct": 0.20, "workspace_pct": 0.15},
+                    "planning": {"chronicle_pct": 0.15, "memory_pct": 0.25, "workspace_pct": 0.35},
+                    "custom_profile": {
+                        "chronicle_pct": 0.30,
+                        "memory_pct": 0.20,
+                        "workspace_pct": 0.25,
+                    },
+                },
+            },
+        }
+    )
+
+    monkeypatch.setattr("silas.main.build_proxy_agent", lambda model, default_context_profile: TestModel())
+    RouteDecision.configure_profiles({"conversation", "coding", "research", "support", "planning"})
+
+    build_stream(settings)
+
+    decision = RouteDecision(
+        route="direct",
+        reason="profile config check",
+        response=AgentResponse(message="ok"),
+        interaction_register=InteractionRegister.status,
+        interaction_mode=InteractionMode.default_and_offer,
+        context_profile="planning",
+    )
+    assert decision.context_profile == "planning"
+
+
+def test_build_stream_wires_output_gate_runner(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SilasSettings.model_validate(
+        {
+            "data_dir": str(tmp_path / "data"),
+            "output_gates": [
+                {
+                    "name": "taint_guard",
+                    "on": GateTrigger.every_agent_response.value,
+                    "check": "taint_ceiling",
+                    "config": {"threshold": "external"},
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr("silas.main.build_proxy_agent", lambda model, default_context_profile: TestModel())
+
+    stream, _ = build_stream(settings)
+
+    assert stream.output_gate_runner is not None

--- a/web/app.js
+++ b/web/app.js
@@ -660,6 +660,7 @@ function openWorkPanel(visible = SHEET_SNAP_VISIBLE.peek) {
   if (!workPanel || !workPanelBackdrop || !workPanelSheet) return;
 
   workPanel.setAttribute("aria-hidden", "false");
+  workPanel.style.visibility = "visible";
   statusStrip?.setAttribute("aria-expanded", "true");
 
   workPanelBackdrop.hidden = false;

--- a/web/index.html
+++ b/web/index.html
@@ -78,7 +78,7 @@
 
     <!-- Work Panel -->
     <div id="work-panel-backdrop" class="work-panel-backdrop" hidden></div>
-    <section id="work-panel" class="work-panel" aria-hidden="true">
+    <section id="work-panel" class="work-panel" aria-hidden="true" style="visibility:hidden">
       <div id="work-panel-sheet" class="work-panel-sheet glass-overlay" role="dialog" aria-label="Active Work">
         <button id="work-panel-handle" class="work-panel-handle" type="button" aria-label="Drag work panel">
           <span class="work-panel-grabber"></span>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "silas-v1";
+const CACHE_NAME = "silas-v2";
 const SHELL = ["/", "/style.css", "/app.js", "/manifest.json"];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## What
Two Phase 2 features wired into Stream:

### Proxy Routing
- Enhanced system prompt with direct vs planner classification criteria
- Planner stub: audit + structured response (real planner in Phase 3)
- Planning profile added to valid set

### Output Gates
- `OutputGateRunner` with 3 built-in gates: taint_ceiling, length_limit, pii_marker
- Wired into Stream after proxy response, before channel send
- Blocked responses → sanitized 'I cannot share that'
- All gate results audited per-turn
- Configurable via `output_gates` in SilasSettings

### Also
- SW cache bumped to v2
- Work panel visibility fix

217 tests, ruff clean. Built by Codex, reviewed + merged by Silas.