### PR TITLE
feat: Phase 4 — SilasGateRunner, PredicateChecker, SilasAccessController

### DIFF
--- a/silas/gates/__init__.py
+++ b/silas/gates/__init__.py
@@ -1,3 +1,11 @@
+from silas.gates.access import SilasAccessController
 from silas.gates.output import OutputGateRunner
+from silas.gates.predicates import PredicateChecker
+from silas.gates.runner import SilasGateRunner
 
-__all__ = ["OutputGateRunner"]
+__all__ = [
+    "OutputGateRunner",
+    "PredicateChecker",
+    "SilasAccessController",
+    "SilasGateRunner",
+]

--- a/silas/gates/access.py
+++ b/silas/gates/access.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Mapping, Sequence
+
+from silas.models.gates import AccessLevel
+from silas.models.messages import TaintLevel
+
+_LEVEL_ORDER: tuple[str, ...] = ("anonymous", "authenticated", "trusted", "owner")
+_DEFAULT_LEVELS: dict[str, AccessLevel] = {
+    "anonymous": AccessLevel(
+        description="Unauthenticated access",
+        tools=[],
+        requires=[],
+    ),
+    "authenticated": AccessLevel(
+        description="Authenticated access",
+        tools=[],
+        requires=["authenticated"],
+    ),
+    "trusted": AccessLevel(
+        description="Trusted access",
+        tools=[],
+        requires=["trusted"],
+    ),
+    "owner": AccessLevel(
+        description="Owner access",
+        tools=["*"],
+        requires=[],
+    ),
+}
+
+
+@dataclass(slots=True)
+class _AccessState:
+    level_name: str
+    verified_gates: set[str] = field(default_factory=set)
+    customer_context: dict[str, object] | None = None
+    granted_at: datetime | None = None
+
+
+class SilasAccessController:
+    """Deterministic, per-connection access controller."""
+
+    def __init__(
+        self,
+        owner_id: str,
+        access_levels: Mapping[str, AccessLevel] | None = None,
+        default_level: str = "anonymous",
+    ) -> None:
+        self.owner_id = owner_id
+        self.default_level = default_level
+        self._access_levels = self._build_access_levels(access_levels)
+        if self.default_level not in self._access_levels:
+            raise ValueError(f"default level must exist in access levels: {self.default_level}")
+
+        self._state_by_connection: dict[str, _AccessState] = {}
+
+    def update_access_levels(
+        self,
+        access_levels: Mapping[str, AccessLevel],
+        *,
+        reset_non_owner_state: bool = False,
+    ) -> None:
+        self._access_levels = self._build_access_levels(access_levels)
+        if self.default_level not in self._access_levels:
+            raise ValueError(f"default level must exist in access levels: {self.default_level}")
+
+        if reset_non_owner_state:
+            for connection_id in list(self._state_by_connection):
+                if connection_id == self.owner_id:
+                    continue
+                self._state_by_connection.pop(connection_id, None)
+
+    def gate_passed(
+        self,
+        connection_id: str,
+        gate_name: str,
+        *,
+        taint: TaintLevel | None = None,
+        customer_context: Mapping[str, object] | None = None,
+    ) -> str:
+        if self._is_owner(connection_id, taint):
+            self._ensure_owner_state(connection_id)
+            return "owner"
+
+        state = self._state_for(connection_id)
+        self._downgrade_if_expired(state)
+
+        state.verified_gates.add(gate_name)
+        next_level = self._highest_reachable_level(state.verified_gates)
+        if self._rank(next_level) > self._rank(state.level_name):
+            state.level_name = next_level
+            state.granted_at = datetime.now(timezone.utc)
+            if customer_context is not None:
+                state.customer_context = dict(customer_context)
+
+        return state.level_name
+
+    def get_access_level(self, connection_id: str, *, taint: TaintLevel | None = None) -> str:
+        if self._is_owner(connection_id, taint):
+            self._ensure_owner_state(connection_id)
+            return "owner"
+
+        state = self._state_for(connection_id)
+        self._downgrade_if_expired(state)
+        return state.level_name
+
+    def get_allowed_tools(self, connection_id: str, *, taint: TaintLevel | None = None) -> list[str]:
+        level = self.get_access_level(connection_id, taint=taint)
+        return list(self._access_levels[level].tools)
+
+    def filter_tools(
+        self,
+        connection_id: str,
+        tool_names: Sequence[str],
+        *,
+        taint: TaintLevel | None = None,
+    ) -> list[str]:
+        allowed = self.get_allowed_tools(connection_id, taint=taint)
+        if "*" in allowed:
+            return list(tool_names)
+        allowed_set = set(allowed)
+        return [tool_name for tool_name in tool_names if tool_name in allowed_set]
+
+    def get_customer_context(
+        self,
+        connection_id: str,
+        *,
+        taint: TaintLevel | None = None,
+    ) -> dict[str, object] | None:
+        if self._is_owner(connection_id, taint):
+            return None
+
+        state = self._state_for(connection_id)
+        self._downgrade_if_expired(state)
+        return dict(state.customer_context) if state.customer_context is not None else None
+
+    def state_snapshot(self, connection_id: str) -> dict[str, object]:
+        state = self._state_for(connection_id)
+        return {
+            "level_name": state.level_name,
+            "verified_gates": sorted(state.verified_gates),
+            "customer_context": dict(state.customer_context) if state.customer_context else None,
+            "granted_at": state.granted_at,
+        }
+
+    def _ensure_owner_state(self, connection_id: str) -> None:
+        state = self._state_by_connection.get(connection_id)
+        if state is None:
+            state = _AccessState(level_name="owner", granted_at=datetime.now(timezone.utc))
+            self._state_by_connection[connection_id] = state
+            return
+
+        state.level_name = "owner"
+        if state.granted_at is None:
+            state.granted_at = datetime.now(timezone.utc)
+
+    def _state_for(self, connection_id: str) -> _AccessState:
+        state = self._state_by_connection.get(connection_id)
+        if state is None:
+            state = _AccessState(level_name=self.default_level)
+            self._state_by_connection[connection_id] = state
+        return state
+
+    def _downgrade_if_expired(self, state: _AccessState) -> None:
+        current_level = self._access_levels[state.level_name]
+        if current_level.expires_after is None:
+            return
+        if state.granted_at is None:
+            return
+
+        expiry_seconds = current_level.expires_after
+        if expiry_seconds <= 0:
+            return
+        deadline = state.granted_at + timedelta(seconds=expiry_seconds)
+        if datetime.now(timezone.utc) < deadline:
+            return
+
+        state.level_name = self.default_level
+        state.granted_at = None
+        state.customer_context = None
+        state.verified_gates.clear()
+
+    def _highest_reachable_level(self, verified_gates: set[str]) -> str:
+        highest = self.default_level
+        for level_name in self._ordered_levels():
+            if level_name == "owner":
+                continue
+            requirements = self._access_levels[level_name].requires
+            if set(requirements).issubset(verified_gates) and self._rank(level_name) >= self._rank(highest):
+                highest = level_name
+        return highest
+
+    def _ordered_levels(self) -> list[str]:
+        known = [name for name in _LEVEL_ORDER if name in self._access_levels]
+        custom = sorted(name for name in self._access_levels if name not in _LEVEL_ORDER)
+        return known + custom
+
+    def _rank(self, level_name: str) -> int:
+        try:
+            return _LEVEL_ORDER.index(level_name)
+        except ValueError:
+            return len(_LEVEL_ORDER)
+
+    def _is_owner(self, connection_id: str, taint: TaintLevel | None) -> bool:
+        return connection_id == self.owner_id or taint == TaintLevel.owner
+
+    def _build_access_levels(
+        self,
+        access_levels: Mapping[str, AccessLevel] | None,
+    ) -> dict[str, AccessLevel]:
+        merged = {
+            level_name: level.model_copy(deep=True)
+            for level_name, level in _DEFAULT_LEVELS.items()
+        }
+        if access_levels is None:
+            return merged
+
+        for level_name, level in access_levels.items():
+            merged[level_name] = level.model_copy(deep=True)
+        return merged
+
+
+__all__ = ["SilasAccessController"]

--- a/silas/gates/predicates.py
+++ b/silas/gates/predicates.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Literal
+
+from silas.core.token_counter import HeuristicTokenCounter
+from silas.models.gates import Gate, GateLane, GateResult, GateType
+
+_AND = "and"
+_OR = "or"
+_RESERVED_CHECK_NAMES = {
+    "regex",
+    "length",
+    "length_limit",
+    "keyword",
+    "keywords",
+    "numeric_range",
+    "string_match",
+}
+
+
+class PredicateChecker:
+    """Deterministic gate checker for predicate-backed gates."""
+
+    def __init__(self, token_counter: HeuristicTokenCounter | None = None) -> None:
+        self._token_counter = token_counter or HeuristicTokenCounter()
+
+    async def check(self, gate: Gate, context: dict[str, object]) -> GateResult:
+        return self.evaluate(gate, context)
+
+    def evaluate(self, gate: Gate, context: Mapping[str, object]) -> GateResult:
+        if gate.type == GateType.approval_always:
+            return self._result(gate.name, "require_approval", "approval_always gate")
+
+        if self._has_logic_predicates(gate.config):
+            return self._evaluate_logic_node(gate, context, gate.config)
+
+        check_name = self._normalize(gate.check or gate.type.value)
+
+        if gate.type == GateType.numeric_range:
+            return self._evaluate_numeric_range(gate, context, gate.config)
+        if gate.type == GateType.regex or check_name == "regex":
+            return self._evaluate_regex(gate, context, gate.config)
+        if self._is_length_check(gate.config, check_name):
+            return self._evaluate_length(gate, context, gate.config)
+        if self._is_keyword_check(gate.config, check_name):
+            return self._evaluate_keyword(gate, context, gate.config)
+        if gate.type == GateType.string_match:
+            return self._evaluate_string_match(gate, context)
+
+        return self._result(
+            gate.name,
+            "block",
+            f"unknown predicate check: {gate.check or gate.type.value}",
+        )
+
+    def _evaluate_logic_node(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        node: Mapping[str, object],
+    ) -> GateResult:
+        raw_logic = node.get("logic", _AND)
+        logic = self._normalize(raw_logic) if isinstance(raw_logic, str) else _AND
+        if logic not in {_AND, _OR}:
+            return self._result(gate.name, "block", f"invalid logic operator: {raw_logic!r}")
+
+        raw_children = node.get("predicates")
+        if not isinstance(raw_children, Sequence) or isinstance(raw_children, str) or not raw_children:
+            return self._result(gate.name, "block", "invalid predicates list")
+
+        child_results: list[GateResult] = []
+        for child in raw_children:
+            if not isinstance(child, Mapping):
+                return self._result(gate.name, "block", "invalid predicate node")
+            child_results.append(self._evaluate_predicate_node(gate, context, child))
+
+        action = self._merge_actions(logic, child_results)
+        reasons = "; ".join(result.reason for result in child_results)
+        flags = sorted(
+            {
+                flag
+                for result in child_results
+                for flag in result.flags
+            }
+        )
+        value = next((result.value for result in child_results if result.value is not None), None)
+        return GateResult(
+            gate_name=gate.name,
+            lane=GateLane.policy,
+            action=action,
+            reason=f"composed({logic}): {reasons}",
+            value=value,
+            flags=flags,
+        )
+
+    def _evaluate_predicate_node(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        node: Mapping[str, object],
+    ) -> GateResult:
+        if self._has_logic_predicates(node):
+            return self._evaluate_logic_node(gate, context, node)
+
+        raw_type = node.get("type")
+        if not isinstance(raw_type, str):
+            return self._result(gate.name, "block", "predicate node missing type")
+
+        predicate_type = self._normalize(raw_type)
+        if predicate_type == "regex":
+            return self._evaluate_regex(gate, context, node)
+        if predicate_type in {"length", "length_limit"}:
+            return self._evaluate_length(gate, context, node)
+        if predicate_type in {"keyword", "keywords"}:
+            return self._evaluate_keyword(gate, context, node)
+
+        return self._result(gate.name, "block", f"unknown predicate type: {raw_type!r}")
+
+    def _evaluate_numeric_range(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        config: Mapping[str, object],
+    ) -> GateResult:
+        extracted = self._extract_value(gate, context, config)
+        value = self._coerce_float(extracted)
+        if value is None:
+            return self._result(gate.name, "block", f"value is not numeric: {extracted!r}")
+
+        outside = gate.block.get("outside") if gate.block else None
+        if isinstance(outside, list) and len(outside) == 2:
+            low = self._coerce_float(outside[0])
+            high = self._coerce_float(outside[1])
+            if low is not None and high is not None and not (low <= value <= high):
+                return self._result(
+                    gate.name,
+                    "block",
+                    f"value {value} outside [{low}, {high}]",
+                    value=value,
+                )
+
+        auto = self._range_bounds(gate.auto_approve)
+        if auto is not None and auto[0] <= value <= auto[1]:
+            return self._result(
+                gate.name,
+                "continue",
+                f"value {value} inside auto-approve range",
+                value=value,
+            )
+
+        approval = self._range_bounds(gate.require_approval)
+        if approval is not None and approval[0] <= value <= approval[1]:
+            return self._result(
+                gate.name,
+                "require_approval",
+                f"value {value} requires approval",
+                value=value,
+            )
+
+        return self._result(gate.name, "block", f"value {value} did not match any allowed range", value=value)
+
+    def _evaluate_string_match(self, gate: Gate, context: Mapping[str, object]) -> GateResult:
+        value = self._as_text(self._extract_value(gate, context, gate.config))
+        case_sensitive = bool(gate.config.get("case_sensitive", True))
+        expected = value if case_sensitive else value.lower()
+
+        allowed_values = self._normalize_values(gate.allowed_values, case_sensitive)
+        approval_values = self._normalize_values(gate.approval_values, case_sensitive)
+
+        if expected in allowed_values:
+            return self._result(gate.name, "continue", f"value {value!r} is allowed", value=value)
+        if expected in approval_values:
+            return self._result(
+                gate.name,
+                "require_approval",
+                f"value {value!r} requires approval",
+                value=value,
+            )
+        return self._result(gate.name, "block", f"value {value!r} is blocked", value=value)
+
+    def _evaluate_regex(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        config: Mapping[str, object],
+    ) -> GateResult:
+        pattern = self._extract_pattern(gate, config)
+        if pattern is None:
+            return self._result(gate.name, "block", "regex pattern is required")
+
+        flags = 0
+        if bool(config.get("ignore_case")):
+            flags |= re.IGNORECASE
+        if bool(config.get("multiline")):
+            flags |= re.MULTILINE
+
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error as exc:
+            return self._result(gate.name, "block", f"invalid regex pattern: {exc}")
+
+        value = self._as_text(self._extract_value(gate, context, config))
+        if compiled.search(value):
+            return self._result(gate.name, "continue", f"value matched regex {pattern!r}", value=value)
+        return self._result(gate.name, "block", f"value did not match regex {pattern!r}", value=value)
+
+    def _evaluate_length(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        config: Mapping[str, object],
+    ) -> GateResult:
+        value = self._as_text(self._extract_value(gate, context, config))
+        char_count = len(value)
+        token_count = self._token_counter.count(value)
+
+        min_chars = self._coerce_int(config.get("min_chars"))
+        max_chars = self._coerce_int(config.get("max_chars"))
+        min_tokens = self._coerce_int(config.get("min_tokens"))
+        max_tokens = self._coerce_int(config.get("max_tokens"))
+
+        if min_chars is not None and char_count < min_chars:
+            return self._result(
+                gate.name,
+                "block",
+                f"length chars {char_count} < min_chars {min_chars}",
+                value=float(char_count),
+            )
+        if max_chars is not None and char_count > max_chars:
+            return self._result(
+                gate.name,
+                "block",
+                f"length chars {char_count} > max_chars {max_chars}",
+                value=float(char_count),
+            )
+        if min_tokens is not None and token_count < min_tokens:
+            return self._result(
+                gate.name,
+                "block",
+                f"length tokens {token_count} < min_tokens {min_tokens}",
+                value=float(token_count),
+            )
+        if max_tokens is not None and token_count > max_tokens:
+            return self._result(
+                gate.name,
+                "block",
+                f"length tokens {token_count} > max_tokens {max_tokens}",
+                value=float(token_count),
+            )
+
+        return self._result(
+            gate.name,
+            "continue",
+            f"length ok chars={char_count} tokens={token_count}",
+            value=float(token_count),
+        )
+
+    def _evaluate_keyword(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        config: Mapping[str, object],
+    ) -> GateResult:
+        text = self._as_text(self._extract_value(gate, context, config))
+        case_sensitive = bool(config.get("case_sensitive", False))
+        haystack = text if case_sensitive else text.lower()
+
+        blocked = self._keyword_list(
+            config.get("blocked_keywords")
+            or config.get("block_keywords")
+            or config.get("blocked")
+            or config.get("block")
+        )
+        required = self._keyword_list(
+            config.get("required_keywords")
+            or config.get("require_keywords")
+            or config.get("required")
+            or config.get("require")
+        )
+        if not case_sensitive:
+            blocked = [token.lower() for token in blocked]
+            required = [token.lower() for token in required]
+
+        blocked_hits = [token for token in blocked if token in haystack]
+        if blocked_hits:
+            return self._result(
+                gate.name,
+                "block",
+                f"blocked keywords found: {', '.join(blocked_hits)}",
+                value=", ".join(blocked_hits),
+            )
+
+        missing = [token for token in required if token not in haystack]
+        if missing:
+            return self._result(
+                gate.name,
+                "require_approval",
+                f"required keywords missing: {', '.join(missing)}",
+                value=", ".join(missing),
+            )
+
+        return self._result(gate.name, "continue", "keyword checks passed")
+
+    def _merge_actions(
+        self,
+        logic: str,
+        results: Sequence[GateResult],
+    ) -> Literal["continue", "block", "require_approval"]:
+        if logic == _AND:
+            if any(result.action == "block" for result in results):
+                return "block"
+            if any(result.action == "require_approval" for result in results):
+                return "require_approval"
+            return "continue"
+
+        if any(result.action == "continue" for result in results):
+            return "continue"
+        if any(result.action == "require_approval" for result in results):
+            return "require_approval"
+        return "block"
+
+    def _extract_value(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+        config: Mapping[str, object],
+    ) -> object:
+        extract = config.get("extract")
+        if not isinstance(extract, str):
+            extract = gate.extract
+        if isinstance(extract, str) and extract in context:
+            return context[extract]
+
+        for key in ("value", "message", "response", "text", "step_output", "tool_args"):
+            if key in context:
+                return context[key]
+        return None
+
+    def _extract_pattern(self, gate: Gate, config: Mapping[str, object]) -> str | None:
+        configured = config.get("pattern")
+        if isinstance(configured, str) and configured:
+            return configured
+
+        if isinstance(gate.check, str):
+            candidate = gate.check.strip()
+            if candidate and self._normalize(candidate) not in _RESERVED_CHECK_NAMES:
+                return candidate
+        return None
+
+    def _normalize_values(self, values: Sequence[str] | None, case_sensitive: bool) -> set[str]:
+        if not values:
+            return set()
+        if case_sensitive:
+            return {value for value in values}
+        return {value.lower() for value in values}
+
+    def _keyword_list(self, value: object) -> list[str]:
+        if not isinstance(value, Sequence) or isinstance(value, str):
+            return []
+        tokens: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                tokens.append(item)
+        return tokens
+
+    def _as_text(self, value: object) -> str:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (dict, list, tuple)):
+            return json.dumps(value, sort_keys=True)
+        if value is None:
+            return ""
+        return str(value)
+
+    def _range_bounds(self, payload: Mapping[str, object] | None) -> tuple[float, float] | None:
+        if not isinstance(payload, Mapping):
+            return None
+        low = self._coerce_float(payload.get("min"))
+        high = self._coerce_float(payload.get("max"))
+        if low is None or high is None:
+            return None
+        return (low, high)
+
+    def _coerce_float(self, value: object) -> float | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return float(stripped)
+            except ValueError:
+                return None
+        return None
+
+    def _coerce_int(self, value: object) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            if not stripped.lstrip("-").isdigit():
+                return None
+            return int(stripped)
+        return None
+
+    def _normalize(self, value: str) -> str:
+        return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+    def _has_logic_predicates(self, config: Mapping[str, object]) -> bool:
+        predicates = config.get("predicates")
+        return isinstance(predicates, Sequence) and not isinstance(predicates, str)
+
+    def _is_length_check(self, config: Mapping[str, object], check_name: str) -> bool:
+        if check_name in {"length", "length_limit"}:
+            return True
+        keys = {"min_chars", "max_chars", "min_tokens", "max_tokens"}
+        return any(key in config for key in keys)
+
+    def _is_keyword_check(self, config: Mapping[str, object], check_name: str) -> bool:
+        if check_name in {"keyword", "keywords"}:
+            return True
+        keys = {
+            "blocked_keywords",
+            "block_keywords",
+            "blocked",
+            "block",
+            "required_keywords",
+            "require_keywords",
+            "required",
+            "require",
+        }
+        return any(key in config for key in keys)
+
+    def _result(
+        self,
+        gate_name: str,
+        action: Literal["continue", "block", "require_approval"],
+        reason: str,
+        *,
+        value: str | float | None = None,
+        flags: list[str] | None = None,
+    ) -> GateResult:
+        return GateResult(
+            gate_name=gate_name,
+            lane=GateLane.policy,
+            action=action,
+            reason=reason,
+            value=value,
+            flags=flags or [],
+        )
+
+
+__all__ = ["PredicateChecker"]

--- a/silas/gates/runner.py
+++ b/silas/gates/runner.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+from silas.gates.predicates import PredicateChecker
+from silas.models.gates import (
+    ALLOWED_MUTATIONS,
+    Gate,
+    GateLane,
+    GateProvider,
+    GateResult,
+    GateTrigger,
+)
+from silas.protocols.gates import GateCheckProvider, GateRunner
+
+if TYPE_CHECKING:
+    from silas.models.work import WorkItem
+
+
+class SilasGateRunner(GateRunner):
+    """Two-lane gate runner for policy enforcement and quality observability."""
+
+    def __init__(
+        self,
+        providers: Mapping[GateProvider | str, GateCheckProvider] | None = None,
+        predicate_checker: PredicateChecker | None = None,
+    ) -> None:
+        self._providers: dict[str, GateCheckProvider] = {}
+        self.quality_log: list[GateResult] = []
+        self.rejected_mutations: list[tuple[str, str]] = []
+
+        self.register_provider(GateProvider.predicate, predicate_checker or PredicateChecker())
+        if providers:
+            for provider_name, provider in providers.items():
+                self.register_provider(provider_name, provider)
+
+    def register_provider(self, provider_name: GateProvider | str, provider: GateCheckProvider) -> None:
+        self._providers[self._provider_key(provider_name)] = provider
+
+    def precompile_turn_gates(
+        self,
+        system_gates: Sequence[Gate] | None = None,
+        work_item_gates: Sequence[Gate] | None = None,
+        work_item: WorkItem | None = None,
+    ) -> tuple[Gate, ...]:
+        compiled: list[Gate] = [gate.model_copy(deep=True) for gate in (system_gates or [])]
+
+        if work_item_gates is not None:
+            compiled.extend(gate.model_copy(deep=True) for gate in work_item_gates)
+        elif work_item is not None:
+            compiled.extend(gate.model_copy(deep=True) for gate in work_item.gates)
+
+        return tuple(compiled)
+
+    def precompile_execution_gates(
+        self,
+        system_gates: Sequence[Gate] | None = None,
+        work_item: WorkItem | None = None,
+    ) -> tuple[Gate, ...]:
+        return self.precompile_turn_gates(system_gates=system_gates, work_item=work_item)
+
+    async def check_after_step(
+        self,
+        gates: Sequence[Gate],
+        step_index: int,
+        context: Mapping[str, object],
+    ) -> tuple[list[GateResult], list[GateResult], dict[str, object]]:
+        scoped_context = dict(context)
+        scoped_context["step_index"] = step_index
+        return await self.check_gates(
+            gates=list(gates),
+            trigger=GateTrigger.after_step,
+            context=scoped_context,
+        )
+
+    async def check_gates(
+        self,
+        gates: list[Gate],
+        trigger: GateTrigger,
+        context: dict[str, object],
+    ) -> tuple[list[GateResult], list[GateResult], dict[str, object]]:
+        step_index = self._step_index_from_context(context) if trigger == GateTrigger.after_step else None
+        matched = self._matching_gates(gates, trigger, step_index)
+        working_context = dict(context)
+
+        policy_results: list[GateResult] = []
+        quality_results: list[GateResult] = []
+
+        for gate in matched:
+            if gate.lane != GateLane.policy:
+                continue
+            result, allowed_mutations = await self._evaluate_policy_gate(gate, working_context)
+            policy_results.append(result)
+            if allowed_mutations:
+                self._merge_allowed_mutations(working_context, allowed_mutations)
+
+        for gate in matched:
+            if gate.lane != GateLane.quality:
+                continue
+            result = await self._evaluate_quality_gate(gate, working_context)
+            quality_results.append(result)
+
+        self.quality_log.extend(quality_results)
+        return policy_results, quality_results, working_context
+
+    async def check_gate(self, gate: Gate, context: dict[str, object]) -> GateResult:
+        if gate.lane == GateLane.quality:
+            return await self._evaluate_quality_gate(gate, context)
+        result, _ = await self._evaluate_policy_gate(gate, context)
+        return result
+
+    async def _evaluate_policy_gate(
+        self,
+        gate: Gate,
+        context: Mapping[str, object],
+    ) -> tuple[GateResult, dict[str, object] | None]:
+        raw = await self._run_provider(gate, context)
+        normalized = self._normalize_policy_result(gate, raw)
+        return self._sanitize_policy_mutation(gate, normalized)
+
+    async def _evaluate_quality_gate(self, gate: Gate, context: Mapping[str, object]) -> GateResult:
+        raw = await self._run_provider(gate, context)
+        return self._normalize_quality_result(gate, raw)
+
+    async def _run_provider(self, gate: Gate, context: Mapping[str, object]) -> GateResult:
+        provider_name = self._provider_key(gate.provider)
+        provider = self._providers.get(provider_name)
+        if provider is None:
+            return GateResult(
+                gate_name=gate.name,
+                lane=GateLane.policy,
+                action="block",
+                reason=f"No provider: {provider_name}",
+            )
+
+        try:
+            result = await provider.check(gate, dict(context))
+        except Exception as exc:  # noqa: BLE001
+            return GateResult(
+                gate_name=gate.name,
+                lane=GateLane.policy,
+                action="block",
+                reason=f"provider '{provider_name}' failed: {exc}",
+                flags=["provider_error"],
+            )
+
+        if not isinstance(result, GateResult):
+            return GateResult(
+                gate_name=gate.name,
+                lane=GateLane.policy,
+                action="block",
+                reason=f"provider '{provider_name}' returned invalid result",
+            )
+        return result
+
+    def _normalize_policy_result(self, gate: Gate, result: GateResult) -> GateResult:
+        flags = list(result.flags)
+        if result.lane != GateLane.policy:
+            flags.append("lane_coerced_policy")
+        return GateResult(
+            gate_name=gate.name,
+            lane=GateLane.policy,
+            action=result.action,
+            reason=result.reason,
+            value=result.value,
+            score=result.score,
+            flags=flags,
+            modified_context=result.modified_context,
+        )
+
+    def _normalize_quality_result(self, gate: Gate, result: GateResult) -> GateResult:
+        flags = list(result.flags)
+        reason = result.reason
+
+        if result.action != "continue":
+            flags.append("quality_lane_violation")
+            reason = f"{reason} (quality action overridden to continue)"
+        if isinstance(result.modified_context, dict):
+            flags.append("quality_mutation_ignored")
+
+        return GateResult(
+            gate_name=gate.name,
+            lane=GateLane.quality,
+            action="continue",
+            reason=reason,
+            value=result.value,
+            score=result.score,
+            flags=sorted(set(flags)),
+            modified_context=None,
+        )
+
+    def _sanitize_policy_mutation(
+        self,
+        gate: Gate,
+        result: GateResult,
+    ) -> tuple[GateResult, dict[str, object] | None]:
+        mutation = result.modified_context
+        if not isinstance(mutation, dict):
+            return result, None
+
+        allowed: dict[str, object] = {}
+        flags = list(result.flags)
+        for key, value in mutation.items():
+            if key in ALLOWED_MUTATIONS:
+                allowed[key] = value
+                continue
+            self.rejected_mutations.append((gate.name, key))
+            flags.append(f"rejected_mutation:{key}")
+
+        sanitized_result = GateResult(
+            gate_name=result.gate_name,
+            lane=result.lane,
+            action=result.action,
+            reason=result.reason,
+            value=result.value,
+            score=result.score,
+            flags=flags,
+            modified_context=allowed or None,
+        )
+        return sanitized_result, allowed or None
+
+    def _merge_allowed_mutations(
+        self,
+        context: dict[str, object],
+        mutation: Mapping[str, object],
+    ) -> None:
+        for key, value in mutation.items():
+            if key == "tool_args" and isinstance(value, Mapping):
+                existing = context.get("tool_args")
+                merged = dict(existing) if isinstance(existing, Mapping) else {}
+                merged.update(value)
+                context["tool_args"] = merged
+                continue
+            context[key] = value
+
+    def _matching_gates(
+        self,
+        gates: Sequence[Gate],
+        trigger: GateTrigger,
+        step_index: int | None,
+    ) -> list[Gate]:
+        matched: list[Gate] = []
+        for gate in gates:
+            if gate.on != trigger:
+                continue
+            if trigger == GateTrigger.after_step and step_index is not None and gate.after_step != step_index:
+                continue
+            matched.append(gate)
+        return matched
+
+    def _step_index_from_context(self, context: Mapping[str, object]) -> int | None:
+        raw = context.get("step_index")
+        if isinstance(raw, bool):
+            return None
+        if isinstance(raw, int):
+            return raw
+        if isinstance(raw, str) and raw.strip().lstrip("-").isdigit():
+            return int(raw)
+        return None
+
+    def _provider_key(self, provider_name: GateProvider | str) -> str:
+        if isinstance(provider_name, GateProvider):
+            return provider_name.value
+        return str(provider_name).strip().lower()
+
+
+__all__ = ["SilasGateRunner"]

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from silas.gates import PredicateChecker, SilasAccessController, SilasGateRunner
+from silas.models.gates import (
+    AccessLevel,
+    Gate,
+    GateLane,
+    GateProvider,
+    GateResult,
+    GateTrigger,
+    GateType,
+)
+from silas.models.work import WorkItem, WorkItemType
+
+
+class StaticGateProvider:
+    def __init__(self, result: GateResult) -> None:
+        self._result = result
+
+    async def check(self, gate: Gate, context: dict[str, object]) -> GateResult:
+        del gate, context
+        return self._result.model_copy(deep=True)
+
+
+def _gate(
+    name: str,
+    *,
+    on: GateTrigger = GateTrigger.every_user_message,
+    provider: GateProvider = GateProvider.predicate,
+    gate_type: GateType = GateType.string_match,
+    check: str | None = None,
+    config: dict[str, object] | None = None,
+    after_step: int | None = None,
+) -> Gate:
+    return Gate(
+        name=name,
+        on=on,
+        after_step=after_step,
+        provider=provider,
+        type=gate_type,
+        check=check,
+        config=config or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_policy_gate_blocks_content() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "no_forbidden",
+        gate_type=GateType.regex,
+        config={"pattern": r"^(?!.*forbidden).*$"},
+    )
+
+    policy_results, quality_results, merged_context = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "this contains forbidden text"},
+    )
+
+    assert len(policy_results) == 1
+    assert policy_results[0].action == "block"
+    assert quality_results == []
+    assert merged_context["message"] == "this contains forbidden text"
+
+
+@pytest.mark.asyncio
+async def test_quality_gate_logs_but_passes() -> None:
+    runner = SilasGateRunner(
+        providers={
+            GateProvider.llm: StaticGateProvider(
+                GateResult(
+                    gate_name="quality_guard",
+                    lane=GateLane.policy,
+                    action="block",
+                    reason="quality checker thought this was low quality",
+                )
+            )
+        }
+    )
+    gate = _gate("quality_guard", provider=GateProvider.llm, check="off_topic")
+
+    policy_results, quality_results, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "hello"},
+    )
+
+    assert policy_results == []
+    assert len(quality_results) == 1
+    assert quality_results[0].lane == GateLane.quality
+    assert quality_results[0].action == "continue"
+    assert "quality_lane_violation" in quality_results[0].flags
+    assert len(runner.quality_log) == 1
+
+
+@pytest.mark.asyncio
+async def test_predicate_regex_evaluation() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "match_ticket",
+        gate_type=GateType.regex,
+        config={"pattern": r"TICKET-\d+"},
+    )
+
+    policy_results, _, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "Please review TICKET-42 today."},
+    )
+
+    assert policy_results[0].action == "continue"
+
+
+@pytest.mark.asyncio
+async def test_predicate_length_evaluation() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "message_length",
+        check="length",
+        config={"max_chars": 8},
+    )
+
+    policy_results, _, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "this is definitely too long"},
+    )
+
+    assert policy_results[0].action == "block"
+    assert "max_chars" in policy_results[0].reason
+
+
+@pytest.mark.asyncio
+async def test_predicate_keyword_blocking() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "keyword_policy",
+        check="keyword",
+        config={"blocked_keywords": ["secret"]},
+    )
+
+    policy_results, _, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "The secret code is 1234"},
+    )
+
+    assert policy_results[0].action == "block"
+
+
+@pytest.mark.asyncio
+async def test_predicate_keyword_require_approval() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "must_include_invoice",
+        check="keyword",
+        config={"required_keywords": ["invoice"]},
+    )
+
+    policy_results, _, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "Need help with my account"},
+    )
+
+    assert policy_results[0].action == "require_approval"
+
+
+@pytest.mark.asyncio
+async def test_predicate_composable_or_logic() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    gate = _gate(
+        "composed",
+        config={
+            "logic": "or",
+            "predicates": [
+                {"type": "regex", "pattern": r"^denied$"},
+                {"type": "keyword", "required_keywords": ["allow"]},
+            ],
+        },
+    )
+
+    policy_results, _, _ = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "please allow this request"},
+    )
+
+    assert policy_results[0].action == "continue"
+
+
+def test_access_level_filtering() -> None:
+    levels = {
+        "anonymous": AccessLevel(description="Anon", tools=["read"]),
+        "authenticated": AccessLevel(
+            description="Auth",
+            tools=["read", "search"],
+            requires=["gate_auth"],
+        ),
+        "trusted": AccessLevel(
+            description="Trusted",
+            tools=["read", "search", "write"],
+            requires=["gate_auth", "gate_trust"],
+        ),
+        "owner": AccessLevel(description="Owner", tools=["*"]),
+    }
+    controller = SilasAccessController(owner_id="owner", access_levels=levels)
+    all_tools = ["read", "search", "write"]
+
+    assert controller.filter_tools("conn-1", all_tools) == ["read"]
+    controller.gate_passed("conn-1", "gate_auth")
+    assert controller.filter_tools("conn-1", all_tools) == ["read", "search"]
+    controller.gate_passed("conn-1", "gate_trust")
+    assert controller.filter_tools("conn-1", all_tools) == ["read", "search", "write"]
+
+
+def test_owner_bypass() -> None:
+    controller = SilasAccessController(owner_id="owner")
+    all_tools = ["read", "search", "write"]
+
+    assert controller.get_access_level("owner") == "owner"
+    assert controller.filter_tools("owner", all_tools) == all_tools
+    assert controller.gate_passed("owner", "any_gate") == "owner"
+
+
+def test_access_level_expiry_downgrades_automatically() -> None:
+    levels = {
+        "anonymous": AccessLevel(description="Anon", tools=["read"]),
+        "authenticated": AccessLevel(
+            description="Auth",
+            tools=["read", "search"],
+            requires=["gate_auth"],
+            expires_after=1,
+        ),
+        "trusted": AccessLevel(description="Trusted", tools=["read", "search", "write"], requires=[]),
+        "owner": AccessLevel(description="Owner", tools=["*"]),
+    }
+    controller = SilasAccessController(owner_id="owner", access_levels=levels)
+    controller.gate_passed("conn-expiring", "gate_auth")
+
+    state = controller._state_by_connection["conn-expiring"]  # noqa: SLF001 - state asserted here
+    state.level_name = "authenticated"
+    state.granted_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+
+    assert controller.get_access_level("conn-expiring") == "anonymous"
+    assert controller.get_allowed_tools("conn-expiring") == ["read"]
+
+
+def test_gate_precompilation_merges_config_and_work_item_gates() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    system_gate = _gate("system_guard")
+    work_gate = _gate("work_guard")
+    work_item = WorkItem(
+        id="w1",
+        type=WorkItemType.task,
+        title="Demo",
+        body="Run task",
+        gates=[work_gate],
+    )
+
+    compiled = runner.precompile_turn_gates(system_gates=[system_gate], work_item=work_item)
+    assert [gate.name for gate in compiled] == ["system_guard", "work_guard"]
+
+    system_gate.name = "mutated"
+    assert compiled[0].name == "system_guard"
+
+
+@pytest.mark.asyncio
+async def test_allowed_mutations_enforced() -> None:
+    mutation_result = GateResult(
+        gate_name="mutate_guard",
+        lane=GateLane.policy,
+        action="continue",
+        reason="rewrite",
+        modified_context={
+            "response": "safe response",
+            "tool_args": {"limit": 5},
+            "disallowed_key": "drop me",
+        },
+    )
+    runner = SilasGateRunner(
+        providers={GateProvider.custom: StaticGateProvider(mutation_result)},
+    )
+    gate = _gate("mutate_guard", provider=GateProvider.custom)
+
+    policy_results, _, merged_context = await runner.check_gates(
+        gates=[gate],
+        trigger=GateTrigger.every_user_message,
+        context={"message": "hello", "tool_args": {"mode": "strict"}},
+    )
+
+    assert policy_results[0].modified_context == {
+        "response": "safe response",
+        "tool_args": {"limit": 5},
+    }
+    assert merged_context["response"] == "safe response"
+    assert merged_context["tool_args"] == {"mode": "strict", "limit": 5}
+    assert "disallowed_key" not in merged_context
+    assert ("mutate_guard", "disallowed_key") in runner.rejected_mutations
+
+
+@pytest.mark.asyncio
+async def test_mid_execution_after_step_gate_runs_only_on_matching_step() -> None:
+    runner = SilasGateRunner(predicate_checker=PredicateChecker())
+    first_step_gate = _gate(
+        "step_one",
+        on=GateTrigger.after_step,
+        after_step=1,
+        gate_type=GateType.regex,
+        config={"pattern": "ok"},
+    )
+    second_step_gate = _gate(
+        "step_two",
+        on=GateTrigger.after_step,
+        after_step=2,
+        gate_type=GateType.regex,
+        config={"pattern": "ok"},
+    )
+
+    policy_results, _, _ = await runner.check_after_step(
+        gates=[first_step_gate, second_step_gate],
+        step_index=2,
+        context={"step_output": "ok"},
+    )
+
+    assert len(policy_results) == 1
+    assert policy_results[0].gate_name == "step_two"


### PR DESCRIPTION
## Phase 4: Guards

### New modules (1,297 lines across 5 files)

**`silas/gates/runner.py`** (268 lines) — `SilasGateRunner`
- Two-lane gate runner (policy blocks + quality logs)
- Provider registration system
- Gate compilation from system + work item gates
- Mutation sanitization via `ALLOWED_MUTATIONS` whitelist

**`silas/gates/predicates.py`** (463 lines) — `PredicateChecker`
- Deterministic gate checker for predicate-backed gates
- Supports: regex, length, keyword, numeric_range, string_match
- Composed logic (AND/OR) with nested predicates

**`silas/gates/access.py`** (226 lines) — `SilasAccessController`
- Per-connection access control with level transitions
- anonymous → authenticated → trusted → owner
- Expiry-based automatic downgrade
- Owner bypass, tool filtering

### Tests
- 13 new tests covering all three modules
- **268 tests total**, all passing in 2.17s
- Ruff clean

Built by Codex (`tender-mist`), reviewed and merged by Silas 🪶