### PR TITLE
feat: Phase 2 scorer agent + two-tier eviction

### DIFF
--- a/silas/agents/__init__.py
+++ b/silas/agents/__init__.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-__all__ = ["ProxyAgent", "build_proxy_agent", "run_structured_agent"]
+__all__ = [
+    "ProxyAgent",
+    "build_proxy_agent",
+    "ContextScorer",
+    "build_scorer_agent",
+    "score_context_blocks",
+    "run_structured_agent",
+]
 
 
 def __getattr__(name: str) -> object:
@@ -8,6 +15,14 @@ def __getattr__(name: str) -> object:
         from silas.agents.proxy import ProxyAgent, build_proxy_agent
 
         return {"ProxyAgent": ProxyAgent, "build_proxy_agent": build_proxy_agent}[name]
+    if name in {"ContextScorer", "build_scorer_agent", "score_context_blocks"}:
+        from silas.agents.scorer import ContextScorer, build_scorer_agent, score_context_blocks
+
+        return {
+            "ContextScorer": ContextScorer,
+            "build_scorer_agent": build_scorer_agent,
+            "score_context_blocks": score_context_blocks,
+        }[name]
     if name == "run_structured_agent":
         from silas.agents.structured import run_structured_agent
 

--- a/silas/agents/scorer.py
+++ b/silas/agents/scorer.py
@@ -1,0 +1,129 @@
+"""Scorer Agent — structured context eviction scorer."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from pydantic_ai import Agent
+
+from silas.agents.structured import run_structured_agent
+from silas.models.scorer import ScorerOutput
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCORER_SYSTEM_PROMPT = """You are the Silas context relevance scorer.
+
+Return a valid ScorerOutput for every request.
+
+Group related context block IDs together in keep_groups or evict_groups.
+Prefer coherent group eviction over orphaning dependent blocks.
+"""
+
+_SCORER_TIMEOUT_SECONDS = 2.0
+_SCORER_BREAKER_FAILURE_LIMIT = 3
+_SCORER_BREAKER_COOLDOWN = timedelta(minutes=5)
+
+
+@dataclass(slots=True)
+class ScorerRunResult:
+    output: ScorerOutput
+
+
+class ContextScorer:
+    def __init__(
+        self,
+        model: str,
+        timeout_seconds: float = _SCORER_TIMEOUT_SECONDS,
+        breaker_failure_limit: int = _SCORER_BREAKER_FAILURE_LIMIT,
+        breaker_cooldown: timedelta = _SCORER_BREAKER_COOLDOWN,
+    ) -> None:
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+        self.breaker_failure_limit = breaker_failure_limit
+        self.breaker_cooldown = breaker_cooldown
+        self.system_prompt = DEFAULT_SCORER_SYSTEM_PROMPT
+
+        self._consecutive_failures = 0
+        self._breaker_open_until: datetime | None = None
+
+        try:
+            self.agent: Agent[None, ScorerOutput] | None = Agent(
+                model=model,
+                output_type=ScorerOutput,
+                system_prompt=self.system_prompt,
+            )
+        except Exception:
+            logger.warning("Failed to initialize scorer agent; deterministic fallback mode")
+            self.agent = None
+
+    async def run(self, prompt: str) -> ScorerRunResult:
+        if self._breaker_is_open():
+            return self._deterministic_fallback()
+
+        if self.agent is None:
+            return self._deterministic_fallback()
+
+        try:
+            result = await asyncio.wait_for(
+                run_structured_agent(
+                    agent=self.agent,
+                    prompt=prompt,
+                    call_name="scorer",
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except Exception:
+            self._record_failure()
+            logger.warning("Scorer call failed; deterministic fallback output")
+            return self._deterministic_fallback()
+
+        if not isinstance(result, ScorerOutput):
+            self._record_failure()
+            logger.warning("Scorer returned invalid output type; deterministic fallback output")
+            return self._deterministic_fallback()
+
+        self._record_success()
+        return ScorerRunResult(output=result)
+
+    def _deterministic_fallback(self) -> ScorerRunResult:
+        return ScorerRunResult(output=ScorerOutput())
+
+    def _breaker_is_open(self) -> bool:
+        if self._breaker_open_until is None:
+            return False
+
+        now = datetime.now(timezone.utc)
+        if now >= self._breaker_open_until:
+            self._record_success()
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._breaker_open_until = None
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures < self.breaker_failure_limit:
+            return
+        self._breaker_open_until = datetime.now(timezone.utc) + self.breaker_cooldown
+
+
+async def score_context_blocks(agent: ContextScorer, prompt: str) -> ScorerOutput:
+    result = await agent.run(prompt)
+    return result.output
+
+
+def build_scorer_agent(model: str) -> ContextScorer:
+    return ContextScorer(model=model)
+
+
+__all__ = [
+    "ContextScorer",
+    "ScorerRunResult",
+    "build_scorer_agent",
+    "score_context_blocks",
+]

--- a/silas/agents/structured.py
+++ b/silas/agents/structured.py
@@ -5,6 +5,7 @@ from typing import Protocol
 from pydantic import ValidationError
 
 from silas.models.agents import AgentResponse, InteractionMode, InteractionRegister, RouteDecision
+from silas.models.scorer import ScorerOutput
 
 
 class StructuredRunnable(Protocol):
@@ -52,6 +53,8 @@ def structured_fallback(call_name: str, default_context_profile: str) -> object:
             plan_action=None,
             needs_approval=False,
         )
+    if call_name == "scorer":
+        return ScorerOutput()
     raise RuntimeError(f"No structured fallback configured for call_name={call_name!r}")
 
 

--- a/silas/core/context_manager.py
+++ b/silas/core/context_manager.py
@@ -1,9 +1,14 @@
-"""Live ContextManager implementation (Phase 1c)."""
+"""Live ContextManager implementation with Tier 2 scorer eviction."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import asyncio
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
 
+from silas.agents.structured import run_structured_agent
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.models.context import (
     ContextItem,
@@ -12,6 +17,7 @@ from silas.models.context import (
     ContextZone,
     TokenBudget,
 )
+from silas.models.scorer import ScorerOutput
 
 _RENDER_ORDER: tuple[ContextZone, ...] = (
     ContextZone.system,
@@ -24,23 +30,57 @@ _EVICTABLE_ZONES: tuple[ContextZone, ...] = (
     ContextZone.memory,
     ContextZone.workspace,
 )
+_ZONE_ORDER: dict[ContextZone, int] = {
+    ContextZone.system: 0,
+    ContextZone.chronicle: 1,
+    ContextZone.memory: 2,
+    ContextZone.workspace: 3,
+}
 _FALLBACK_PROFILE = ContextProfile(
     name="conversation",
     chronicle_pct=0.45,
     memory_pct=0.20,
     workspace_pct=0.15,
 )
+_SCORER_TIMEOUT_SECONDS = 2.0
+_SCORER_BREAKER_FAILURE_LIMIT = 3
+_SCORER_BREAKER_COOLDOWN = timedelta(minutes=5)
+
+
+class _ScorerRunnable(Protocol):
+    async def run(self, prompt: str) -> object: ...
+
+
+@dataclass(slots=True)
+class _ScorerCallResult:
+    output: ScorerOutput | None = None
+    error: Exception | None = None
 
 
 class LiveContextManager:
-    def __init__(self, token_budget: TokenBudget, token_counter: HeuristicTokenCounter):
+    def __init__(
+        self,
+        token_budget: TokenBudget,
+        token_counter: HeuristicTokenCounter,
+        scorer_agent: _ScorerRunnable | None = None,
+        scorer_timeout_seconds: float = _SCORER_TIMEOUT_SECONDS,
+    ):
         self._token_budget = token_budget
         self._token_counter = token_counter
+        self._scorer_agent = scorer_agent
+        self._scorer_timeout_seconds = scorer_timeout_seconds
+        self._scorer_consecutive_failures = 0
+        self._scorer_breaker_open_until: datetime | None = None
 
         # Context storage by scope.
         self.by_scope: dict[str, list[ContextItem]] = {}
         self.subscriptions_by_scope: dict[str, dict[str, ContextSubscription]] = {}
         self.profile_by_scope: dict[str, str] = {}
+
+    def set_scorer(self, scorer_agent: _ScorerRunnable | None) -> None:
+        self._scorer_agent = scorer_agent
+        self._scorer_consecutive_failures = 0
+        self._scorer_breaker_open_until = None
 
     def add(self, scope_id: str, item: ContextItem) -> str:
         stored_item = item.model_copy(deep=True)
@@ -93,27 +133,16 @@ class LiveContextManager:
         return "\n\n".join(blocks)
 
     def enforce_budget(self, scope_id: str, turn_number: int, current_goal: str | None) -> list[str]:
-        del current_goal  # Phase 1c: heuristic-only eviction (no scorer context).
         self._apply_observation_masking(scope_id, turn_number)
 
-        usage = self.token_usage(scope_id)
-        budgets = self._zone_budgets(scope_id, usage[ContextZone.system.value])
         evicted: list[str] = []
+        self._extend_unique(evicted, self._evict_to_zone_budgets(scope_id))
+        if not self._is_over_threshold(scope_id, self._token_budget.eviction_threshold_pct):
+            return evicted
 
-        for zone in _EVICTABLE_ZONES:
-            zone_key = zone.value
-            zone_budget = budgets[zone_key]
-            while usage[zone_key] > zone_budget:
-                candidate = self._pick_eviction_candidate(scope_id, zone)
-                if candidate is None:
-                    break
-
-                removed = self._remove_item(scope_id, candidate.ctx_id)
-                if removed is None:
-                    break
-
-                evicted.append(removed.ctx_id)
-                usage[zone_key] -= removed.token_count
+        self._extend_unique(evicted, self._evict_with_scorer(scope_id, turn_number, current_goal))
+        if self._is_over_threshold(scope_id, self._token_budget.eviction_threshold_pct):
+            self._extend_unique(evicted, self._aggressive_heuristic_eviction(scope_id))
 
         return evicted
 
@@ -174,11 +203,191 @@ class LiveContextManager:
             item.masked = True
             item.token_count = self._token_counter.count(placeholder)
 
-    def _pick_eviction_candidate(self, scope_id: str, zone: ContextZone) -> ContextItem | None:
-        candidates = [
+    def _evict_to_zone_budgets(self, scope_id: str) -> list[str]:
+        usage = self.token_usage(scope_id)
+        budgets = self._zone_budgets(scope_id, usage[ContextZone.system.value])
+        evicted: list[str] = []
+
+        for zone in _EVICTABLE_ZONES:
+            zone_key = zone.value
+            zone_budget = budgets[zone_key]
+            while usage[zone_key] > zone_budget:
+                candidate = self._pick_eviction_candidate(scope_id, zone)
+                if candidate is None:
+                    break
+
+                removed = self._remove_item(scope_id, candidate.ctx_id)
+                if removed is None:
+                    break
+
+                evicted.append(removed.ctx_id)
+                usage[zone_key] -= removed.token_count
+
+        return evicted
+
+    def _evict_with_scorer(
+        self,
+        scope_id: str,
+        turn_number: int,
+        current_goal: str | None,
+    ) -> list[str]:
+        if self._scorer_agent is None:
+            return []
+        if not self._scorer_circuit_closed():
+            return []
+
+        scorer_output = self._run_scorer(scope_id, turn_number, current_goal)
+        if scorer_output is None:
+            self._record_scorer_failure()
+            return []
+
+        self._record_scorer_success()
+        return self._evict_from_scorer_groups(scope_id, scorer_output)
+
+    def _run_scorer(
+        self,
+        scope_id: str,
+        turn_number: int,
+        current_goal: str | None,
+    ) -> ScorerOutput | None:
+        if self._scorer_agent is None:
+            return None
+
+        prompt = self._build_scorer_prompt(scope_id, turn_number, current_goal)
+        call_result = _ScorerCallResult()
+
+        def _invoke() -> None:
+            try:
+                result = asyncio.run(
+                    run_structured_agent(
+                        agent=self._scorer_agent,
+                        prompt=prompt,
+                        call_name="scorer",
+                        default_context_profile=self._token_budget.default_profile,
+                    )
+                )
+            except Exception as err:
+                call_result.error = err
+                return
+
+            if isinstance(result, ScorerOutput):
+                call_result.output = result
+                return
+            call_result.error = TypeError("scorer must return ScorerOutput")
+
+        worker = threading.Thread(target=_invoke, daemon=True)
+        worker.start()
+        worker.join(timeout=self._scorer_timeout_seconds)
+
+        if worker.is_alive():
+            return None
+        if call_result.error is not None:
+            return None
+        return call_result.output
+
+    def _build_scorer_prompt(
+        self,
+        scope_id: str,
+        turn_number: int,
+        current_goal: str | None,
+    ) -> str:
+        goal = current_goal or "(none)"
+        recent_turns = self._render_recent_turns(scope_id, turn_number)
+        blocks = self._render_scorer_blocks(scope_id)
+
+        return (
+            "You are a context relevance scorer. Given the current conversation goal\n"
+            "and recent turns, identify which context groups are least valuable.\n\n"
+            f"Current goal: {goal}\n"
+            f"Recent turns (last 2-3):\n{recent_turns}\n\n"
+            "Context blocks to evaluate:\n"
+            f"{blocks}\n\n"
+            'Output two lists: "keep_groups" and "evict_groups".\n'
+            "Group related blocks together. Prefer coherent group eviction over orphaning blocks."
+        )
+
+    def _render_recent_turns(self, scope_id: str, turn_number: int) -> str:
+        chronicle = [
             item
             for item in self.by_scope.get(scope_id, [])
-            if item.zone == zone and not item.pinned
+            if item.zone == ContextZone.chronicle and item.turn_number <= turn_number
+        ]
+        chronicle.sort(key=lambda item: (item.turn_number, item.created_at, item.ctx_id))
+        if not chronicle:
+            return "- (none)"
+
+        lines: list[str] = []
+        for item in chronicle[-3:]:
+            lines.append(
+                f"- turn {item.turn_number} | {item.source} | "
+                f"{self._truncate_text(item.content, max_chars=180)}"
+            )
+        return "\n".join(lines)
+
+    def _render_scorer_blocks(self, scope_id: str) -> str:
+        items = list(self.by_scope.get(scope_id, []))
+        if not items:
+            return "- (none)"
+
+        items.sort(
+            key=lambda item: (
+                _ZONE_ORDER[item.zone],
+                item.turn_number,
+                item.created_at,
+                item.ctx_id,
+            )
+        )
+
+        lines: list[str] = []
+        for item in items:
+            lines.append(
+                f"- id={item.ctx_id} | zone={item.zone.value} | kind={item.kind} | "
+                f"turn={item.turn_number} | source={item.source} | tokens={item.token_count} | "
+                f"relevance={item.relevance:.3f} | pinned={item.pinned}"
+            )
+            lines.append(f"  content={self._truncate_text(item.content, max_chars=200)}")
+        return "\n".join(lines)
+
+    def _evict_from_scorer_groups(self, scope_id: str, scorer_output: ScorerOutput) -> list[str]:
+        evicted: list[str] = []
+        seen_block_ids: set[str] = set()
+
+        for group in scorer_output.evict_groups:
+            for block_id in group.block_ids:
+                if block_id in seen_block_ids:
+                    continue
+                seen_block_ids.add(block_id)
+
+                item = self._find_item(scope_id, block_id)
+                if item is None or item.pinned or item.zone == ContextZone.system:
+                    continue
+
+                removed = self._remove_item(scope_id, block_id)
+                if removed is not None:
+                    evicted.append(removed.ctx_id)
+
+            if not self._is_over_threshold(scope_id, self._token_budget.eviction_threshold_pct):
+                break
+
+        return evicted
+
+    def _aggressive_heuristic_eviction(self, scope_id: str) -> list[str]:
+        evicted: list[str] = []
+        while self._is_over_threshold(scope_id, self._token_budget.eviction_threshold_pct):
+            candidate = self._pick_aggressive_candidate(scope_id)
+            if candidate is None:
+                break
+
+            removed = self._remove_item(scope_id, candidate.ctx_id)
+            if removed is None:
+                break
+            evicted.append(removed.ctx_id)
+
+        return evicted
+
+    def _pick_eviction_candidate(self, scope_id: str, zone: ContextZone) -> ContextItem | None:
+        candidates = [
+            item for item in self.by_scope.get(scope_id, []) if item.zone == zone and not item.pinned
         ]
         if not candidates:
             return None
@@ -192,6 +401,77 @@ class LiveContextManager:
             )
         )
         return candidates[0]
+
+    def _pick_aggressive_candidate(self, scope_id: str) -> ContextItem | None:
+        candidates = [
+            item
+            for item in self.by_scope.get(scope_id, [])
+            if item.zone in _EVICTABLE_ZONES and not item.pinned
+        ]
+        if not candidates:
+            return None
+
+        candidates.sort(
+            key=lambda item: (
+                0 if item.zone == ContextZone.chronicle else 1 if item.zone == ContextZone.memory else 2,
+                item.turn_number if item.zone == ContextZone.chronicle else int(item.relevance * 1_000_000),
+                item.turn_number,
+                item.created_at,
+                item.ctx_id,
+            )
+        )
+        return candidates[0]
+
+    def _scorer_circuit_closed(self) -> bool:
+        if self._scorer_breaker_open_until is None:
+            return True
+
+        now = datetime.now(timezone.utc)
+        if now >= self._scorer_breaker_open_until:
+            self._scorer_consecutive_failures = 0
+            self._scorer_breaker_open_until = None
+            return True
+        return False
+
+    def _record_scorer_success(self) -> None:
+        self._scorer_consecutive_failures = 0
+        self._scorer_breaker_open_until = None
+
+    def _record_scorer_failure(self) -> None:
+        self._scorer_consecutive_failures += 1
+        if self._scorer_consecutive_failures < _SCORER_BREAKER_FAILURE_LIMIT:
+            return
+        self._scorer_breaker_open_until = datetime.now(timezone.utc) + _SCORER_BREAKER_COOLDOWN
+
+    def _find_item(self, scope_id: str, ctx_id: str) -> ContextItem | None:
+        for item in self.by_scope.get(scope_id, []):
+            if item.ctx_id == ctx_id:
+                return item
+        return None
+
+    def _total_usage_tokens(self, scope_id: str) -> int:
+        usage = self.token_usage(scope_id)
+        return sum(usage.values())
+
+    def _is_over_threshold(self, scope_id: str, threshold_pct: float) -> bool:
+        threshold_tokens = int(self._token_budget.total * threshold_pct)
+        return self._total_usage_tokens(scope_id) > threshold_tokens
+
+    def _truncate_text(self, text: str, max_chars: int = 200) -> str:
+        compact = " ".join(text.split())
+        if len(compact) <= max_chars:
+            return compact
+        if max_chars <= 3:
+            return compact[:max_chars]
+        return f"{compact[:max_chars - 3]}..."
+
+    def _extend_unique(self, target: list[str], additions: list[str]) -> None:
+        seen = set(target)
+        for ctx_id in additions:
+            if ctx_id in seen:
+                continue
+            seen.add(ctx_id)
+            target.append(ctx_id)
 
     def _remove_item(self, scope_id: str, ctx_id: str) -> ContextItem | None:
         items = self.by_scope.get(scope_id)

--- a/silas/main.py
+++ b/silas/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from silas.agents.proxy import build_proxy_agent
+from silas.agents.scorer import build_scorer_agent
 from silas.approval import LiveApprovalManager
 from silas.audit.sqlite_audit import SQLiteAuditLog
 from silas.channels.web import WebChannel
@@ -50,6 +51,7 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         model=settings.models.proxy,
         default_context_profile=settings.context.default_profile,
     )
+    scorer = build_scorer_agent(model=settings.models.scorer)
 
     memory_store = SQLiteMemoryStore(db)
     chronicle_store = SQLiteChronicleStore(db)
@@ -60,6 +62,7 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
     context_manager = LiveContextManager(
         token_budget=settings.context.as_token_budget(),
         token_counter=token_counter,
+        scorer_agent=scorer,
     )
     skill_registry = SkillRegistry()
     register_builtin_skills(skill_registry)

--- a/silas/models/__init__.py
+++ b/silas/models/__init__.py
@@ -63,6 +63,7 @@ from silas.models.personality import (
 from silas.models.preferences import InferredPreference, PreferenceSignal
 from silas.models.proactivity import Suggestion, SuggestionProposal
 from silas.models.review import BatchActionDecision, BatchActionItem, BatchProposal
+from silas.models.scorer import ScorerGroup, ScorerOutput
 from silas.models.sessions import Session, SessionType
 from silas.models.skills import SkillDefinition, SkillMetadata, SkillRef, SkillResult
 from silas.models.undo import UndoEntry
@@ -104,6 +105,8 @@ __all__ = [
     "MemoryItem",
     "ContextZone",
     "ContextProfile",
+    "ScorerGroup",
+    "ScorerOutput",
     "ContextItem",
     "ContextSubscription",
     "TokenBudget",

--- a/silas/models/context.py
+++ b/silas/models/context.py
@@ -7,6 +7,7 @@ from math import floor
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from silas.models.messages import TaintLevel, utc_now
+from silas.models.scorer import ScorerGroup, ScorerOutput
 
 
 class ContextZone(str, Enum):
@@ -123,5 +124,7 @@ __all__ = [
     "ContextProfile",
     "ContextItem",
     "ContextSubscription",
+    "ScorerGroup",
+    "ScorerOutput",
     "TokenBudget",
 ]

--- a/silas/models/scorer.py
+++ b/silas/models/scorer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ScorerGroup(BaseModel):
+    reason: str
+    block_ids: list[str] = Field(default_factory=list)
+
+
+class ScorerOutput(BaseModel):
+    keep_groups: list[ScorerGroup] = Field(default_factory=list)
+    evict_groups: list[ScorerGroup] = Field(default_factory=list)
+
+
+__all__ = ["ScorerGroup", "ScorerOutput"]

--- a/silas/protocols/__init__.py
+++ b/silas/protocols/__init__.py
@@ -2,7 +2,7 @@ from silas.protocols.approval import ApprovalManager, ApprovalVerifier, NonceSto
 from silas.protocols.audit import AuditLog
 from silas.protocols.channels import ChannelAdapterCore, RichCardChannel
 from silas.protocols.connections import ConnectionManager
-from silas.protocols.context import ContextManager
+from silas.protocols.context import ContextManager, ContextScorer
 from silas.protocols.execution import EphemeralExecutor, SandboxManager
 from silas.protocols.gates import GateCheckProvider, GateRunner
 from silas.protocols.goals import GoalManager
@@ -26,6 +26,7 @@ __all__ = [
     "MemoryConsolidator",
     "MemoryPortability",
     "ContextManager",
+    "ContextScorer",
     "ConnectionManager",
     "ApprovalVerifier",
     "NonceStore",

--- a/silas/protocols/context.py
+++ b/silas/protocols/context.py
@@ -26,4 +26,9 @@ class ContextManager(Protocol):
     def token_usage(self, scope_id: str) -> dict[str, int]: ...
 
 
-__all__ = ["ContextManager"]
+@runtime_checkable
+class ContextScorer(Protocol):
+    async def run(self, prompt: str) -> object: ...
+
+
+__all__ = ["ContextManager", "ContextScorer"]

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import pytest
+from silas.agents.scorer import score_context_blocks
+from silas.core.context_manager import LiveContextManager
+from silas.core.token_counter import HeuristicTokenCounter
+from silas.models.context import (
+    ContextItem,
+    ContextProfile,
+    ContextZone,
+    ScorerGroup,
+    ScorerOutput,
+    TokenBudget,
+)
+from silas.models.messages import TaintLevel
+
+from tests.fakes import FakeContextScorer
+
+
+def _item(
+    ctx_id: str,
+    zone: ContextZone,
+    content: str,
+    *,
+    turn: int = 1,
+    kind: str = "message",
+    relevance: float = 1.0,
+    source: str = "test",
+    pinned: bool = False,
+) -> ContextItem:
+    counter = HeuristicTokenCounter()
+    return ContextItem(
+        ctx_id=ctx_id,
+        zone=zone,
+        content=content,
+        token_count=counter.count(content),
+        turn_number=turn,
+        source=source,
+        taint=TaintLevel.owner,
+        kind=kind,
+        relevance=relevance,
+        pinned=pinned,
+    )
+
+
+def _budget(
+    *,
+    total: int = 1000,
+    system_max: int = 100,
+    eviction_threshold_pct: float = 0.50,
+    profiles: dict[str, ContextProfile] | None = None,
+) -> TokenBudget:
+    configured_profiles = profiles or {
+        "conversation": ContextProfile(
+            name="conversation",
+            chronicle_pct=0.45,
+            memory_pct=0.20,
+            workspace_pct=0.15,
+        )
+    }
+    return TokenBudget(
+        total=total,
+        system_max=system_max,
+        eviction_threshold_pct=eviction_threshold_pct,
+        profiles=configured_profiles,
+        default_profile="conversation",
+    )
+
+
+def _manager(
+    budget: TokenBudget,
+    scorer: FakeContextScorer | None = None,
+    *,
+    timeout_seconds: float = 2.0,
+) -> LiveContextManager:
+    return LiveContextManager(
+        token_budget=budget,
+        token_counter=HeuristicTokenCounter(),
+        scorer_agent=scorer,
+        scorer_timeout_seconds=timeout_seconds,
+    )
+
+
+def _seed_over_budget(manager: LiveContextManager, scope_id: str) -> list[str]:
+    block_ids: list[str] = []
+    for idx in range(4):
+        block_id = f"c{idx}"
+        manager.add(
+            scope_id,
+            _item(block_id, ContextZone.chronicle, "x" * 350, turn=idx + 1, relevance=0.6),
+        )
+        block_ids.append(block_id)
+    for idx in range(4):
+        block_id = f"m{idx}"
+        manager.add(
+            scope_id,
+            _item(block_id, ContextZone.memory, "y" * 350, turn=idx + 1, relevance=0.2),
+        )
+        block_ids.append(block_id)
+    return block_ids
+
+
+@pytest.mark.asyncio
+async def test_scorer_output_parsing_via_structured_wrapper() -> None:
+    expected = ScorerOutput(
+        keep_groups=[ScorerGroup(reason="retain active thread", block_ids=["c1", "c2"])],
+        evict_groups=[ScorerGroup(reason="stale branch", block_ids=["m9"])],
+    )
+    scorer = FakeContextScorer(outputs=[expected.model_copy(deep=True)])
+
+    parsed = await score_context_blocks(scorer, "score these blocks")
+
+    assert parsed.model_dump(mode="json") == expected.model_dump(mode="json")
+    assert scorer.calls == 1
+
+
+def test_scorer_output_model_parses_groups() -> None:
+    payload = {
+        "keep_groups": [{"reason": "recent", "block_ids": ["a", "b"]}],
+        "evict_groups": [{"reason": "stale", "block_ids": ["c"]}],
+    }
+
+    parsed = ScorerOutput.model_validate(payload)
+
+    assert parsed.keep_groups[0].reason == "recent"
+    assert parsed.keep_groups[0].block_ids == ["a", "b"]
+    assert parsed.evict_groups[0].block_ids == ["c"]
+
+
+def test_timeout_falls_back_to_aggressive_heuristic_eviction() -> None:
+    scorer = FakeContextScorer(delay_seconds=0.20)
+    manager = _manager(_budget(), scorer=scorer, timeout_seconds=0.01)
+    _seed_over_budget(manager, "owner")
+
+    evicted = manager.enforce_budget("owner", turn_number=10, current_goal="keep recent debugging state")
+
+    assert scorer.calls == 1
+    assert manager._scorer_consecutive_failures == 1  # noqa: SLF001
+    assert len(evicted) >= 3
+    total_tokens = sum(manager.token_usage("owner").values())
+    assert total_tokens <= 500
+
+
+def test_scorer_circuit_breaker_opens_after_three_failures() -> None:
+    scorer = FakeContextScorer(errors=[RuntimeError("boom"), RuntimeError("boom"), RuntimeError("boom")])
+    manager = _manager(_budget(), scorer=scorer, timeout_seconds=0.05)
+
+    for idx in range(4):
+        scope = f"scope-{idx}"
+        _seed_over_budget(manager, scope)
+        manager.enforce_budget(scope, turn_number=10, current_goal="triage")
+
+    assert scorer.calls == 3
+    assert manager._scorer_breaker_open_until is not None  # noqa: SLF001
+
+
+def test_context_manager_uses_scorer_groups_for_eviction() -> None:
+    profiles = {
+        "conversation": ContextProfile(
+            name="conversation",
+            chronicle_pct=0.40,
+            memory_pct=0.40,
+            workspace_pct=0.00,
+        )
+    }
+    budget = _budget(profiles=profiles)
+    scorer = FakeContextScorer(
+        outputs=[
+            ScorerOutput(
+                keep_groups=[ScorerGroup(reason="keep latest chronicle", block_ids=["c0", "c1", "c2"])],
+                evict_groups=[ScorerGroup(reason="drop memory shard", block_ids=["m0"])],
+            )
+        ]
+    )
+    manager = _manager(budget, scorer=scorer)
+
+    for idx in range(3):
+        manager.add("owner", _item(f"c{idx}", ContextZone.chronicle, "a" * 350, turn=idx + 1))
+        manager.add("owner", _item(f"m{idx}", ContextZone.memory, "b" * 350, turn=idx + 1))
+
+    evicted = manager.enforce_budget("owner", turn_number=9, current_goal="focus on live thread")
+
+    assert scorer.calls == 1
+    assert "m0" in evicted
+    remaining_ids = {item.ctx_id for item in manager.by_scope["owner"]}
+    assert "m0" not in remaining_ids
+    assert {"c0", "c1", "c2"}.issubset(remaining_ids)
+
+
+def test_empty_context_is_noop() -> None:
+    scorer = FakeContextScorer(outputs=[ScorerOutput()])
+    manager = _manager(_budget(), scorer=scorer)
+
+    evicted = manager.enforce_budget("empty", turn_number=1, current_goal=None)
+
+    assert evicted == []
+    assert scorer.calls == 0
+
+
+def test_all_high_priority_pinned_items_are_preserved() -> None:
+    scorer = FakeContextScorer(
+        outputs=[
+            ScorerOutput(
+                evict_groups=[ScorerGroup(reason="attempt", block_ids=["c0", "m0"])],
+            )
+        ]
+    )
+    manager = _manager(_budget(), scorer=scorer)
+    manager.add("owner", _item("c0", ContextZone.chronicle, "c" * 350, pinned=True))
+    manager.add("owner", _item("m0", ContextZone.memory, "m" * 350, pinned=True))
+
+    evicted = manager.enforce_budget("owner", turn_number=7, current_goal="none")
+
+    assert evicted == []
+    assert {item.ctx_id for item in manager.by_scope["owner"]} == {"c0", "m0"}
+
+
+def test_all_low_priority_items_can_be_evicted() -> None:
+    profiles = {
+        "conversation": ContextProfile(
+            name="conversation",
+            chronicle_pct=0.40,
+            memory_pct=0.40,
+            workspace_pct=0.00,
+        )
+    }
+    budget = _budget(total=500, eviction_threshold_pct=0.40, profiles=profiles)
+    scorer = FakeContextScorer(
+        outputs=[
+            ScorerOutput(
+                evict_groups=[
+                    ScorerGroup(reason="drop stale data", block_ids=["c0", "c1", "m0", "m1"])
+                ]
+            )
+        ]
+    )
+    manager = _manager(budget, scorer=scorer)
+
+    manager.add("owner", _item("c0", ContextZone.chronicle, "c" * 350, relevance=0.01))
+    manager.add("owner", _item("c1", ContextZone.chronicle, "c" * 350, relevance=0.01))
+    manager.add("owner", _item("m0", ContextZone.memory, "m" * 350, relevance=0.01))
+    manager.add("owner", _item("m1", ContextZone.memory, "m" * 350, relevance=0.01))
+
+    evicted = manager.enforce_budget("owner", turn_number=12, current_goal="latest only")
+
+    assert set(evicted) == {"c0", "c1", "m0", "m1"}
+    assert manager.by_scope["owner"] == []


### PR DESCRIPTION
- ScorerOutput/ScorerGroup models
- ContextScorer agent with run_structured_agent (2s timeout, circuit breaker, deterministic fallback)
- Two-tier eviction in LiveContextManager: heuristic pre-filter → scorer model
- 8 new tests (test_scorer.py): fallback, multi-scope, group eviction, budget enforcement
- 430 passed, ruff clean