### PR TITLE
feat: coverage boost — execution + agent tests (+21)

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,68 @@
+"""Tests for agent fallback behavior (planner, executor, proxy).
+
+These test deterministic fallback mode — no LLM calls needed.
+Agents gracefully degrade when the model is unavailable.
+"""
+
+from __future__ import annotations
+
+import pytest
+from silas.agents.executor_agent import ExecutorAgent, build_executor_agent
+from silas.agents.planner import PlannerAgent, build_planner_agent
+from silas.agents.proxy import build_proxy_agent
+from silas.models.agents import AgentResponse, RouteDecision
+from silas.models.execution import ExecutorAgentOutput
+
+# --- Planner Agent ---
+
+
+class TestPlannerAgent:
+    def test_build_planner_agent(self) -> None:
+        agent = build_planner_agent(model="nonexistent-model")
+        assert isinstance(agent, PlannerAgent)
+
+    @pytest.mark.asyncio
+    async def test_fallback_produces_agent_response(self) -> None:
+        """With no LLM, planner should return a deterministic AgentResponse."""
+        agent = build_planner_agent(model="nonexistent-model")
+        result = await agent.run("Create a hello world script")
+        assert result.output is not None
+        assert isinstance(result.output, AgentResponse)
+
+    @pytest.mark.asyncio
+    async def test_fallback_response_has_plan_action(self) -> None:
+        agent = build_planner_agent(model="nonexistent-model")
+        result = await agent.run("Build a REST API")
+        # Fallback should include a plan_action with the request echoed
+        assert result.output.plan_action is not None
+
+
+# --- Executor Agent ---
+
+
+class TestExecutorAgent:
+    def test_build_executor_agent(self) -> None:
+        agent = build_executor_agent(model="nonexistent-model")
+        assert isinstance(agent, ExecutorAgent)
+
+    @pytest.mark.asyncio
+    async def test_fallback_produces_output(self) -> None:
+        agent = build_executor_agent(model="nonexistent-model")
+        result = await agent.run("Execute the deployment script")
+        assert result.output is not None
+        assert isinstance(result.output, ExecutorAgentOutput)
+        # Fallback should indicate it couldn't get structured output
+        assert "fallback" in result.output.summary.lower()
+
+
+# --- Proxy Agent ---
+
+
+class TestProxyAgent:
+    @pytest.mark.asyncio
+    async def test_fallback_produces_route_decision(self) -> None:
+        agent = build_proxy_agent(model="nonexistent-model")
+        result = await agent.run("What's the weather?")
+        assert result.output is not None
+        assert isinstance(result.output, RouteDecision)
+        assert result.output.route in ("responder", "planner", "direct")

--- a/tests/test_execution_layer.py
+++ b/tests/test_execution_layer.py
@@ -1,0 +1,180 @@
+"""Tests for execution layer: sandbox manager, shell executor, python executor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from silas.execution.python import PythonExecutor
+from silas.execution.sandbox import SubprocessSandboxManager
+from silas.execution.shell import ShellExecutor
+from silas.models.execution import ExecutionEnvelope, SandboxConfig
+
+# --- SubprocessSandboxManager ---
+
+
+class TestSubprocessSandboxManager:
+    @pytest.mark.asyncio
+    async def test_create_and_destroy(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        assert sandbox.sandbox_id
+        assert Path(sandbox.work_dir).exists()
+        await mgr.destroy(sandbox.sandbox_id)
+        assert not Path(sandbox.work_dir).exists()
+
+    @pytest.mark.asyncio
+    async def test_exec_simple_command(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        result = await mgr.exec(sandbox.sandbox_id, ["echo", "hello"], timeout_seconds=5)
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+        assert not result.timed_out
+        await mgr.destroy(sandbox.sandbox_id)
+
+    @pytest.mark.asyncio
+    async def test_exec_timeout(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        result = await mgr.exec(sandbox.sandbox_id, ["sleep", "10"], timeout_seconds=0.5)
+        assert result.timed_out is True
+        await mgr.destroy(sandbox.sandbox_id)
+
+    @pytest.mark.asyncio
+    async def test_exec_nonexistent_sandbox(self) -> None:
+        mgr = SubprocessSandboxManager()
+        with pytest.raises(KeyError, match="unknown sandbox_id"):
+            await mgr.exec("nonexistent", ["echo", "hi"], timeout_seconds=5)
+
+    @pytest.mark.asyncio
+    async def test_exec_empty_command(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        with pytest.raises(ValueError, match="must not be empty"):
+            await mgr.exec(sandbox.sandbox_id, [], timeout_seconds=5)
+        await mgr.destroy(sandbox.sandbox_id)
+
+    @pytest.mark.asyncio
+    async def test_exec_captures_stderr(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        result = await mgr.exec(
+            sandbox.sandbox_id, ["bash", "-c", "echo error >&2"], timeout_seconds=5,
+        )
+        assert "error" in result.stderr
+        await mgr.destroy(sandbox.sandbox_id)
+
+    @pytest.mark.asyncio
+    async def test_exec_nonzero_exit(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        result = await mgr.exec(sandbox.sandbox_id, ["false"], timeout_seconds=5)
+        assert result.exit_code != 0
+        await mgr.destroy(sandbox.sandbox_id)
+
+    @pytest.mark.asyncio
+    async def test_destroy_idempotent(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        await mgr.destroy(sandbox.sandbox_id)
+        await mgr.destroy(sandbox.sandbox_id)  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_output_truncation(self, tmp_path: Path) -> None:
+        mgr = SubprocessSandboxManager(base_dir=tmp_path)
+        sandbox = await mgr.create(SandboxConfig(work_dir=str(tmp_path / "work")))
+        result = await mgr.exec(
+            sandbox.sandbox_id,
+            ["python3", "-c", "print('x' * 5000)"],
+            timeout_seconds=5,
+            max_output_bytes=100,
+        )
+        assert len(result.stdout) <= 100
+        await mgr.destroy(sandbox.sandbox_id)
+
+
+# --- ShellExecutor ---
+
+
+def _shell_envelope(command: str, **kwargs) -> ExecutionEnvelope:
+    defaults = {
+        "execution_id": "test-exec",
+        "step_index": 0,
+        "task_description": "test",
+        "action": "shell_exec",
+        "args": {"command": command},
+    }
+    defaults.update(kwargs)
+    return ExecutionEnvelope(**defaults)
+
+
+class TestShellExecutor:
+    @pytest.mark.asyncio
+    async def test_execute_echo(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = ShellExecutor(sandbox_manager=mgr)
+        envelope = _shell_envelope("echo 'shell test'")
+        result = await executor.execute(envelope)
+        assert result.success is True
+        assert "shell test" in result.return_value
+
+    @pytest.mark.asyncio
+    async def test_execute_failure(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = ShellExecutor(sandbox_manager=mgr)
+        envelope = _shell_envelope("exit 42")
+        result = await executor.execute(envelope)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_wrong_action_rejected(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = ShellExecutor(sandbox_manager=mgr)
+        envelope = _shell_envelope("echo hi", action="python_exec")
+        result = await executor.execute(envelope)
+        assert result.success is False
+        assert "unsupported" in (result.error or "").lower()
+
+
+# --- PythonExecutor ---
+
+
+def _python_envelope(code: str, **kwargs) -> ExecutionEnvelope:
+    defaults = {
+        "execution_id": "test-exec",
+        "step_index": 0,
+        "task_description": "test",
+        "action": "python_exec",
+        "args": {"script": code},
+    }
+    defaults.update(kwargs)
+    return ExecutionEnvelope(**defaults)
+
+
+class TestPythonExecutor:
+    @pytest.mark.asyncio
+    async def test_execute_simple(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = PythonExecutor(sandbox_manager=mgr)
+        envelope = _python_envelope("print(1 + 1)")
+        result = await executor.execute(envelope)
+        assert result.success is True
+        assert "2" in result.return_value
+
+    @pytest.mark.asyncio
+    async def test_execute_error(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = PythonExecutor(sandbox_manager=mgr)
+        envelope = _python_envelope("raise ValueError('boom')")
+        result = await executor.execute(envelope)
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_wrong_action_rejected(self) -> None:
+        mgr = SubprocessSandboxManager()
+        executor = PythonExecutor(sandbox_manager=mgr)
+        envelope = _python_envelope("print(1)", action="shell_exec")
+        result = await executor.execute(envelope)
+        assert result.success is False
+        assert "unsupported" in (result.error or "").lower()


### PR DESCRIPTION
15 execution layer tests + 6 agent fallback tests. 545 total.