### PR TITLE
feat: Phase 6a — SkillLoader, SkillValidator, SkillInstaller

### DIFF
--- a/silas/skills/__init__.py
+++ b/silas/skills/__init__.py
@@ -1,13 +1,24 @@
+from __future__ import annotations
+
 from silas.skills.executor import (
     SkillExecutor,
     builtin_skill_definitions,
     register_builtin_skills,
 )
+from silas.skills.installer import SkillInstaller
+from silas.skills.loader import SilasSkillLoader
 from silas.skills.registry import SkillRegistry
+from silas.skills.validator import SkillValidator
+
+SkillLoader = SilasSkillLoader
 
 __all__ = [
     "SkillExecutor",
+    "SkillInstaller",
+    "SkillLoader",
     "SkillRegistry",
+    "SkillValidator",
+    "SilasSkillLoader",
     "builtin_skill_definitions",
     "register_builtin_skills",
 ]

--- a/silas/skills/installer.py
+++ b/silas/skills/installer.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from silas.models.skills import SkillMetadata
+from silas.protocols.skills import SkillLoader
+from silas.skills.loader import SilasSkillLoader
+
+
+class SkillInstaller:
+    def __init__(self, loader: SkillLoader, skills_dir: Path) -> None:
+        self._loader = loader
+        self._skills_dir = skills_dir.expanduser().resolve()
+
+    def install(self, source: str, approval_token: str | None = None) -> dict[str, object]:
+        source_dir = self._resolve_source_dir(source)
+        source_loader = SilasSkillLoader(source_dir.parent)
+        skill_name = source_dir.name
+        validation_report = source_loader.validate(skill_name)
+
+        metadata: SkillMetadata | None = None
+        try:
+            metadata = source_loader.load_metadata(skill_name)
+        except ValueError as exc:
+            validation_report = dict(validation_report)
+            errors = list(validation_report.get("errors", []))
+            errors.append(str(exc))
+            validation_report["errors"] = errors
+            validation_report["valid"] = False
+
+        if not bool(validation_report.get("valid")):
+            return {
+                "installed": False,
+                "skill_name": skill_name,
+                "approval_required": False,
+                "validation_report": validation_report,
+            }
+
+        if metadata is not None and metadata.requires_approval and approval_token is None:
+            return {
+                "installed": False,
+                "skill_name": skill_name,
+                "approval_required": True,
+                "validation_report": validation_report,
+            }
+
+        destination = self._resolve_destination(skill_name)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(source_dir, destination)
+
+        indexed = self._loader.scan()
+        return {
+            "installed": True,
+            "skill_name": skill_name,
+            "approval_required": False,
+            "validation_report": validation_report,
+            "indexed_count": len(indexed),
+            "destination": str(destination),
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def uninstall(self, skill_name: str) -> bool:
+        try:
+            target = self._resolve_destination(skill_name)
+        except ValueError:
+            return False
+
+        if not target.exists() or not target.is_dir():
+            return False
+
+        shutil.rmtree(target)
+        return True
+
+    def list_installed(self) -> list[SkillMetadata]:
+        return self._loader.scan()
+
+    def _resolve_source_dir(self, source: str) -> Path:
+        candidate = Path(source).expanduser().resolve()
+        if candidate.is_file() and candidate.name == "SKILL.md":
+            candidate = candidate.parent
+        if not candidate.exists() or not candidate.is_dir():
+            raise ValueError(f"source skill directory not found: {source}")
+        if not (candidate / "SKILL.md").is_file():
+            raise ValueError(f"source skill is missing SKILL.md: {source}")
+        return candidate
+
+    def _resolve_destination(self, skill_name: str) -> Path:
+        if not skill_name.strip():
+            raise ValueError("skill_name must be non-empty")
+
+        destination = (self._skills_dir / skill_name).resolve()
+        if not _is_within(destination, self._skills_dir):
+            raise ValueError("skill destination escapes skills directory")
+        return destination
+
+
+def _is_within(candidate: Path, parent: Path) -> bool:
+    try:
+        candidate.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = ["SkillInstaller"]

--- a/silas/skills/loader.py
+++ b/silas/skills/loader.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from silas.models.skills import SkillMetadata
+from silas.skills.validator import (
+    check_forbidden_patterns,
+    validate_frontmatter,
+    validate_references,
+    validate_scripts,
+)
+
+
+class SilasSkillLoader:
+    def __init__(self, skills_dir: str | Path) -> None:
+        self._skills_dir = Path(skills_dir).expanduser().resolve()
+
+    @property
+    def skills_dir(self) -> Path:
+        return self._skills_dir
+
+    def scan(self) -> list[SkillMetadata]:
+        if not self._skills_dir.exists():
+            return []
+
+        metadata: list[SkillMetadata] = []
+        for skill_file in sorted(self._skills_dir.glob("*/SKILL.md")):
+            skill_name = skill_file.parent.name
+            try:
+                metadata.append(self.load_metadata(skill_name))
+            except ValueError:
+                continue
+        return metadata
+
+    def load_metadata(self, skill_name: str) -> SkillMetadata:
+        skill_file = self._skill_markdown_path(skill_name)
+        parsed = self._parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        try:
+            metadata = SkillMetadata.model_validate(parsed)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"invalid frontmatter for '{skill_name}': {exc}") from exc
+
+        if metadata.name != skill_name:
+            raise ValueError(
+                f"frontmatter name '{metadata.name}' does not match skill directory '{skill_name}'"
+            )
+
+        return metadata
+
+    def load_full(self, skill_name: str) -> str:
+        skill_file = self._skill_markdown_path(skill_name)
+        return skill_file.read_text(encoding="utf-8")
+
+    def resolve_script(self, skill_name: str, script_path: str) -> str:
+        if not script_path.strip():
+            raise ValueError("script_path must be non-empty")
+
+        skill_dir = self._resolve_skill_dir(skill_name)
+        candidate = (skill_dir / script_path).resolve()
+        if not _is_within(candidate, skill_dir):
+            raise ValueError("script path escapes skill directory")
+        if not candidate.exists() or not candidate.is_file():
+            raise ValueError(f"script not found: {script_path}")
+        return str(candidate)
+
+    def validate(self, skill_name: str) -> dict[str, object]:
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        try:
+            skill_dir = self._resolve_skill_dir(skill_name)
+        except ValueError as exc:
+            return {"valid": False, "errors": [str(exc)], "warnings": warnings}
+
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            return {"valid": False, "errors": ["SKILL.md not found"], "warnings": warnings}
+
+        frontmatter: dict[str, object] = {}
+        try:
+            frontmatter = self._parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            errors.append(str(exc))
+
+        metadata = self._coerce_metadata(frontmatter, skill_name, errors)
+
+        if metadata.name != skill_name:
+            errors.append(
+                f"frontmatter name '{metadata.name}' does not match skill directory '{skill_name}'"
+            )
+
+        errors.extend(validate_frontmatter(metadata))
+        errors.extend(validate_scripts(skill_dir))
+        errors.extend(check_forbidden_patterns(skill_dir))
+        errors.extend(validate_references(skill_dir, metadata))
+
+        return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+    def import_external(self, source: str, format_hint: str | None = None) -> dict[str, object]:
+        payload = self._parse_external_payload(source)
+        hint = (format_hint or "").strip().lower()
+
+        normalized: dict[str, object] | None = None
+        detected = ""
+
+        if hint in {"", "openai"}:
+            normalized = self._normalize_openai(payload)
+            if normalized is not None:
+                detected = "openai"
+
+        if normalized is None and hint in {"", "claude", "tool_use"}:
+            normalized = self._normalize_claude(payload)
+            if normalized is not None:
+                detected = "claude"
+
+        if normalized is None:
+            raise ValueError("unsupported external skill format")
+
+        skill_md = self._render_skill_md(normalized)
+        return {
+            "format": detected,
+            "skill_name": normalized["name"],
+            "skill_md": skill_md,
+            "transformation_report": {
+                "source_format": detected,
+                "translated_fields": ["name", "description", "script_args"],
+                "removed_fields": [],
+                "warnings": [],
+            },
+        }
+
+    def _resolve_skill_dir(self, skill_name: str) -> Path:
+        if not skill_name.strip():
+            raise ValueError("skill_name must be non-empty")
+
+        skill_dir = (self._skills_dir / skill_name).resolve()
+        if not _is_within(skill_dir, self._skills_dir):
+            raise ValueError("skill path escapes skills directory")
+        if not skill_dir.exists() or not skill_dir.is_dir():
+            raise ValueError(f"skill not found: {skill_name}")
+        return skill_dir
+
+    def _skill_markdown_path(self, skill_name: str) -> Path:
+        skill_dir = self._resolve_skill_dir(skill_name)
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists() or not skill_file.is_file():
+            raise ValueError(f"SKILL.md not found for skill '{skill_name}'")
+        return skill_file
+
+    def _parse_frontmatter(self, skill_content: str) -> dict[str, object]:
+        lines = skill_content.splitlines()
+        if not lines or lines[0].strip() != "---":
+            raise ValueError("SKILL.md is missing YAML frontmatter start delimiter")
+
+        end_idx = -1
+        for idx in range(1, len(lines)):
+            if lines[idx].strip() == "---":
+                end_idx = idx
+                break
+
+        if end_idx == -1:
+            raise ValueError("SKILL.md is missing YAML frontmatter end delimiter")
+
+        block = "\n".join(lines[1:end_idx])
+        try:
+            parsed = yaml.safe_load(block) or {}
+        except yaml.YAMLError as exc:
+            raise ValueError(f"invalid YAML frontmatter: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("SKILL.md frontmatter must be a mapping")
+
+        return parsed
+
+    def _coerce_metadata(
+        self,
+        frontmatter: dict[str, object],
+        skill_name: str,
+        errors: list[str],
+    ) -> SkillMetadata:
+        try:
+            return SkillMetadata.model_validate(frontmatter)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"invalid frontmatter schema: {exc}")
+
+        name = frontmatter.get("name")
+        description = frontmatter.get("description")
+        activation = frontmatter.get("activation")
+        ui = frontmatter.get("ui")
+        composes_with = frontmatter.get("composes_with")
+        script_args = frontmatter.get("script_args")
+        metadata = frontmatter.get("metadata")
+        requires_approval = frontmatter.get("requires_approval")
+        tool_name = frontmatter.get("tool_name")
+        tool_description = frontmatter.get("tool_description")
+        tool_schema = frontmatter.get("tool_schema")
+
+        return SkillMetadata(
+            name=name if isinstance(name, str) else skill_name,
+            description=description if isinstance(description, str) else "",
+            activation=activation if isinstance(activation, str) else None,
+            ui=ui if isinstance(ui, dict) else {},
+            composes_with=composes_with if isinstance(composes_with, list) else [],
+            script_args=script_args if isinstance(script_args, dict) else {},
+            metadata=metadata if isinstance(metadata, dict) else {},
+            requires_approval=requires_approval if isinstance(requires_approval, bool) else False,
+            tool_name=tool_name if isinstance(tool_name, str) else None,
+            tool_description=tool_description if isinstance(tool_description, str) else None,
+            tool_schema=tool_schema if isinstance(tool_schema, dict) else {},
+        )
+
+    def _parse_external_payload(self, source: str) -> object:
+        try:
+            return json.loads(source)
+        except json.JSONDecodeError:
+            try:
+                parsed = yaml.safe_load(source)
+            except yaml.YAMLError as exc:
+                raise ValueError(f"invalid external skill source: {exc}") from exc
+            if parsed is None:
+                raise ValueError("external source is empty") from None
+            return parsed
+
+    def _normalize_openai(self, payload: object) -> dict[str, object] | None:
+        function_payload = _extract_openai_function_payload(payload)
+        if function_payload is None:
+            return None
+
+        name = _normalize_skill_name(str(function_payload.get("name") or "imported-skill"))
+        description = _normalize_description(
+            str(function_payload.get("description") or "Imported OpenAI function skill.")
+        )
+        parameters = function_payload.get("parameters")
+        script_args = _schema_to_script_args(parameters)
+        return {"name": name, "description": description, "script_args": script_args}
+
+    def _normalize_claude(self, payload: object) -> dict[str, object] | None:
+        tool_payload = _extract_claude_tool_payload(payload)
+        if tool_payload is None:
+            return None
+
+        name = _normalize_skill_name(str(tool_payload.get("name") or "imported-skill"))
+        description = _normalize_description(
+            str(tool_payload.get("description") or "Imported Claude tool skill.")
+        )
+        input_schema = tool_payload.get("input_schema")
+        script_args = _schema_to_script_args(input_schema)
+        return {"name": name, "description": description, "script_args": script_args}
+
+    def _render_skill_md(self, normalized: dict[str, object]) -> str:
+        frontmatter: dict[str, object] = {
+            "name": normalized["name"],
+            "description": normalized["description"],
+            "activation": "manual",
+            "requires_approval": False,
+        }
+        script_args = normalized.get("script_args")
+        if isinstance(script_args, dict) and script_args:
+            frontmatter["script_args"] = script_args
+
+        yaml_block = yaml.safe_dump(frontmatter, sort_keys=False).strip()
+        title = str(normalized["name"]).replace("-", " ").title()
+        return (
+            f"---\n{yaml_block}\n---\n\n"
+            f"# {title}\n\n"
+            "Imported skill scaffold generated by Silas.\n"
+        )
+
+
+def _extract_openai_function_payload(payload: object) -> dict[str, object] | None:
+    if isinstance(payload, dict):
+        if "function" in payload and isinstance(payload["function"], dict):
+            return payload["function"]
+        if "name" in payload and "parameters" in payload:
+            return payload
+        tools = payload.get("tools")
+        if isinstance(tools, list):
+            for item in tools:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "function" and isinstance(item.get("function"), dict):
+                    return item["function"]
+
+    if isinstance(payload, list):
+        for item in payload:
+            extracted = _extract_openai_function_payload(item)
+            if extracted is not None:
+                return extracted
+    return None
+
+
+def _extract_claude_tool_payload(payload: object) -> dict[str, object] | None:
+    if isinstance(payload, dict):
+        if "name" in payload and "input_schema" in payload:
+            return payload
+        tools = payload.get("tools")
+        if isinstance(tools, list):
+            for item in tools:
+                if not isinstance(item, dict):
+                    continue
+                if "name" in item and "input_schema" in item:
+                    return item
+
+    if isinstance(payload, list):
+        for item in payload:
+            extracted = _extract_claude_tool_payload(item)
+            if extracted is not None:
+                return extracted
+    return None
+
+
+def _schema_to_script_args(schema: object) -> dict[str, dict[str, object]]:
+    if not isinstance(schema, dict):
+        return {}
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+
+    normalized_properties: dict[str, object] = {}
+    for key, value in properties.items():
+        if isinstance(key, str) and isinstance(value, dict):
+            normalized_properties[key] = value
+
+    if not normalized_properties:
+        return {}
+
+    return {"scripts/run.py": normalized_properties}
+
+
+def _normalize_skill_name(raw: str) -> str:
+    lowered = raw.strip().lower()
+    cleaned = re.sub(r"[^a-z0-9-]+", "-", lowered)
+    cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-")
+    return cleaned or "imported-skill"
+
+
+def _normalize_description(raw: str) -> str:
+    text = raw.strip()
+    if len(text) < 10:
+        return "Imported external skill for tool execution."
+    if len(text) > 500:
+        return text[:500]
+    return text
+
+
+def _is_within(candidate: Path, parent: Path) -> bool:
+    try:
+        candidate.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+SkillLoader = SilasSkillLoader
+
+
+__all__ = ["SilasSkillLoader", "SkillLoader"]

--- a/silas/skills/validator.py
+++ b/silas/skills/validator.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from silas.models.skills import SkillMetadata
+
+_FORBIDDEN_PATTERNS: tuple[str, ...] = ("eval(", "exec(", "__import__")
+
+
+def validate_frontmatter(metadata: SkillMetadata) -> list[str]:
+    errors: list[str] = []
+
+    if not metadata.name.strip():
+        errors.append("frontmatter.name is required")
+
+    description = metadata.description.strip()
+    if not description:
+        errors.append("frontmatter.description is required")
+    elif len(description) < 10 or len(description) > 500:
+        errors.append("frontmatter.description must be between 10 and 500 characters")
+
+    return errors
+
+
+def validate_scripts(skill_dir: Path) -> list[str]:
+    errors: list[str] = []
+    for script_file in _iter_python_files(skill_dir):
+        source = script_file.read_text(encoding="utf-8")
+        try:
+            compile(source, str(script_file), "exec")
+        except SyntaxError as exc:
+            line = exc.lineno or 0
+            rel = script_file.relative_to(skill_dir)
+            errors.append(f"syntax error in {rel}:{line}: {exc.msg}")
+    return errors
+
+
+def check_forbidden_patterns(skill_dir: Path) -> list[str]:
+    errors: list[str] = []
+    for script_file in _iter_python_files(skill_dir):
+        rel = script_file.relative_to(skill_dir)
+        lines = script_file.read_text(encoding="utf-8").splitlines()
+        for line_no, line in enumerate(lines, start=1):
+            for pattern in _FORBIDDEN_PATTERNS:
+                if pattern in line:
+                    errors.append(f"forbidden pattern '{pattern}' in {rel}:{line_no}")
+    return errors
+
+
+def validate_references(skill_dir: Path, metadata: SkillMetadata) -> list[str]:
+    errors: list[str] = []
+    skill_root = skill_dir.resolve()
+    for script_path in metadata.script_args:
+        candidate = (skill_root / script_path).resolve()
+        if not _is_within(candidate, skill_root):
+            errors.append(f"script_args reference '{script_path}' escapes skill directory")
+            continue
+        if not candidate.exists() or not candidate.is_file():
+            errors.append(f"script_args reference '{script_path}' does not exist")
+    return errors
+
+
+class SkillValidator:
+    @staticmethod
+    def validate_frontmatter(metadata: SkillMetadata) -> list[str]:
+        return validate_frontmatter(metadata)
+
+    @staticmethod
+    def validate_scripts(skill_dir: Path) -> list[str]:
+        return validate_scripts(skill_dir)
+
+    @staticmethod
+    def check_forbidden_patterns(skill_dir: Path) -> list[str]:
+        return check_forbidden_patterns(skill_dir)
+
+    @staticmethod
+    def validate_references(skill_dir: Path, metadata: SkillMetadata) -> list[str]:
+        return validate_references(skill_dir, metadata)
+
+
+def _iter_python_files(skill_dir: Path) -> list[Path]:
+    if not skill_dir.exists():
+        return []
+    return sorted(path for path in skill_dir.rglob("*.py") if path.is_file())
+
+
+def _is_within(candidate: Path, parent: Path) -> bool:
+    try:
+        candidate.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "SkillValidator",
+    "check_forbidden_patterns",
+    "validate_frontmatter",
+    "validate_references",
+    "validate_scripts",
+]

--- a/skills/coding/SKILL.md
+++ b/skills/coding/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: coding
+description: Write, review, and refactor code using language-aware tools
+activation: auto
+requires_approval: false
+---
+# Coding Skill
+Execute code-related tasks...

--- a/skills/skill-maker/SKILL.md
+++ b/skills/skill-maker/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: skill-maker
+description: Create new skills from natural language descriptions
+activation: manual
+requires_approval: true
+---
+# Skill Maker
+Create new Silas skills...

--- a/tests/test_skill_system.py
+++ b/tests/test_skill_system.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from silas.skills.installer import SkillInstaller
+from silas.skills.loader import SilasSkillLoader
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    description: str = "Skill used for deterministic test coverage.",
+    body: str = "# Skill\n\nInstructions.",
+    frontmatter_overrides: dict[str, object] | None = None,
+    scripts: dict[str, str] | None = None,
+) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    frontmatter: dict[str, object] = {"name": name, "description": description}
+    if frontmatter_overrides:
+        frontmatter.update(frontmatter_overrides)
+
+    yaml_block = yaml.safe_dump(frontmatter, sort_keys=False).strip()
+    (skill_dir / "SKILL.md").write_text(f"---\n{yaml_block}\n---\n\n{body}\n", encoding="utf-8")
+
+    for relative_path, content in (scripts or {}).items():
+        target = skill_dir / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    return skill_dir
+
+
+def test_scan_finds_skills_in_directory(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding")
+    _write_skill(skills_dir, "ops")
+
+    loader = SilasSkillLoader(skills_dir)
+
+    assert [item.name for item in loader.scan()] == ["coding", "ops"]
+
+
+def test_load_metadata_returns_correct_skill_metadata(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding", frontmatter_overrides={"activation": "auto"})
+
+    loader = SilasSkillLoader(skills_dir)
+    metadata = loader.load_metadata("coding")
+
+    assert metadata.name == "coding"
+    assert metadata.activation == "auto"
+
+
+def test_load_metadata_raises_for_missing_skill(tmp_path: Path) -> None:
+    loader = SilasSkillLoader(tmp_path / "skills")
+
+    with pytest.raises(ValueError, match="skill not found"):
+        loader.load_metadata("missing")
+
+
+def test_load_full_returns_complete_skill_md_content(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding", body="# Coding Skill\n\nExecute coding tasks.")
+
+    loader = SilasSkillLoader(skills_dir)
+    full = loader.load_full("coding")
+
+    assert full.startswith("---")
+    assert "Coding Skill" in full
+
+
+def test_resolve_script_returns_absolute_path(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = _write_skill(skills_dir, "coding", scripts={"scripts/run.py": "print('ok')\n"})
+
+    loader = SilasSkillLoader(skills_dir)
+    resolved = loader.resolve_script("coding", "scripts/run.py")
+
+    assert Path(resolved).is_absolute()
+    assert Path(resolved) == (skill_dir / "scripts/run.py")
+
+
+def test_resolve_script_blocks_path_traversal(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding", scripts={"scripts/run.py": "print('ok')\n"})
+    (tmp_path / "outside.py").write_text("print('outside')\n", encoding="utf-8")
+
+    loader = SilasSkillLoader(skills_dir)
+
+    with pytest.raises(ValueError, match="escapes"):
+        loader.resolve_script("coding", "../outside.py")
+
+
+def test_resolve_script_raises_for_missing_file(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding")
+    loader = SilasSkillLoader(skills_dir)
+
+    with pytest.raises(ValueError, match="script not found"):
+        loader.resolve_script("coding", "scripts/missing.py")
+
+
+def test_validate_returns_valid_for_good_skill(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "coding",
+        frontmatter_overrides={
+            "script_args": {"scripts/run.py": {"path": {"type": "string"}}},
+        },
+        scripts={"scripts/run.py": "print('ok')\n"},
+    )
+
+    loader = SilasSkillLoader(skills_dir)
+    report = loader.validate("coding")
+
+    assert report["valid"] is True
+    assert report["errors"] == []
+
+
+def test_validate_catches_missing_description(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "broken"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: broken\n---\n\n# Broken\n", encoding="utf-8")
+
+    loader = SilasSkillLoader(skills_dir)
+    report = loader.validate("broken")
+
+    assert report["valid"] is False
+    assert any("description" in str(error).lower() for error in report["errors"])
+
+
+def test_validate_catches_forbidden_patterns_eval(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding", scripts={"scripts/run.py": "value = eval('1 + 1')\n"})
+
+    loader = SilasSkillLoader(skills_dir)
+    report = loader.validate("coding")
+
+    assert report["valid"] is False
+    assert any("eval(" in str(error) for error in report["errors"])
+
+
+def test_validate_catches_syntax_errors(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "coding", scripts={"scripts/run.py": "def broken(:\n    pass\n"})
+
+    loader = SilasSkillLoader(skills_dir)
+    report = loader.validate("coding")
+
+    assert report["valid"] is False
+    assert any("syntax error" in str(error) for error in report["errors"])
+
+
+def test_import_external_handles_openai_function_format(tmp_path: Path) -> None:
+    loader = SilasSkillLoader(tmp_path / "skills")
+    source = json.dumps(
+        {
+            "type": "function",
+            "function": {
+                "name": "deploy_app",
+                "description": "Deploy application releases safely.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"environment": {"type": "string"}},
+                },
+            },
+        }
+    )
+
+    report = loader.import_external(source)
+
+    assert report["format"] == "openai"
+    assert report["skill_name"] == "deploy-app"
+    assert "name: deploy-app" in str(report["skill_md"])
+
+
+def test_skill_installer_install_flow(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    destination = tmp_path / "installed"
+    source_skill = _write_skill(
+        source_root,
+        "coding",
+        scripts={"scripts/run.py": "print('ok')\n"},
+    )
+
+    loader = SilasSkillLoader(destination)
+    installer = SkillInstaller(loader=loader, skills_dir=destination)
+    report = installer.install(str(source_skill))
+
+    assert report["installed"] is True
+    assert (destination / "coding" / "SKILL.md").exists()
+    assert [item.name for item in loader.scan()] == ["coding"]
+
+
+def test_skill_installer_install_requires_approval(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    destination = tmp_path / "installed"
+    source_skill = _write_skill(
+        source_root,
+        "skill-maker",
+        frontmatter_overrides={"requires_approval": True},
+    )
+
+    loader = SilasSkillLoader(destination)
+    installer = SkillInstaller(loader=loader, skills_dir=destination)
+    report = installer.install(str(source_skill))
+
+    assert report["installed"] is False
+    assert report["approval_required"] is True
+    assert not (destination / "skill-maker").exists()
+
+
+def test_skill_installer_uninstall(tmp_path: Path) -> None:
+    destination = tmp_path / "installed"
+    _write_skill(destination, "coding")
+    loader = SilasSkillLoader(destination)
+    installer = SkillInstaller(loader=loader, skills_dir=destination)
+
+    assert installer.uninstall("coding") is True
+    assert installer.uninstall("coding") is False
+
+
+def test_skill_installer_list_installed(tmp_path: Path) -> None:
+    destination = tmp_path / "installed"
+    _write_skill(destination, "coding")
+    _write_skill(destination, "skill-maker")
+    loader = SilasSkillLoader(destination)
+    installer = SkillInstaller(loader=loader, skills_dir=destination)
+
+    names = [item.name for item in installer.list_installed()]
+
+    assert names == ["coding", "skill-maker"]
+
+
+def test_frontmatter_parsing_edge_cases(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "edge"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\r\n"
+        "name: edge\r\n"
+        "description: Handles edge parsing scenarios well.\r\n"
+        "activation: auto\r\n"
+        "---\r\n"
+        "\r\n"
+        "# Edge\r\n",
+        encoding="utf-8",
+    )
+
+    loader = SilasSkillLoader(skills_dir)
+    metadata = loader.load_metadata("edge")
+
+    assert metadata.name == "edge"
+    assert metadata.activation == "auto"
+
+
+def test_empty_skills_directory(tmp_path: Path) -> None:
+    loader = SilasSkillLoader(tmp_path / "skills")
+    assert loader.scan() == []
+
+
+def test_skill_with_script_args(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "ops",
+        frontmatter_overrides={
+            "script_args": {
+                "scripts/run.py": {"target": {"type": "string"}},
+                "scripts/prepare.py": {"flag": {"type": "boolean"}},
+            }
+        },
+        scripts={
+            "scripts/run.py": "print('run')\n",
+            "scripts/prepare.py": "print('prepare')\n",
+        },
+    )
+
+    loader = SilasSkillLoader(skills_dir)
+    metadata = loader.load_metadata("ops")
+    report = loader.validate("ops")
+
+    assert "scripts/run.py" in metadata.script_args
+    assert report["valid"] is True
+
+
+def test_validate_references_catches_missing_script_args_target(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "ops",
+        frontmatter_overrides={"script_args": {"scripts/missing.py": {"x": {"type": "string"}}}},
+        scripts={"scripts/run.py": "print('run')\n"},
+    )
+
+    loader = SilasSkillLoader(skills_dir)
+    report = loader.validate("ops")
+
+    assert report["valid"] is False
+    assert any("does not exist" in str(error) for error in report["errors"])


### PR DESCRIPTION
## Phase 6a: Skill System

### New modules (906 lines across 7 files)

**`silas/skills/loader.py`** (361 lines) — `SilasSkillLoader`
- YAML frontmatter parsing from SKILL.md files
- Flat directory scanner, metadata loading, full content loading
- Script path resolution with path traversal protection
- External skill import (OpenAI/Claude format adaptation)

**`silas/skills/validator.py`** (101 lines) — `SkillValidator`
- Frontmatter completeness + description bounds
- Script syntax verification (compile check)
- Forbidden pattern detection (eval, exec, __import__)
- Reference integrity checks

**`silas/skills/installer.py`** (109 lines) — `SkillInstaller`
- Install/uninstall flow with pre-validation
- Skills directory management

**Default skills:**
- `skills/coding/SKILL.md` — auto-activate, no approval
- `skills/skill-maker/SKILL.md` — manual, requires approval

### Tests
- 20 new tests
- **309 tests total**, ruff clean

Built by Codex (`cool-meadow`), reviewed and merged by Silas 🪶