### PR TITLE
feat: toolset pipeline — wrapper chain, skill resolver (Phase 3c)

### DIFF
--- a/silas/models/__init__.py
+++ b/silas/models/__init__.py
@@ -39,6 +39,7 @@ from silas.models.memory import MemoryItem, MemoryType
 from silas.models.messages import ChannelMessage, SignedMessage, TaintLevel
 from silas.models.proactivity import Suggestion, SuggestionProposal
 from silas.models.sessions import Session, SessionType
+from silas.models.skills import SkillDefinition, SkillMetadata, SkillRef, SkillResult
 from silas.models.work import (
     Budget,
     BudgetUsed,
@@ -107,4 +108,8 @@ __all__ = [
     "SessionType",
     "Suggestion",
     "SuggestionProposal",
+    "SkillDefinition",
+    "SkillMetadata",
+    "SkillRef",
+    "SkillResult",
 ]

--- a/silas/models/skills.py
+++ b/silas/models/skills.py
@@ -3,6 +3,32 @@ from __future__ import annotations
 from pydantic import BaseModel, Field, field_validator
 
 
+class SkillMetadata(BaseModel):
+    name: str
+    description: str
+    activation: str | None = None
+    ui: dict[str, object] = Field(default_factory=dict)
+    composes_with: list[str] = Field(default_factory=list)
+    script_args: dict[str, dict[str, object]] = Field(default_factory=dict)
+    metadata: dict[str, object] = Field(default_factory=dict)
+    requires_approval: bool = False
+    tool_name: str | None = None
+    tool_description: str | None = None
+    tool_schema: dict[str, object] = Field(default_factory=dict)
+
+    @property
+    def exposed_tool_name(self) -> str:
+        return self.tool_name or self.name
+
+    @property
+    def exposed_tool_description(self) -> str:
+        return self.tool_description or self.description
+
+
+class SkillRef(BaseModel):
+    name: str
+
+
 class SkillDefinition(BaseModel):
     name: str
     description: str
@@ -44,4 +70,4 @@ class SkillResult(BaseModel):
         return value
 
 
-__all__ = ["SkillDefinition", "SkillResult"]
+__all__ = ["SkillMetadata", "SkillRef", "SkillDefinition", "SkillResult"]

--- a/silas/protocols/skills.py
+++ b/silas/protocols/skills.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+from silas.models.skills import SkillMetadata
 from silas.models.work import WorkItem
 
 
 @runtime_checkable
 class SkillLoader(Protocol):
-    def scan(self) -> list[object]: ...
+    def scan(self) -> list[SkillMetadata]: ...
 
-    def load_metadata(self, skill_name: str) -> object: ...
+    def load_metadata(self, skill_name: str) -> SkillMetadata: ...
 
     def load_full(self, skill_name: str) -> str: ...
 
@@ -22,7 +23,7 @@ class SkillLoader(Protocol):
 
 @runtime_checkable
 class SkillResolver(Protocol):
-    def resolve_for_work_item(self, work_item: WorkItem) -> list[object]: ...
+    def resolve_for_work_item(self, work_item: WorkItem) -> list[SkillMetadata]: ...
 
     def prepare_toolset(
         self,

--- a/silas/tools/__init__.py
+++ b/silas/tools/__init__.py
@@ -1,0 +1,31 @@
+from silas.tools.approval_required import ApprovalRequiredToolset, PendingApprovalCall
+from silas.tools.filtered import FilteredToolset
+from silas.tools.prepared import PreparedToolset
+from silas.tools.resolver import LiveSkillResolver, SkillResolver
+from silas.tools.skill_toolset import (
+    ApprovalRequest,
+    FunctionToolset,
+    SkillToolset,
+    ToolCallResult,
+    ToolCallStatus,
+    ToolDefinition,
+    ToolHandler,
+    ToolsetProtocol,
+)
+
+__all__ = [
+    "ApprovalRequest",
+    "ApprovalRequiredToolset",
+    "FilteredToolset",
+    "FunctionToolset",
+    "LiveSkillResolver",
+    "PendingApprovalCall",
+    "PreparedToolset",
+    "SkillResolver",
+    "SkillToolset",
+    "ToolCallResult",
+    "ToolCallStatus",
+    "ToolDefinition",
+    "ToolHandler",
+    "ToolsetProtocol",
+]

--- a/silas/tools/approval_required.py
+++ b/silas/tools/approval_required.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from silas.tools.skill_toolset import (
+    ApprovalRequest,
+    ToolCallResult,
+    ToolDefinition,
+    ToolsetProtocol,
+)
+
+
+@dataclass(slots=True)
+class PendingApprovalCall:
+    request_id: str
+    tool_name: str
+    arguments: dict[str, object]
+    created_at: datetime
+
+
+class ApprovalRequiredToolset:
+    """Pauses execution for tools marked requires_approval until resume()."""
+
+    def __init__(self, inner: ToolsetProtocol) -> None:
+        self.inner = inner
+        self._pending: dict[str, PendingApprovalCall] = {}
+
+    def list_tools(self) -> list[ToolDefinition]:
+        return self.inner.list_tools()
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult:
+        tool = self._find_tool(tool_name)
+        if tool is None:
+            return self.inner.call(tool_name, arguments)
+
+        if not tool.requires_approval:
+            return self.inner.call(tool_name, arguments)
+
+        request_id = uuid.uuid4().hex
+        created_at = datetime.now(timezone.utc)
+        pending = PendingApprovalCall(
+            request_id=request_id,
+            tool_name=tool_name,
+            arguments=dict(arguments),
+            created_at=created_at,
+        )
+        self._pending[request_id] = pending
+
+        return ToolCallResult(
+            status="approval_required",
+            approval_request=ApprovalRequest(
+                request_id=request_id,
+                tool_name=tool_name,
+                arguments=dict(arguments),
+                created_at=created_at,
+            ),
+        )
+
+    def resume(self, request_id: str, approved: bool) -> ToolCallResult:
+        pending = self._pending.pop(request_id, None)
+        if pending is None:
+            return ToolCallResult(status="error", error=f"unknown approval request: {request_id}")
+
+        if not approved:
+            return ToolCallResult(
+                status="denied",
+                error=f"approval declined for tool '{pending.tool_name}'",
+            )
+
+        return self.inner.call(pending.tool_name, dict(pending.arguments))
+
+    def pending_requests(self) -> list[ApprovalRequest]:
+        return [
+            ApprovalRequest(
+                request_id=pending.request_id,
+                tool_name=pending.tool_name,
+                arguments=dict(pending.arguments),
+                created_at=pending.created_at,
+            )
+            for pending in self._pending.values()
+        ]
+
+    def _find_tool(self, tool_name: str) -> ToolDefinition | None:
+        for tool in self.inner.list_tools():
+            if tool.name == tool_name:
+                return tool
+        return None
+
+
+__all__ = ["ApprovalRequiredToolset", "PendingApprovalCall"]

--- a/silas/tools/filtered.py
+++ b/silas/tools/filtered.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from silas.tools.skill_toolset import ToolCallResult, ToolDefinition, ToolsetProtocol
+
+
+class FilteredToolset:
+    """Filters tools to an allowlist before model exposure and execution."""
+
+    def __init__(self, inner: ToolsetProtocol, allowed_tools: list[str] | None) -> None:
+        self.inner = inner
+        self.allowed_tools = list(allowed_tools or [])
+        self._allowed_set = set(self.allowed_tools)
+
+    def list_tools(self) -> list[ToolDefinition]:
+        if not self._allowed_set:
+            return []
+        return [tool for tool in self.inner.list_tools() if tool.name in self._allowed_set]
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult:
+        if tool_name not in self._allowed_set:
+            return ToolCallResult(
+                status="filtered",
+                error=f"tool '{tool_name}' is not allowed in this scope",
+            )
+        return self.inner.call(tool_name, arguments)
+
+
+__all__ = ["FilteredToolset"]

--- a/silas/tools/prepared.py
+++ b/silas/tools/prepared.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from silas.tools.skill_toolset import ToolCallResult, ToolDefinition, ToolsetProtocol
+
+
+class PreparedToolset:
+    """Adds deterministic role-specific metadata to tool definitions."""
+
+    def __init__(self, inner: ToolsetProtocol, agent_role: str) -> None:
+        self.inner = inner
+        self.agent_role = agent_role
+
+    def list_tools(self) -> list[ToolDefinition]:
+        return [self._prepare_tool(tool) for tool in self.inner.list_tools()]
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult:
+        return self.inner.call(tool_name, arguments)
+
+    def _prepare_tool(self, tool: ToolDefinition) -> ToolDefinition:
+        schema = dict(tool.input_schema)
+        schema["x-silas-agent-role"] = self.agent_role
+
+        metadata = dict(tool.metadata)
+        metadata["prepared_for_role"] = self.agent_role
+
+        return ToolDefinition(
+            name=tool.name,
+            description=f"{tool.description}\n[Prepared for role: {self.agent_role}]",
+            input_schema=schema,
+            handler=tool.handler,
+            requires_approval=tool.requires_approval,
+            metadata=metadata,
+        )
+
+
+__all__ = ["PreparedToolset"]

--- a/silas/tools/resolver.py
+++ b/silas/tools/resolver.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from silas.models.skills import SkillMetadata
+from silas.models.work import WorkItem
+from silas.protocols.skills import SkillLoader
+from silas.tools.approval_required import ApprovalRequiredToolset
+from silas.tools.filtered import FilteredToolset
+from silas.tools.prepared import PreparedToolset
+from silas.tools.skill_toolset import SkillToolset, ToolDefinition, ToolsetProtocol
+
+
+class LiveSkillResolver:
+    """Resolves skill metadata and composes the canonical toolset wrapper chain."""
+
+    def __init__(
+        self,
+        skill_loader: SkillLoader,
+        work_item_lookup: Callable[[str], WorkItem | None] | None = None,
+    ) -> None:
+        self._skill_loader = skill_loader
+        self._work_item_lookup = work_item_lookup
+
+    def resolve_for_work_item(self, work_item: WorkItem) -> list[SkillMetadata]:
+        skill_names = self._resolve_skill_names(work_item)
+        metadata: list[SkillMetadata] = []
+
+        for skill_name in skill_names:
+            loaded = self._skill_loader.load_metadata(skill_name)
+            if isinstance(loaded, SkillMetadata):
+                metadata.append(loaded.model_copy(deep=True))
+            elif isinstance(loaded, dict):
+                metadata.append(SkillMetadata.model_validate(loaded))
+            else:
+                raise TypeError(
+                    f"skill_loader.load_metadata({skill_name!r}) returned unsupported type "
+                    f"{type(loaded).__name__}"
+                )
+
+        return metadata
+
+    def prepare_toolset(
+        self,
+        work_item: WorkItem,
+        agent_role: str,
+        base_toolset: ToolsetProtocol | list[ToolDefinition],
+        allowed_tools: list[str],
+    ) -> ApprovalRequiredToolset:
+        skill_metadata = self.resolve_for_work_item(work_item)
+
+        skill_toolset = SkillToolset(base_toolset=base_toolset, skill_metadata=skill_metadata)
+        prepared_toolset = PreparedToolset(inner=skill_toolset, agent_role=agent_role)
+        filtered_toolset = FilteredToolset(inner=prepared_toolset, allowed_tools=allowed_tools)
+        return ApprovalRequiredToolset(inner=filtered_toolset)
+
+    def _resolve_skill_names(self, work_item: WorkItem) -> list[str]:
+        if work_item.skills:
+            return self._dedupe(work_item.skills)
+
+        if not work_item.parent or self._work_item_lookup is None:
+            return []
+
+        visited: set[str] = {work_item.id}
+        parent_id: str | None = work_item.parent
+
+        while parent_id is not None:
+            if parent_id in visited:
+                break
+            visited.add(parent_id)
+
+            parent = self._work_item_lookup(parent_id)
+            if parent is None:
+                break
+
+            if parent.skills:
+                return self._dedupe(parent.skills)
+
+            parent_id = parent.parent
+
+        return []
+
+    def _dedupe(self, names: list[str]) -> list[str]:
+        seen: set[str] = set()
+        resolved: list[str] = []
+        for name in names:
+            if name in seen:
+                continue
+            seen.add(name)
+            resolved.append(name)
+        return resolved
+
+
+SkillResolver = LiveSkillResolver
+
+
+__all__ = ["LiveSkillResolver", "SkillResolver"]

--- a/silas/tools/skill_toolset.py
+++ b/silas/tools/skill_toolset.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Literal, Protocol
+
+from silas.models.skills import SkillMetadata
+
+ToolHandler = Callable[[dict[str, object]], object]
+ToolCallStatus = Literal[
+    "ok",
+    "error",
+    "not_found",
+    "filtered",
+    "approval_required",
+    "denied",
+]
+
+
+@dataclass(slots=True)
+class ApprovalRequest:
+    request_id: str
+    tool_name: str
+    arguments: dict[str, object]
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class ToolCallResult:
+    status: ToolCallStatus
+    output: object | None = None
+    error: str | None = None
+    approval_request: ApprovalRequest | None = None
+
+
+@dataclass(slots=True)
+class ToolDefinition:
+    name: str
+    description: str
+    input_schema: dict[str, object] = field(default_factory=dict)
+    handler: ToolHandler | None = None
+    requires_approval: bool = False
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def call(self, arguments: dict[str, object]) -> object:
+        if self.handler is None:
+            return {
+                "tool": self.name,
+                "arguments": dict(arguments),
+                "invoked_at": datetime.now(timezone.utc).isoformat(),
+            }
+        return self.handler(dict(arguments))
+
+
+class ToolsetProtocol(Protocol):
+    def list_tools(self) -> list[ToolDefinition]: ...
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult: ...
+
+
+class FunctionToolset:
+    """Concrete in-memory function toolset for runtime wrappers and tests."""
+
+    def __init__(self, tools: list[ToolDefinition] | None = None) -> None:
+        self._tools: dict[str, ToolDefinition] = {}
+        for tool in tools or []:
+            self.register(tool)
+
+    def register(self, tool: ToolDefinition) -> None:
+        self._tools[tool.name] = tool
+
+    def list_tools(self) -> list[ToolDefinition]:
+        return [self._copy_tool(tool) for tool in self._tools.values()]
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult:
+        tool = self._tools.get(tool_name)
+        if tool is None:
+            return ToolCallResult(status="not_found", error=f"unknown tool: {tool_name}")
+
+        try:
+            output = tool.call(arguments)
+        except Exception as exc:  # noqa: BLE001
+            return ToolCallResult(status="error", error=str(exc))
+        return ToolCallResult(status="ok", output=output)
+
+    def _copy_tool(self, tool: ToolDefinition) -> ToolDefinition:
+        return ToolDefinition(
+            name=tool.name,
+            description=tool.description,
+            input_schema=dict(tool.input_schema),
+            handler=tool.handler,
+            requires_approval=tool.requires_approval,
+            metadata=dict(tool.metadata),
+        )
+
+
+class SkillToolset:
+    """Inner wrapper exposing base harness tools and active work-item skill tools."""
+
+    def __init__(
+        self,
+        base_toolset: ToolsetProtocol | list[ToolDefinition],
+        skill_metadata: list[SkillMetadata],
+        skill_tools: list[ToolDefinition] | None = None,
+    ) -> None:
+        self.inner = self._coerce_base_toolset(base_toolset)
+        self.skill_metadata = [item.model_copy(deep=True) for item in skill_metadata]
+
+        tool_defs = skill_tools or [self._tool_from_skill(meta) for meta in self.skill_metadata]
+        self._skill_tools: dict[str, ToolDefinition] = {
+            tool.name: self._copy_tool(tool)
+            for tool in tool_defs
+        }
+
+    def list_tools(self) -> list[ToolDefinition]:
+        seen: set[str] = set()
+        tools: list[ToolDefinition] = []
+
+        for tool in self.inner.list_tools():
+            tools.append(self._copy_tool(tool))
+            seen.add(tool.name)
+
+        for tool in self._skill_tools.values():
+            if tool.name in seen:
+                continue
+            tools.append(self._copy_tool(tool))
+
+        return tools
+
+    def call(self, tool_name: str, arguments: dict[str, object]) -> ToolCallResult:
+        skill_tool = self._skill_tools.get(tool_name)
+        if skill_tool is not None:
+            try:
+                output = skill_tool.call(arguments)
+            except Exception as exc:  # noqa: BLE001
+                return ToolCallResult(status="error", error=str(exc))
+            return ToolCallResult(status="ok", output=output)
+
+        return self.inner.call(tool_name, arguments)
+
+    def _tool_from_skill(self, metadata: SkillMetadata) -> ToolDefinition:
+        tool_schema = dict(metadata.tool_schema)
+        if not tool_schema and metadata.script_args:
+            tool_schema = {
+                "type": "object",
+                "properties": {name: dict(schema) for name, schema in metadata.script_args.items()},
+            }
+
+        return ToolDefinition(
+            name=metadata.exposed_tool_name,
+            description=metadata.exposed_tool_description,
+            input_schema=tool_schema,
+            requires_approval=metadata.requires_approval,
+            metadata={"source": "skill", "skill_name": metadata.name, **metadata.metadata},
+        )
+
+    def _copy_tool(self, tool: ToolDefinition) -> ToolDefinition:
+        return ToolDefinition(
+            name=tool.name,
+            description=tool.description,
+            input_schema=dict(tool.input_schema),
+            handler=tool.handler,
+            requires_approval=tool.requires_approval,
+            metadata=dict(tool.metadata),
+        )
+
+    def _coerce_base_toolset(
+        self,
+        base_toolset: ToolsetProtocol | list[ToolDefinition],
+    ) -> ToolsetProtocol:
+        if isinstance(base_toolset, list):
+            return FunctionToolset(base_toolset)
+        return base_toolset
+
+
+__all__ = [
+    "ApprovalRequest",
+    "FunctionToolset",
+    "SkillToolset",
+    "ToolCallResult",
+    "ToolCallStatus",
+    "ToolDefinition",
+    "ToolHandler",
+    "ToolsetProtocol",
+]

--- a/tests/test_toolset_pipeline.py
+++ b/tests/test_toolset_pipeline.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from silas.models.skills import SkillMetadata
+from silas.models.work import WorkItem, WorkItemType
+from silas.tools.approval_required import ApprovalRequiredToolset
+from silas.tools.filtered import FilteredToolset
+from silas.tools.prepared import PreparedToolset
+from silas.tools.resolver import LiveSkillResolver
+from silas.tools.skill_toolset import FunctionToolset, SkillToolset, ToolDefinition
+
+
+class _FakeSkillLoader:
+    def __init__(self, metadata_by_name: dict[str, SkillMetadata]) -> None:
+        self._metadata_by_name = metadata_by_name
+        self.loaded: list[str] = []
+
+    def scan(self) -> list[SkillMetadata]:
+        return [item.model_copy(deep=True) for item in self._metadata_by_name.values()]
+
+    def load_metadata(self, skill_name: str) -> SkillMetadata:
+        self.loaded.append(skill_name)
+        return self._metadata_by_name[skill_name].model_copy(deep=True)
+
+    def load_full(self, skill_name: str) -> str:
+        return f"# {skill_name}"
+
+    def resolve_script(self, skill_name: str, script_path: str) -> str:
+        return f"/skills/{skill_name}/{script_path}"
+
+    def validate(self, skill_name: str) -> dict[str, object]:
+        return {"skill": skill_name, "ok": True}
+
+    def import_external(self, source: str, format_hint: str | None = None) -> dict[str, object]:
+        return {"source": source, "format_hint": format_hint, "ok": True}
+
+
+def _tool(
+    name: str,
+    *,
+    requires_approval: bool = False,
+) -> ToolDefinition:
+    def _handler(arguments: dict[str, object]) -> object:
+        return {"tool": name, "arguments": dict(arguments)}
+
+    return ToolDefinition(
+        name=name,
+        description=f"{name} description",
+        input_schema={"type": "object"},
+        handler=_handler,
+        requires_approval=requires_approval,
+    )
+
+
+def _work_item(
+    work_item_id: str,
+    *,
+    skills: list[str] | None = None,
+    parent: str | None = None,
+) -> WorkItem:
+    return WorkItem(
+        id=work_item_id,
+        type=WorkItemType.task,
+        title=f"Work item {work_item_id}",
+        body="do work",
+        skills=skills or [],
+        parent=parent,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_skill_toolset_exposes_base_and_skill_tools() -> None:
+    base = FunctionToolset([_tool("shell_exec"), _tool("web_search")])
+    metadata = [
+        SkillMetadata(name="ops-triage", description="Triages operations queue"),
+        SkillMetadata(name="billing", description="Billing integration"),
+    ]
+
+    toolset = SkillToolset(base_toolset=base, skill_metadata=metadata)
+
+    names = [tool.name for tool in toolset.list_tools()]
+    assert names == ["shell_exec", "web_search", "ops-triage", "billing"]
+
+
+def test_prepared_toolset_enriches_role_specific_data() -> None:
+    base = FunctionToolset([_tool("shell_exec")])
+    prepared = PreparedToolset(inner=base, agent_role="proxy")
+
+    tools = prepared.list_tools()
+
+    assert len(tools) == 1
+    assert "proxy" in tools[0].description
+    assert tools[0].input_schema["x-silas-agent-role"] == "proxy"
+    assert tools[0].metadata["prepared_for_role"] == "proxy"
+
+
+def test_filtered_toolset_removes_disallowed_tools() -> None:
+    base = FunctionToolset([_tool("shell_exec"), _tool("python_exec"), _tool("web_search")])
+    filtered = FilteredToolset(inner=base, allowed_tools=["shell_exec", "web_search"])
+
+    names = [tool.name for tool in filtered.list_tools()]
+    blocked = filtered.call("python_exec", {"code": "print(1)"})
+
+    assert names == ["shell_exec", "web_search"]
+    assert blocked.status == "filtered"
+
+
+def test_approval_required_toolset_pauses_when_approval_needed() -> None:
+    base = FunctionToolset([_tool("delete_records", requires_approval=True)])
+    guarded = ApprovalRequiredToolset(inner=base)
+
+    paused = guarded.call("delete_records", {"target": "all"})
+
+    assert paused.status == "approval_required"
+    assert paused.approval_request is not None
+    assert paused.approval_request.tool_name == "delete_records"
+
+
+def test_approval_required_toolset_resume_executes_when_approved() -> None:
+    base = FunctionToolset([_tool("delete_records", requires_approval=True)])
+    guarded = ApprovalRequiredToolset(inner=base)
+
+    paused = guarded.call("delete_records", {"target": "all"})
+    assert paused.approval_request is not None
+
+    resumed = guarded.resume(paused.approval_request.request_id, approved=True)
+
+    assert resumed.status == "ok"
+    assert resumed.output == {"tool": "delete_records", "arguments": {"target": "all"}}
+
+
+def test_approval_required_toolset_resume_decline_returns_denied() -> None:
+    base = FunctionToolset([_tool("delete_records", requires_approval=True)])
+    guarded = ApprovalRequiredToolset(inner=base)
+
+    paused = guarded.call("delete_records", {"target": "all"})
+    assert paused.approval_request is not None
+
+    denied = guarded.resume(paused.approval_request.request_id, approved=False)
+
+    assert denied.status == "denied"
+
+
+def test_skill_resolver_resolves_skills_from_work_item_and_parent_inheritance() -> None:
+    loader = _FakeSkillLoader(
+        {
+            "ops-triage": SkillMetadata(name="ops-triage", description="ops"),
+            "billing": SkillMetadata(name="billing", description="billing"),
+        }
+    )
+
+    parent = _work_item("parent", skills=["ops-triage", "billing"])
+    child = _work_item("child", parent="parent")
+
+    resolver = LiveSkillResolver(skill_loader=loader, work_item_lookup={"parent": parent}.get)
+    resolved = resolver.resolve_for_work_item(child)
+
+    assert [item.name for item in resolved] == ["ops-triage", "billing"]
+    assert loader.loaded == ["ops-triage", "billing"]
+
+
+def test_prepare_toolset_builds_canonical_chain_and_runs_end_to_end() -> None:
+    loader = _FakeSkillLoader(
+        {
+            "ops-triage": SkillMetadata(
+                name="ops-triage",
+                description="triage actions",
+                requires_approval=True,
+            )
+        }
+    )
+
+    resolver = LiveSkillResolver(skill_loader=loader)
+    base = FunctionToolset([_tool("shell_exec"), _tool("web_search")])
+    work_item = _work_item("wi-1", skills=["ops-triage"])
+
+    toolset = resolver.prepare_toolset(
+        work_item=work_item,
+        agent_role="executor",
+        base_toolset=base,
+        allowed_tools=["shell_exec", "ops-triage"],
+    )
+
+    assert isinstance(toolset, ApprovalRequiredToolset)
+    assert isinstance(toolset.inner, FilteredToolset)
+    assert isinstance(toolset.inner.inner, PreparedToolset)
+    assert isinstance(toolset.inner.inner.inner, SkillToolset)
+
+    names = [tool.name for tool in toolset.list_tools()]
+    assert names == ["shell_exec", "ops-triage"]
+
+    safe_result = toolset.call("shell_exec", {"cmd": "echo hi"})
+    assert safe_result.status == "ok"
+
+    paused = toolset.call("ops-triage", {"limit": 10})
+    assert paused.status == "approval_required"
+    assert paused.approval_request is not None
+
+    resumed = toolset.resume(paused.approval_request.request_id, approved=True)
+    assert resumed.status == "ok"


### PR DESCRIPTION
## Changes
- **SkillToolset**: Core harness + work-item-scoped skill tools
- **PreparedToolset**: Role-specific enrichment (descriptions, schemas)
- **FilteredToolset**: Tool filtering by allowed_tools list
- **ApprovalRequiredToolset**: Pause/resume flow for approval-gated tools
- **LiveSkillResolver**: Resolves skills from WorkItem, builds canonical wrapper chain
- **SkillMetadata** model + **SkillLoader** protocol updates

## Spec alignment
§4.21 SkillResolver, §4.24 Toolset binding

## Tests
255 passed, ruff clean. 8 new toolset pipeline tests.