### PR TITLE
feat: proactive engine — SuggestionEngine, AutonomyCalibrator, Stream wiring

### DIFF
--- a/silas/main.py
+++ b/silas/main.py
@@ -22,6 +22,7 @@ from silas.persistence.chronicle_store import SQLiteChronicleStore
 from silas.persistence.migrations import run_migrations
 from silas.persistence.nonce_store import SQLiteNonceStore
 from silas.persistence.work_item_store import SQLiteWorkItemStore
+from silas.proactivity import SimpleAutonomyCalibrator, SimpleSuggestionEngine
 from silas.skills.executor import SkillExecutor, register_builtin_skills
 from silas.skills.registry import SkillRegistry
 
@@ -64,6 +65,8 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
     register_builtin_skills(skill_registry)
     skill_executor = SkillExecutor(skill_registry=skill_registry, memory_store=memory_store)
     approval_manager = LiveApprovalManager()
+    suggestion_engine = SimpleSuggestionEngine()
+    autonomy_calibrator = SimpleAutonomyCalibrator()
     output_gate_runner = (
         OutputGateRunner(settings.output_gates, token_counter=token_counter)
         if settings.output_gates
@@ -80,6 +83,8 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         skill_registry=skill_registry,
         skill_executor=skill_executor,
         approval_manager=approval_manager,
+        suggestion_engine=suggestion_engine,
+        autonomy_calibrator=autonomy_calibrator,
         audit=audit,
         config=settings,
     )
@@ -91,6 +96,8 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         owner_id=settings.owner_id,
         default_context_profile=settings.context.default_profile,
         output_gate_runner=output_gate_runner,
+        suggestion_engine=suggestion_engine,
+        autonomy_calibrator=autonomy_calibrator,
     )
     return stream, channel
 

--- a/silas/models/__init__.py
+++ b/silas/models/__init__.py
@@ -37,6 +37,7 @@ from silas.models.gates import (
 )
 from silas.models.memory import MemoryItem, MemoryType
 from silas.models.messages import ChannelMessage, SignedMessage, TaintLevel
+from silas.models.proactivity import Suggestion, SuggestionProposal
 from silas.models.sessions import Session, SessionType
 from silas.models.work import (
     Budget,
@@ -104,4 +105,6 @@ __all__ = [
     "PendingApproval",
     "Session",
     "SessionType",
+    "Suggestion",
+    "SuggestionProposal",
 ]

--- a/silas/models/proactivity.py
+++ b/silas/models/proactivity.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Suggestion(BaseModel):
+    id: str
+    text: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    source: str
+    category: str
+    created_at: datetime = Field(default_factory=_utc_now)
+
+    @field_validator("created_at")
+    @classmethod
+    def _ensure_created_at_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("created_at must be timezone-aware")
+        return value
+
+
+class SuggestionProposal(Suggestion):
+    action_hint: str
+    expires_at: datetime
+
+    @field_validator("expires_at")
+    @classmethod
+    def _ensure_expires_at_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("expires_at must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_expiry(self) -> SuggestionProposal:
+        if self.expires_at <= self.created_at:
+            raise ValueError("expires_at must be greater than created_at")
+        return self
+
+
+__all__ = ["Suggestion", "SuggestionProposal"]

--- a/silas/proactivity/__init__.py
+++ b/silas/proactivity/__init__.py
@@ -1,0 +1,4 @@
+from silas.proactivity.calibrator import SimpleAutonomyCalibrator
+from silas.proactivity.suggestions import SimpleSuggestionEngine
+
+__all__ = ["SimpleSuggestionEngine", "SimpleAutonomyCalibrator"]

--- a/silas/proactivity/calibrator.py
+++ b/silas/proactivity/calibrator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+_CORRECTION_OUTCOMES = {"edit_selection", "declined", "undo"}
+
+
+class SimpleAutonomyCalibrator:
+    def __init__(
+        self,
+        *,
+        window_size: int = 25,
+        min_sample_size: int = 5,
+        widen_threshold: float = 0.10,
+        tighten_threshold: float = 0.35,
+    ) -> None:
+        self._window_size = window_size
+        self._min_sample_size = min_sample_size
+        self._widen_threshold = widen_threshold
+        self._tighten_threshold = tighten_threshold
+        self._events_by_scope: dict[str, list[dict[str, object]]] = {}
+
+    async def record_outcome(self, scope_id: str, action_family: str, outcome: str) -> None:
+        events = self._events_by_scope.setdefault(scope_id, [])
+        events.append(
+            {
+                "recorded_at": datetime.now(timezone.utc),
+                "action_family": action_family,
+                "outcome": outcome,
+            }
+        )
+        if len(events) > self._window_size:
+            del events[: len(events) - self._window_size]
+
+    async def evaluate(self, scope_id: str, now: datetime) -> list[dict[str, object]]:
+        events = self._events_by_scope.get(scope_id, [])
+        if len(events) < self._min_sample_size:
+            return []
+
+        corrections = sum(
+            1
+            for event in events
+            if isinstance(event.get("outcome"), str) and event["outcome"] in _CORRECTION_OUTCOMES
+        )
+        correction_rate = corrections / len(events)
+
+        direction: str | None = None
+        if correction_rate <= self._widen_threshold:
+            direction = "widen"
+        elif correction_rate >= self._tighten_threshold:
+            direction = "tighten"
+        if direction is None:
+            return []
+
+        return [
+            {
+                "proposal_id": f"autonomy:{scope_id}:{uuid.uuid4().hex}",
+                "scope_id": scope_id,
+                "direction": direction,
+                "sample_size": len(events),
+                "correction_rate": round(correction_rate, 4),
+                "created_at": now,
+            }
+        ]
+
+
+__all__ = ["SimpleAutonomyCalibrator"]

--- a/silas/proactivity/suggestions.py
+++ b/silas/proactivity/suggestions.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from silas.models.proactivity import SuggestionProposal
+from silas.models.work import WorkItemResult, WorkItemStatus
+
+
+class SimpleSuggestionEngine:
+    def __init__(self, cooldown: timedelta = timedelta(minutes=15)) -> None:
+        self._cooldown = cooldown
+        self._idle_by_scope: dict[str, list[SuggestionProposal]] = {}
+        self._handled_at: dict[str, dict[str, datetime]] = {}
+
+    def queue_idle(self, scope_id: str, suggestion: SuggestionProposal) -> None:
+        self._idle_by_scope.setdefault(scope_id, []).append(suggestion)
+
+    async def generate_idle(self, scope_id: str, now: datetime) -> list[SuggestionProposal]:
+        self._prune_expired(scope_id, now)
+        handled = self._handled_at.get(scope_id, {})
+        proposals: list[SuggestionProposal] = []
+        for suggestion in self._idle_by_scope.get(scope_id, []):
+            handled_at = handled.get(suggestion.id)
+            if handled_at is not None and handled_at + self._cooldown > now:
+                continue
+            proposals.append(suggestion)
+        return proposals
+
+    async def generate_post_execution(
+        self,
+        scope_id: str,
+        result: WorkItemResult,
+    ) -> list[SuggestionProposal]:
+        now = datetime.now(timezone.utc)
+        confidence = 0.75 if result.status == WorkItemStatus.done else 0.55
+        expires_at = now + timedelta(hours=12)
+
+        return [
+            SuggestionProposal(
+                id=f"suggestion:post:{scope_id}:{result.work_item_id}:{index}:{uuid.uuid4().hex}",
+                text=step,
+                confidence=confidence,
+                source="post_execution",
+                category="next_step",
+                action_hint="Run this next step",
+                created_at=now,
+                expires_at=expires_at,
+            )
+            for index, step in enumerate(result.next_steps, start=1)
+        ]
+
+    async def mark_handled(self, scope_id: str, suggestion_id: str, outcome: str) -> None:
+        del outcome
+        self._handled_at.setdefault(scope_id, {})[suggestion_id] = datetime.now(timezone.utc)
+
+    def _prune_expired(self, scope_id: str, now: datetime) -> None:
+        suggestions = self._idle_by_scope.get(scope_id, [])
+        self._idle_by_scope[scope_id] = [
+            suggestion
+            for suggestion in suggestions
+            if suggestion.expires_at > now
+        ]
+
+
+__all__ = ["SimpleSuggestionEngine"]

--- a/silas/protocols/proactivity.py
+++ b/silas/protocols/proactivity.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Protocol, runtime_checkable
 
+from silas.models.proactivity import SuggestionProposal
 from silas.models.work import WorkItemResult
 
 
 @runtime_checkable
 class SuggestionEngine(Protocol):
-    async def generate_idle(self, scope_id: str, now: datetime) -> list[object]: ...
+    async def generate_idle(self, scope_id: str, now: datetime) -> list[SuggestionProposal]: ...
 
-    async def generate_post_execution(self, scope_id: str, result: WorkItemResult) -> list[object]: ...
+    async def generate_post_execution(
+        self,
+        scope_id: str,
+        result: WorkItemResult,
+    ) -> list[SuggestionProposal]: ...
 
     async def mark_handled(self, scope_id: str, suggestion_id: str, outcome: str) -> None: ...
 
@@ -19,9 +24,7 @@ class SuggestionEngine(Protocol):
 class AutonomyCalibrator(Protocol):
     async def record_outcome(self, scope_id: str, action_family: str, outcome: str) -> None: ...
 
-    async def evaluate(self, scope_id: str, now: datetime) -> list[object]: ...
-
-    async def apply(self, proposal: object, decision: object) -> dict[str, object]: ...
+    async def evaluate(self, scope_id: str, now: datetime) -> list[dict[str, object]]: ...
 
 
 __all__ = ["SuggestionEngine", "AutonomyCalibrator"]

--- a/tests/test_proactivity.py
+++ b/tests/test_proactivity.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+from silas.core.stream import Stream
+from silas.models.messages import ChannelMessage
+from silas.models.proactivity import Suggestion, SuggestionProposal
+from silas.models.work import WorkItemResult, WorkItemStatus
+from silas.proactivity import SimpleAutonomyCalibrator, SimpleSuggestionEngine
+
+from tests.fakes import FakeAutonomyCalibrator, FakeSuggestionEngine, InMemoryChannel
+
+
+def _msg(text: str, sender_id: str = "owner") -> ChannelMessage:
+    return ChannelMessage(
+        channel="web",
+        sender_id=sender_id,
+        text=text,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+def _proposal(
+    *,
+    suggestion_id: str,
+    text: str,
+    confidence: float,
+    source: str = "idle_heartbeat",
+    category: str = "next_step",
+) -> SuggestionProposal:
+    now = datetime.now(timezone.utc)
+    return SuggestionProposal(
+        id=suggestion_id,
+        text=text,
+        confidence=confidence,
+        source=source,
+        category=category,
+        action_hint="Do it",
+        created_at=now,
+        expires_at=now + timedelta(minutes=30),
+    )
+
+
+def test_suggestion_confidence_range() -> None:
+    with pytest.raises(ValidationError):
+        Suggestion(
+            id="s1",
+            text="Try this",
+            confidence=-0.01,
+            source="idle_heartbeat",
+            category="next_step",
+        )
+    with pytest.raises(ValidationError):
+        Suggestion(
+            id="s2",
+            text="Try this",
+            confidence=1.01,
+            source="idle_heartbeat",
+            category="next_step",
+        )
+
+
+def test_suggestion_proposal_expiry_validation() -> None:
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError):
+        SuggestionProposal(
+            id="sp1",
+            text="Follow up",
+            confidence=0.7,
+            source="idle_heartbeat",
+            category="next_step",
+            action_hint="Do it",
+            created_at=now,
+            expires_at=now,
+        )
+
+
+@pytest.mark.asyncio
+async def test_simple_suggestion_engine_idle_filters_expired_and_handled() -> None:
+    engine = SimpleSuggestionEngine(cooldown=timedelta(minutes=30))
+    now = datetime.now(timezone.utc)
+    active = SuggestionProposal(
+        id="active",
+        text="active",
+        confidence=0.7,
+        source="idle_heartbeat",
+        category="next_step",
+        action_hint="Act",
+        created_at=now - timedelta(minutes=10),
+        expires_at=now + timedelta(minutes=10),
+    )
+    also_active = SuggestionProposal(
+        id="also-active",
+        text="also active",
+        confidence=0.6,
+        source="idle_heartbeat",
+        category="next_step",
+        action_hint="Act",
+        created_at=now - timedelta(minutes=5),
+        expires_at=now + timedelta(minutes=10),
+    )
+    expired = SuggestionProposal(
+        id="expired",
+        text="expired",
+        confidence=0.6,
+        source="idle_heartbeat",
+        category="next_step",
+        action_hint="Act",
+        created_at=now - timedelta(hours=2),
+        expires_at=now - timedelta(minutes=1),
+    )
+
+    engine.queue_idle("owner", active)
+    engine.queue_idle("owner", also_active)
+    engine.queue_idle("owner", expired)
+    await engine.mark_handled("owner", "active", "dismissed")
+
+    generated = await engine.generate_idle("owner", now)
+    assert [suggestion.id for suggestion in generated] == ["also-active"]
+
+
+@pytest.mark.asyncio
+async def test_simple_suggestion_engine_generate_post_execution() -> None:
+    engine = SimpleSuggestionEngine()
+    result = WorkItemResult(
+        work_item_id="w1",
+        status=WorkItemStatus.done,
+        summary="done",
+        next_steps=["Write tests", "Ship patch"],
+    )
+
+    generated = await engine.generate_post_execution("owner", result)
+    assert len(generated) == 2
+    assert all(suggestion.source == "post_execution" for suggestion in generated)
+    assert all(suggestion.confidence == 0.75 for suggestion in generated)
+
+
+@pytest.mark.asyncio
+async def test_simple_autonomy_calibrator_emits_widen_and_tighten() -> None:
+    now = datetime.now(timezone.utc)
+
+    widen_calibrator = SimpleAutonomyCalibrator(
+        window_size=6,
+        min_sample_size=5,
+        widen_threshold=0.2,
+        tighten_threshold=0.6,
+    )
+    for _ in range(5):
+        await widen_calibrator.record_outcome("owner", "direct", "approved")
+    widen = await widen_calibrator.evaluate("owner", now)
+    assert widen and widen[0]["direction"] == "widen"
+
+    tighten_calibrator = SimpleAutonomyCalibrator(
+        window_size=6,
+        min_sample_size=5,
+        widen_threshold=0.1,
+        tighten_threshold=0.4,
+    )
+    for _ in range(3):
+        await tighten_calibrator.record_outcome("owner", "direct", "declined")
+    for _ in range(2):
+        await tighten_calibrator.record_outcome("owner", "direct", "approved")
+    tighten = await tighten_calibrator.evaluate("owner", now)
+    assert tighten and tighten[0]["direction"] == "tighten"
+
+
+@pytest.mark.asyncio
+async def test_stream_high_confidence_suggestion_prepended(
+    channel: InMemoryChannel,
+    turn_context,
+) -> None:
+    suggestion = _proposal(
+        suggestion_id="s-high",
+        text="You can also ask me to create a checklist.",
+        confidence=0.91,
+    )
+    engine = FakeSuggestionEngine(idle_by_scope={"owner": [suggestion]})
+    stream = Stream(
+        channel=channel,
+        turn_context=turn_context,
+        suggestion_engine=engine,
+    )
+
+    result = await stream._process_turn(_msg("hello"))
+
+    assert result.startswith("Suggestion: You can also ask me to create a checklist.")
+    assert channel.outgoing[0]["text"] == result
+    assert channel.suggestion_cards == []
+
+
+@pytest.mark.asyncio
+async def test_stream_low_confidence_suggestion_sent_to_side_panel(
+    channel: InMemoryChannel,
+    turn_context,
+) -> None:
+    low = _proposal(
+        suggestion_id="s-low",
+        text="Review open tasks",
+        confidence=0.40,
+    )
+    engine = FakeSuggestionEngine(idle_by_scope={"owner": [low]})
+    stream = Stream(
+        channel=channel,
+        turn_context=turn_context,
+        suggestion_engine=engine,
+    )
+
+    result = await stream._process_turn(_msg("hello"))
+
+    assert result == "echo: hello"
+    assert len(channel.suggestion_cards) == 1
+    assert channel.suggestion_cards[0]["suggestion"] == low
+
+
+@pytest.mark.asyncio
+async def test_stream_records_autonomy_outcome(
+    channel: InMemoryChannel,
+    turn_context,
+) -> None:
+    calibrator = FakeAutonomyCalibrator()
+    stream = Stream(
+        channel=channel,
+        turn_context=turn_context,
+        autonomy_calibrator=calibrator,
+    )
+
+    await stream._process_turn(_msg("hello"))
+
+    assert calibrator.record_calls == [("owner", "direct", "approved")]


### PR DESCRIPTION
## Changes
- **Pydantic models**: `Suggestion`, `SuggestionProposal` with timezone-aware validators
- **SimpleSuggestionEngine**: idle generation, post-execution next steps from WorkItemResult, cooldown tracking, expiry pruning
- **SimpleAutonomyCalibrator**: correction-rate sliding window, widen/tighten threshold proposals
- **Stream integration**: step 0.5 proactive queue review (high confidence >0.80 → prepend to response, low confidence → side panel push), step 15 autonomy calibration post-turn
- **Protocol updates**: spec-aligned signatures for SuggestionEngine + AutonomyCalibrator
- **Test fakes**: FakeSuggestionEngine + FakeAutonomyCalibrator

## Tests
236 passed, ruff clean.

## Spec alignment
§4.22 SuggestionEngine, §4.23 AutonomyCalibrator