### PR TITLE
feat: Security tests + Phase 7c partial (undo, drafts, fatigue)

### DIFF
--- a/silas/core/undo.py
+++ b/silas/core/undo.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+
+from silas.models.undo import UndoEntry
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _require_timezone_aware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+class UndoManager:
+    def __init__(self, undo_window: timedelta = timedelta(minutes=5)) -> None:
+        if undo_window.total_seconds() <= 0:
+            raise ValueError("undo_window must be positive")
+        self._undo_window = undo_window
+        self._entries_by_scope: dict[str, dict[str, UndoEntry]] = {}
+
+    @property
+    def undo_window(self) -> timedelta:
+        return self._undo_window
+
+    def record_execution(
+        self,
+        scope_id: str,
+        execution_id: str,
+        reverse_actions: list[dict[str, object]],
+        *,
+        summary: str = "",
+        metadata: dict[str, object] | None = None,
+        entry_id: str | None = None,
+        now: datetime | None = None,
+    ) -> UndoEntry:
+        now_utc = now if now is not None else _utc_now()
+        _require_timezone_aware(now_utc, "now")
+
+        undo_entry = UndoEntry(
+            entry_id=entry_id or f"undo:{scope_id}:{execution_id}:{uuid.uuid4().hex}",
+            scope_id=scope_id,
+            execution_id=execution_id,
+            reverse_actions=[dict(action) for action in reverse_actions],
+            summary=summary,
+            metadata={} if metadata is None else dict(metadata),
+            created_at=now_utc,
+            expires_at=now_utc + self._undo_window,
+        )
+        self._entries_by_scope.setdefault(scope_id, {})[undo_entry.entry_id] = undo_entry
+        return undo_entry.model_copy(deep=True)
+
+    def get_entry(self, scope_id: str, entry_id: str) -> UndoEntry | None:
+        entry = self._entries_by_scope.get(scope_id, {}).get(entry_id)
+        if entry is None:
+            return None
+        return entry.model_copy(deep=True)
+
+    def list_active(self, scope_id: str, now: datetime | None = None) -> list[UndoEntry]:
+        now_utc = now if now is not None else _utc_now()
+        _require_timezone_aware(now_utc, "now")
+
+        active = [
+            entry.model_copy(deep=True)
+            for entry in self._entries_by_scope.get(scope_id, {}).values()
+            if entry.can_undo(now_utc)
+        ]
+        active.sort(key=lambda entry: entry.created_at, reverse=True)
+        return active
+
+    def undo(
+        self,
+        scope_id: str,
+        entry_id: str,
+        *,
+        apply_reverse_action: Callable[[dict[str, object]], None] | None = None,
+        now: datetime | None = None,
+    ) -> bool:
+        now_utc = now if now is not None else _utc_now()
+        _require_timezone_aware(now_utc, "now")
+
+        entry = self._entries_by_scope.get(scope_id, {}).get(entry_id)
+        if entry is None:
+            return False
+        if not entry.can_undo(now_utc):
+            return False
+
+        for action in reversed(entry.reverse_actions):
+            if apply_reverse_action is not None:
+                apply_reverse_action(dict(action))
+
+        self._entries_by_scope[scope_id][entry_id] = entry.model_copy(update={"undone_at": now_utc})
+        return True
+
+    def build_post_execution_card(
+        self,
+        scope_id: str,
+        entry_id: str,
+        *,
+        results: list[dict[str, object]] | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        now_utc = now if now is not None else _utc_now()
+        _require_timezone_aware(now_utc, "now")
+
+        entry = self._entries_by_scope.get(scope_id, {}).get(entry_id)
+        if entry is None:
+            return {
+                "type": "post_execution",
+                "scope_id": scope_id,
+                "undo_entry_id": entry_id,
+                "undo_available": False,
+                "undo_label": "Undo unavailable",
+                "results": [] if results is None else list(results),
+                "generated_at": now_utc,
+            }
+
+        can_undo = entry.can_undo(now_utc)
+        status = "available"
+        if entry.undone_at is not None:
+            status = "already_undone"
+        elif now_utc > entry.expires_at:
+            status = "expired"
+
+        return {
+            "type": "post_execution",
+            "scope_id": scope_id,
+            "undo_entry_id": entry.entry_id,
+            "execution_id": entry.execution_id,
+            "summary": entry.summary,
+            "metadata": dict(entry.metadata),
+            "results": [] if results is None else list(results),
+            "undo_available": can_undo,
+            "undo_label": "Undo" if can_undo else "Undo unavailable",
+            "undo_status": status,
+            "undo_expires_at": entry.expires_at,
+            "generated_at": now_utc,
+        }
+
+    def prune_expired(self, scope_id: str | None = None, now: datetime | None = None) -> int:
+        now_utc = now if now is not None else _utc_now()
+        _require_timezone_aware(now_utc, "now")
+
+        removed = 0
+        scope_ids = [scope_id] if scope_id is not None else list(self._entries_by_scope)
+        for current_scope in scope_ids:
+            entries = self._entries_by_scope.get(current_scope, {})
+            expired_ids = [entry_id for entry_id, entry in entries.items() if now_utc > entry.expires_at]
+            for entry_id in expired_ids:
+                del entries[entry_id]
+            removed += len(expired_ids)
+            if not entries and current_scope in self._entries_by_scope:
+                del self._entries_by_scope[current_scope]
+        return removed
+
+
+__all__ = ["UndoManager"]

--- a/silas/models/draft.py
+++ b/silas/models/draft.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class DraftVerdict(str, Enum):
+    approve = "approve"
+    edit = "edit"
+    rephrase = "rephrase"
+    reject = "reject"
+
+
+class DraftReview(BaseModel):
+    review_id: str
+    context: str
+    draft: str
+    metadata: dict[str, object] = Field(default_factory=dict)
+    verdict: DraftVerdict | None = None
+    edited_text: str | None = None
+    created_at: datetime = Field(default_factory=_utc_now)
+    decided_at: datetime | None = None
+
+    @field_validator("created_at", "decided_at")
+    @classmethod
+    def _ensure_timezone_aware(
+        cls,
+        value: datetime | None,
+    ) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("datetime fields must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_edit_requirements(self) -> DraftReview:
+        requires_edit_text = self.verdict in {DraftVerdict.edit, DraftVerdict.rephrase}
+        if requires_edit_text and not (self.edited_text and self.edited_text.strip()):
+            raise ValueError("edited_text is required for edit/rephrase verdicts")
+        if self.verdict is None and self.decided_at is not None:
+            raise ValueError("decided_at requires a verdict")
+        if self.decided_at is not None and self.decided_at < self.created_at:
+            raise ValueError("decided_at must be greater than or equal to created_at")
+        return self
+
+
+__all__ = ["DraftVerdict", "DraftReview"]

--- a/silas/models/undo.py
+++ b/silas/models/undo.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class UndoEntry(BaseModel):
+    entry_id: str
+    scope_id: str
+    execution_id: str
+    reverse_actions: list[dict[str, object]] = Field(default_factory=list)
+    summary: str = ""
+    metadata: dict[str, object] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    expires_at: datetime
+    undone_at: datetime | None = None
+
+    @field_validator("created_at", "expires_at", "undone_at")
+    @classmethod
+    def _ensure_timezone_aware(
+        cls,
+        value: datetime | None,
+    ) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("datetime fields must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_temporal_order(self) -> UndoEntry:
+        if self.expires_at <= self.created_at:
+            raise ValueError("expires_at must be greater than created_at")
+        if self.undone_at is not None and self.undone_at < self.created_at:
+            raise ValueError("undone_at must be greater than or equal to created_at")
+        return self
+
+    def can_undo(self, now: datetime | None = None) -> bool:
+        if self.undone_at is not None:
+            return False
+        now_utc = now if now is not None else datetime.now(timezone.utc)
+        return now_utc <= self.expires_at
+
+
+__all__ = ["UndoEntry"]

--- a/silas/proactivity/fatigue.py
+++ b/silas/proactivity/fatigue.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from statistics import median
+
+_MEDIUM_PLUS_RISK_LEVELS = {"medium", "high", "irreversible"}
+
+
+def _require_timezone_aware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+class ApprovalFatigueTracker:
+    def __init__(
+        self,
+        *,
+        rolling_window_size: int = 25,
+        queue_density_threshold: int = 5,
+    ) -> None:
+        self._rolling_window_size = max(1, rolling_window_size)
+        self._queue_density_threshold = queue_density_threshold
+
+        self._decision_times_by_scope: dict[str, list[float]] = {}
+        self._decision_timestamps_by_scope: dict[str, list[datetime]] = {}
+        self._queue_density_cue_active: dict[str, bool] = {}
+        self._decision_time_cue_active: dict[str, bool] = {}
+        self._fatigue_triggers_by_scope: dict[str, int] = {}
+
+    def record_decision(
+        self,
+        scope_id: str,
+        risk_level: str,
+        requested_at: datetime,
+        decided_at: datetime,
+    ) -> dict[str, float | int | bool | None]:
+        _require_timezone_aware(requested_at, "requested_at")
+        _require_timezone_aware(decided_at, "decided_at")
+
+        if risk_level not in _MEDIUM_PLUS_RISK_LEVELS:
+            return self.status(scope_id)
+
+        decision_seconds = max((decided_at - requested_at).total_seconds(), 0.0)
+        decision_times = self._decision_times_by_scope.setdefault(scope_id, [])
+        decision_times.append(decision_seconds)
+        self._trim_window(decision_times)
+
+        decision_timestamps = self._decision_timestamps_by_scope.setdefault(scope_id, [])
+        decision_timestamps.append(decided_at)
+        self._trim_window(decision_timestamps)
+
+        median_seconds = self.median_decision_time(scope_id)
+        decision_time_cue = bool(median_seconds is not None and median_seconds < 1.0)
+        if decision_time_cue and not self._decision_time_cue_active.get(scope_id, False):
+            self._fatigue_triggers_by_scope[scope_id] = self._fatigue_triggers_by_scope.get(scope_id, 0) + 1
+        self._decision_time_cue_active[scope_id] = decision_time_cue
+
+        return self.status(scope_id)
+
+    def record_queue_depth(self, scope_id: str, medium_plus_pending: int) -> bool:
+        queue_density_cue = medium_plus_pending > self._queue_density_threshold
+        previously_active = self._queue_density_cue_active.get(scope_id, False)
+        if queue_density_cue and not previously_active:
+            self._fatigue_triggers_by_scope[scope_id] = self._fatigue_triggers_by_scope.get(scope_id, 0) + 1
+        self._queue_density_cue_active[scope_id] = queue_density_cue
+        return queue_density_cue
+
+    def median_decision_time(self, scope_id: str) -> float | None:
+        values = self._decision_times_by_scope.get(scope_id, [])
+        if not values:
+            return None
+        return float(median(values))
+
+    def cadence_per_minute(self, scope_id: str) -> float:
+        timestamps = self._decision_timestamps_by_scope.get(scope_id, [])
+        if len(timestamps) < 2:
+            return 0.0
+        span_seconds = (timestamps[-1] - timestamps[0]).total_seconds()
+        span_seconds = max(span_seconds, 1.0)
+        cadence = len(timestamps) / (span_seconds / 60.0)
+        return round(cadence, 4)
+
+    def fatigue_trigger_count(self, scope_id: str) -> int:
+        return self._fatigue_triggers_by_scope.get(scope_id, 0)
+
+    def should_throttle(self, scope_id: str) -> bool:
+        del scope_id
+        # Explicitly non-blocking by spec: no mandatory delays/cooldowns.
+        return False
+
+    def status(
+        self,
+        scope_id: str,
+        medium_plus_pending: int = 0,
+    ) -> dict[str, float | int | bool | None]:
+        median_seconds = self.median_decision_time(scope_id)
+        return {
+            "scope_id": scope_id,
+            "queue_density_cue": medium_plus_pending > self._queue_density_threshold,
+            "decision_time_fatigue_cue": bool(median_seconds is not None and median_seconds < 1.0),
+            "median_decision_time_seconds": median_seconds,
+            "cadence_decisions_per_minute": self.cadence_per_minute(scope_id),
+            "fatigue_trigger_count": self.fatigue_trigger_count(scope_id),
+            "hard_throttle": False,
+            "checked_at": datetime.now(timezone.utc),
+        }
+
+    def _trim_window(self, values: list[float] | list[datetime]) -> None:
+        overflow = len(values) - self._rolling_window_size
+        if overflow > 0:
+            del values[:overflow]
+
+
+__all__ = ["ApprovalFatigueTracker"]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,419 @@
+"""Security-focused tests for approval, token, nonce, and taint behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+import pytest
+from pydantic import ValidationError
+from silas.approval.manager import LiveApprovalManager
+from silas.core.stream import Stream
+from silas.goals.manager import SilasGoalManager
+from silas.models.approval import (
+    ApprovalScope,
+    ApprovalToken,
+    ApprovalVerdict,
+)
+from silas.models.context import ContextZone
+from silas.models.goals import Goal, GoalSchedule
+from silas.models.messages import ChannelMessage, TaintLevel
+from silas.models.work import WorkItem, WorkItemStatus, WorkItemType
+from silas.persistence.migrations import run_migrations
+from silas.persistence.nonce_store import SQLiteNonceStore
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _work_item(item_id: str = "wi-sec", *, body: str = "Perform secure operation") -> WorkItem:
+    return WorkItem(
+        id=item_id,
+        type=WorkItemType.task,
+        title=f"Security Work Item {item_id}",
+        body=body,
+    )
+
+
+def _approval_token(**kwargs: object) -> ApprovalToken:
+    now = _utc_now()
+    payload: dict[str, object] = {
+        "token_id": "token-sec-1",
+        "plan_hash": "deadbeef",
+        "work_item_id": "wi-sec",
+        "scope": ApprovalScope.full_plan,
+        "verdict": ApprovalVerdict.approved,
+        "signature": b"\x01\x02binary-signature",
+        "issued_at": now,
+        "expires_at": now + timedelta(minutes=30),
+        "nonce": "nonce-sec-1",
+    }
+    payload.update(kwargs)
+    return ApprovalToken.model_validate(payload)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _spawn_policy_hash(
+    *,
+    failure_context_template: str,
+    skills: list[str],
+    gates: list[dict[str, object]],
+    verify: list[dict[str, object]],
+    escalation_config: dict[str, object],
+) -> str:
+    """Spec-style canonical spawn policy hash helper (Section 3.6)."""
+    canonical = {
+        "failure_context_template": failure_context_template,
+        "skills": sorted(set(skills)),
+        "gates": sorted(_canonical_json(gate) for gate in gates),
+        "verify": sorted(_canonical_json(check) for check in verify),
+        "escalation_config": {
+            key: escalation_config[key]
+            for key in sorted(escalation_config)
+        },
+    }
+    return hashlib.sha256(_canonical_json(canonical).encode("utf-8")).hexdigest()
+
+
+def _goal(goal_id: str = "goal-sec") -> Goal:
+    now = _utc_now()
+    return Goal(
+        goal_id=goal_id,
+        name=f"Goal {goal_id}",
+        description="Run security checks",
+        schedule=GoalSchedule(kind="interval", interval_seconds=300),
+        work_template={
+            "type": "task",
+            "title": "Run goal task",
+            "body": "Investigate and remediate drift",
+        },
+        skills=["security"],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _msg(text: str, sender_id: str = "owner") -> ChannelMessage:
+    return ChannelMessage(
+        channel="web",
+        sender_id=sender_id,
+        text=text,
+        timestamp=_utc_now(),
+    )
+
+
+class _CollectingWorkItemStore:
+    def __init__(self) -> None:
+        self.saved: list[WorkItem] = []
+
+    async def save(self, item: WorkItem) -> None:
+        self.saved.append(item.model_copy(deep=True))
+
+
+# ---------------------------------------------------------------------------
+# 1) Approval Engine (LiveApprovalManager) — spec Section 5.11 (current subset)
+# ---------------------------------------------------------------------------
+
+
+class TestLiveApprovalManager:
+    def test_issue_pending_approval_and_list_pending(self) -> None:
+        manager = LiveApprovalManager(timeout=timedelta(minutes=10))
+        work_item = _work_item("wi-pending")
+
+        token = manager.request_approval(work_item, ApprovalScope.full_plan)
+
+        pending = manager.list_pending()
+        assert len(pending) == 1
+        assert pending[0].token.token_id == token.token_id
+        assert pending[0].token.verdict == ApprovalVerdict.conditional
+        assert pending[0].decision is None
+        assert pending[0].requested_at.tzinfo is not None
+
+    @pytest.mark.parametrize("verdict", [ApprovalVerdict.approved, ApprovalVerdict.declined])
+    def test_resolve_approval_verdict_and_check(self, verdict: ApprovalVerdict) -> None:
+        manager = LiveApprovalManager(timeout=timedelta(minutes=10))
+        token = manager.request_approval(_work_item("wi-resolve"), ApprovalScope.full_plan)
+
+        first = manager.resolve(token.token_id, verdict, resolved_by="owner")
+        second = manager.resolve(token.token_id, ApprovalVerdict.declined, resolved_by="owner")
+
+        assert first.verdict == verdict
+        assert second.verdict == verdict  # idempotent once resolved
+        checked = manager.check_approval(token.token_id)
+        assert checked is not None
+        assert checked.verdict == verdict
+        assert manager.list_pending() == []
+
+    def test_timeout_prunes_expired_pending_approval(self) -> None:
+        # Use a tiny positive timeout so the token is valid at creation but expires almost instantly
+        manager = LiveApprovalManager(timeout=timedelta(milliseconds=1))
+        token = manager.request_approval(_work_item("wi-expired"), ApprovalScope.full_plan)
+
+        import time
+        time.sleep(0.01)  # ensure expiry
+
+        assert token.expires_at <= _utc_now()
+        # After expiry, check_approval and list_pending should prune
+        assert manager.check_approval(token.token_id) is None
+        assert manager.list_pending() == []
+        with pytest.raises(KeyError, match="unknown approval token"):
+            manager.resolve(token.token_id, ApprovalVerdict.approved, resolved_by="owner")
+
+    def test_plan_hash_binding_uses_work_item_canonical_hash(self) -> None:
+        manager = LiveApprovalManager(timeout=timedelta(minutes=10))
+        work_item = _work_item("wi-plan-hash", body="initial body")
+
+        token = manager.request_approval(work_item, ApprovalScope.full_plan)
+
+        assert token.work_item_id == work_item.id
+        assert token.plan_hash == work_item.plan_hash()
+
+        work_item.status = WorkItemStatus.running
+        work_item.attempts = 3
+        assert token.plan_hash == token.plan_hash
+
+        changed_plan = work_item.model_copy(update={"body": "changed body"})
+        assert token.plan_hash != changed_plan.plan_hash()
+
+
+# ---------------------------------------------------------------------------
+# 2) ApprovalToken model — spec Section 3.6
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalTokenSecurityModel:
+    def test_base64bytes_json_round_trip(self) -> None:
+        token = _approval_token(signature=b"\x00\xffbinary-data")
+
+        encoded_json = token.model_dump_json()
+        loaded = ApprovalToken.model_validate_json(encoded_json)
+
+        assert loaded.signature == b"\x00\xffbinary-data"
+
+    def test_invalid_base64_signature_rejected(self) -> None:
+        now = _utc_now()
+        payload = {
+            "token_id": "token-invalid",
+            "plan_hash": "abc",
+            "work_item_id": "wi",
+            "scope": ApprovalScope.full_plan,
+            "verdict": ApprovalVerdict.approved,
+            "signature": "***not-base64***",
+            "issued_at": now.isoformat(),
+            "expires_at": (now + timedelta(minutes=1)).isoformat(),
+            "nonce": "n1",
+        }
+
+        with pytest.raises(ValidationError, match="invalid base64 data"):
+            ApprovalToken.model_validate(payload)
+
+    def test_expiry_must_be_after_issued_at(self) -> None:
+        now = _utc_now()
+        with pytest.raises(ValidationError, match="expires_at must be greater"):
+            _approval_token(issued_at=now, expires_at=now)
+
+    def test_standing_scope_requires_spawn_policy_hash(self) -> None:
+        with pytest.raises(ValidationError, match="spawn_policy_hash"):
+            _approval_token(
+                scope=ApprovalScope.standing,
+                conditions={},
+            )
+
+    def test_spawn_policy_hash_canonicalization_equivalence(self) -> None:
+        hash_a = _spawn_policy_hash(
+            failure_context_template="Fix $failed_checks and rerun",
+            skills=["security", "security", "notify"],
+            gates=[
+                {"name": "risk", "threshold": "high"},
+                {"threshold": "low", "name": "format"},
+            ],
+            verify=[
+                {"name": "pytest", "run": "pytest -q"},
+                {"run": "ruff check", "name": "ruff"},
+            ],
+            escalation_config={"report": {"action": "report"}, "retry": {"max_retries": 1}},
+        )
+        hash_b = _spawn_policy_hash(
+            failure_context_template="Fix $failed_checks and rerun",
+            skills=["notify", "security"],
+            gates=[
+                {"threshold": "low", "name": "format"},
+                {"name": "risk", "threshold": "high"},
+            ],
+            verify=[
+                {"run": "ruff check", "name": "ruff"},
+                {"name": "pytest", "run": "pytest -q"},
+            ],
+            escalation_config={"retry": {"max_retries": 1}, "report": {"action": "report"}},
+        )
+
+        assert hash_a == hash_b
+
+        standing = _approval_token(
+            scope=ApprovalScope.standing,
+            max_executions=10,
+            conditions={"spawn_policy_hash": hash_a},
+        )
+        assert standing.conditions["spawn_policy_hash"] == hash_b
+        assert standing.max_executions == 10
+
+
+# ---------------------------------------------------------------------------
+# 3) Nonce Store — SQLiteNonceStore
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def nonce_db_path(tmp_path: Path) -> str:
+    db_path = tmp_path / "security_nonces.db"
+    await run_migrations(str(db_path))
+    return str(db_path)
+
+
+@pytest.fixture
+async def nonce_store(nonce_db_path: str) -> SQLiteNonceStore:
+    return SQLiteNonceStore(nonce_db_path)
+
+
+@pytest.mark.asyncio
+async def test_nonce_store_record_and_check(nonce_store: SQLiteNonceStore) -> None:
+    assert await nonce_store.is_used("exec", "nonce-1") is False
+    await nonce_store.record("exec", "nonce-1")
+    assert await nonce_store.is_used("exec", "nonce-1") is True
+
+
+@pytest.mark.asyncio
+async def test_nonce_store_replay_detection_is_idempotent(
+    nonce_store: SQLiteNonceStore,
+    nonce_db_path: str,
+) -> None:
+    await nonce_store.record("exec", "replay-nonce")
+    await nonce_store.record("exec", "replay-nonce")
+
+    assert await nonce_store.is_used("exec", "replay-nonce") is True
+    async with aiosqlite.connect(nonce_db_path) as db:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM nonces WHERE domain = ? AND nonce = ?",
+            ("exec", "replay-nonce"),
+        )
+        row = await cursor.fetchone()
+    assert row is not None
+    assert row[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_nonce_store_ttl_expiry_prunes_old_entries(nonce_store: SQLiteNonceStore) -> None:
+    await nonce_store.record("msg", "ttl-nonce")
+
+    pruned_too_early = await nonce_store.prune_expired(_utc_now() - timedelta(minutes=1))
+    assert pruned_too_early == 0
+    assert await nonce_store.is_used("msg", "ttl-nonce") is True
+
+    pruned = await nonce_store.prune_expired(_utc_now() + timedelta(minutes=1))
+    assert pruned == 1
+    assert await nonce_store.is_used("msg", "ttl-nonce") is False
+
+
+# ---------------------------------------------------------------------------
+# 4) Message signing flow (spec 5.1 step 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason=(
+        "Stream step 2 signature verification is not implemented yet; owner sender_id is "
+        "currently trusted without cryptographic verification."
+    )
+)
+async def test_unsigned_owner_message_taint_is_downgraded_to_external(
+    channel,
+    turn_context,
+    context_manager,
+) -> None:
+    stream = Stream(
+        channel=channel,
+        turn_context=turn_context,
+        owner_id="owner",
+        default_context_profile="conversation",
+    )
+
+    await stream._process_turn(_msg("unsigned owner message", sender_id="owner"))
+
+    chronicle = context_manager.get_zone("owner", ContextZone.chronicle)
+    assert chronicle[0].taint == TaintLevel.external
+
+
+# ---------------------------------------------------------------------------
+# 5) Standing approval verification behavior (spec 5.2.3 target behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestStandingApprovalVerification:
+    def test_standing_approval_allows_multiple_executions_until_max_uses(self) -> None:
+        store = _CollectingWorkItemStore()
+        manager = SilasGoalManager(goals_config=[_goal("goal-multi")], work_item_store=store)
+        goal = manager.load_goals()[0]
+        assert goal.spawn_policy_hash is not None
+
+        manager.grant_standing_approval(
+            goal_id=goal.goal_id,
+            policy_hash=goal.spawn_policy_hash,
+            granted_by="owner",
+            expires_at=None,
+            max_uses=2,
+        )
+
+        manager.run_goal(goal.goal_id)
+        manager.run_goal(goal.goal_id)
+        manager.run_goal(goal.goal_id)
+
+        assert [item.needs_approval for item in store.saved] == [False, False, True]
+
+    def test_spawn_policy_hash_binding_rejects_mismatched_hash(self) -> None:
+        store = _CollectingWorkItemStore()
+        manager = SilasGoalManager(goals_config=[_goal("goal-bind")], work_item_store=store)
+        goal = manager.load_goals()[0]
+        assert goal.spawn_policy_hash is not None
+
+        wrong_hash = hashlib.sha256(b"not-the-goal-policy").hexdigest()
+        manager.grant_standing_approval(
+            goal_id=goal.goal_id,
+            policy_hash=wrong_hash,
+            granted_by="owner",
+            expires_at=None,
+            max_uses=5,
+        )
+
+        manager.run_goal(goal.goal_id)
+        assert len(store.saved) == 1
+        assert store.saved[0].needs_approval is True
+
+    def test_spawn_policy_hash_canonicalized_hex_allows_case_insensitive_binding(self) -> None:
+        store = _CollectingWorkItemStore()
+        manager = SilasGoalManager(
+            goals_config=[_goal("goal-case-canonicalization")],
+            work_item_store=store,
+        )
+        goal = manager.load_goals()[0]
+        assert goal.spawn_policy_hash is not None
+
+        manager.grant_standing_approval(
+            goal_id=goal.goal_id,
+            policy_hash=goal.spawn_policy_hash.upper(),
+            granted_by="owner",
+            expires_at=None,
+            max_uses=1,
+        )
+
+        manager.run_goal(goal.goal_id)
+        assert len(store.saved) == 1
+        assert store.saved[0].needs_approval is False


### PR DESCRIPTION
## Security Tests (test_security.py)
- LiveApprovalManager lifecycle (pending, approve/decline, timeout, plan hash binding)
- ApprovalToken model (Base64Bytes round-trip, expiry, standing scope, spawn_policy_hash)
- spawn_policy_hash canonicalization equivalence
- SQLiteNonceStore (record/check, replay detection, TTL pruning)
- Message signing xfail (spec §5.1 step 2 — not implemented yet)
- Standing approval (multi-execution, mismatched hash rejection, case-insensitive binding)

## Phase 7c Partial
- UndoManager: reverse action log, 5-min window, undo card generation
- DraftVerdict enum + DraftReview model (§3.11)
- UndoEntry model
- ApprovalFatigueTracker: cadence tracking, queue density cues

**389 passed, 1 xfailed**, ruff clean.
Built by Codex (sharp-crest, young-haven).