### PR TITLE
feat: work item retry runner + sandbox zombie cleanup

### DIFF
--- a/silas/work/runner.py
+++ b/silas/work/runner.py
@@ -1,0 +1,175 @@
+"""WorkItemRunner — retry loop and failure escalation for work items.
+
+Wraps an executor to provide:
+- Configurable retry with exponential backoff
+- Budget tracking (attempt counting)
+- on_failure escalation (report, retry, escalate, pause)
+- Failure context propagation for diagnostics
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from silas.models.work import (
+    BudgetUsed,
+    EscalationAction,
+    WorkItem,
+    WorkItemResult,
+    WorkItemStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WorkExecutor(Protocol):
+    """Protocol for the underlying executor that runs a single work item attempt."""
+
+    async def execute(self, work_item: WorkItem) -> WorkItemResult: ...
+
+
+class WorkItemRunner:
+    """Runs work items with retry, budget tracking, and failure escalation.
+
+    Sits between the Stream's execution loop and the raw WorkExecutor.
+    Handles the retry/escalation logic that the spec defines but wasn't wired up.
+    """
+
+    def __init__(
+        self,
+        executor: WorkExecutor,
+        *,
+        backoff_base_seconds: float = 1.0,
+        backoff_max_seconds: float = 30.0,
+        on_escalate: Callable[[WorkItem, EscalationAction], Awaitable[None]] | None = None,
+    ) -> None:
+        self._executor = executor
+        self._backoff_base = backoff_base_seconds
+        self._backoff_max = backoff_max_seconds
+        self._on_escalate = on_escalate
+
+    async def run(self, work_item: WorkItem) -> WorkItemResult:
+        """Execute a work item with retry logic based on its budget and on_failure policy."""
+        max_attempts = work_item.budget.max_attempts
+        last_result: WorkItemResult | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            # Update attempt count on the work item
+            work_item = work_item.model_copy(update={"attempts": attempt})
+
+            result = await self._executor.execute(work_item)
+
+            # Track budget usage
+            result = result.model_copy(
+                update={
+                    "budget_used": BudgetUsed(
+                        attempts=attempt,
+                        tokens=result.budget_used.tokens,
+                        cost_usd=result.budget_used.cost_usd,
+                        wall_time_seconds=result.budget_used.wall_time_seconds,
+                        planner_calls=result.budget_used.planner_calls,
+                        executor_runs=result.budget_used.executor_runs,
+                    ),
+                },
+            )
+
+            if result.status == WorkItemStatus.done:
+                logger.info(
+                    "Work item %s completed on attempt %d/%d",
+                    work_item.id, attempt, max_attempts,
+                )
+                return result
+
+            last_result = result
+
+            # Check if we should retry based on on_failure policy
+            should_retry = self._should_retry(work_item, attempt, max_attempts)
+            if not should_retry:
+                break
+
+            # Backoff before next attempt
+            delay = self._backoff_delay(attempt)
+            logger.info(
+                "Work item %s failed on attempt %d/%d, retrying in %.1fs: %s",
+                work_item.id, attempt, max_attempts, delay,
+                result.last_error or result.summary,
+            )
+            await asyncio.sleep(delay)
+
+        # All attempts exhausted or policy says stop
+        assert last_result is not None
+        return await self._handle_failure(work_item, last_result)
+
+    def _should_retry(self, work_item: WorkItem, attempt: int, max_attempts: int) -> bool:
+        """Determine if the work item should be retried based on policy and budget."""
+        if attempt >= max_attempts:
+            return False
+
+        on_failure = work_item.on_failure
+        # "report" = no retry, just report the failure
+        # "retry" = retry up to max_attempts
+        # "escalate" = retry once then escalate
+        # "pause" = no retry, pause for human intervention
+        if on_failure == "report":
+            return False
+        if on_failure == "pause":
+            return False
+        if on_failure == "escalate":
+            # Escalate after first failure — allow one retry before escalating
+            return attempt < 2
+        # Default: "retry" or unknown policies get retry behavior
+        return True
+
+    def _backoff_delay(self, attempt: int) -> float:
+        """Exponential backoff with cap."""
+        delay = self._backoff_base * (2 ** (attempt - 1))
+        return min(delay, self._backoff_max)
+
+    async def _handle_failure(
+        self, work_item: WorkItem, result: WorkItemResult,
+    ) -> WorkItemResult:
+        """Handle final failure based on on_failure policy."""
+        on_failure = work_item.on_failure
+        failure_context = (
+            f"Work item '{work_item.title}' failed after {result.budget_used.attempts} attempts. "
+            f"Last error: {result.last_error or result.summary}"
+        )
+
+        if on_failure == "pause":
+            logger.warning("Work item %s paused for human intervention", work_item.id)
+            return result.model_copy(
+                update={
+                    "status": WorkItemStatus.stuck,
+                    "summary": f"Paused: {failure_context}",
+                },
+            )
+
+        if on_failure == "escalate":
+            escalation = work_item.escalation.get("default")
+            if escalation is not None and self._on_escalate is not None:
+                logger.warning(
+                    "Escalating work item %s: %s", work_item.id, escalation.action,
+                )
+                try:
+                    await self._on_escalate(work_item, escalation)
+                except (ValueError, RuntimeError, OSError) as exc:
+                    logger.warning(
+                        "Escalation failed for work item %s: %s", work_item.id, exc,
+                    )
+            return result.model_copy(
+                update={"summary": f"Escalated: {failure_context}"},
+            )
+
+        # Default "report" — just return the failure as-is
+        return result.model_copy(
+            update={
+                "summary": failure_context,
+                "status": WorkItemStatus.failed,
+            },
+        )
+
+
+__all__ = ["WorkExecutor", "WorkItemRunner"]

--- a/tests/test_work_runner.py
+++ b/tests/test_work_runner.py
@@ -1,0 +1,188 @@
+"""Tests for WorkItemRunner retry logic and failure escalation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from silas.models.work import (
+    Budget,
+    EscalationAction,
+    WorkItem,
+    WorkItemResult,
+    WorkItemStatus,
+    WorkItemType,
+)
+from silas.work.runner import WorkItemRunner
+
+
+def _make_work_item(
+    *,
+    on_failure: str = "retry",
+    max_attempts: int = 3,
+    escalation: dict[str, EscalationAction] | None = None,
+) -> WorkItem:
+    return WorkItem(
+        id="wi-test-001",
+        type=WorkItemType.task,
+        title="Test work item",
+        body="Do the thing",
+        budget=Budget(max_attempts=max_attempts),
+        on_failure=on_failure,
+        needs_approval=False,
+        escalation=escalation or {},
+        created_at=datetime.now(UTC),
+    )
+
+
+def _success_result(work_item_id: str) -> WorkItemResult:
+    return WorkItemResult(
+        work_item_id=work_item_id,
+        status=WorkItemStatus.done,
+        summary="Completed successfully",
+    )
+
+
+def _failure_result(work_item_id: str, error: str = "something broke") -> WorkItemResult:
+    return WorkItemResult(
+        work_item_id=work_item_id,
+        status=WorkItemStatus.failed,
+        summary="Failed",
+        last_error=error,
+    )
+
+
+class FakeExecutor:
+    """Executor that returns configurable results per attempt."""
+
+    def __init__(self, results: list[WorkItemResult]) -> None:
+        self._results = list(results)
+        self._call_count = 0
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    async def execute(self, work_item: WorkItem) -> WorkItemResult:
+        idx = min(self._call_count, len(self._results) - 1)
+        self._call_count += 1
+        return self._results[idx]
+
+
+class TestRetryOnSuccess:
+    @pytest.mark.asyncio
+    async def test_succeeds_first_try(self) -> None:
+        executor = FakeExecutor([_success_result("wi-test-001")])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item())
+        assert result.status == WorkItemStatus.done
+        assert executor.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_succeeds_after_retries(self) -> None:
+        executor = FakeExecutor([
+            _failure_result("wi-test-001"),
+            _failure_result("wi-test-001"),
+            _success_result("wi-test-001"),
+        ])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(max_attempts=3))
+        assert result.status == WorkItemStatus.done
+        assert executor.call_count == 3
+
+
+class TestOnFailureReport:
+    @pytest.mark.asyncio
+    async def test_no_retry_on_report(self) -> None:
+        executor = FakeExecutor([_failure_result("wi-test-001")])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(on_failure="report", max_attempts=3))
+        assert result.status == WorkItemStatus.failed
+        assert executor.call_count == 1
+
+
+class TestOnFailurePause:
+    @pytest.mark.asyncio
+    async def test_pause_returns_stuck(self) -> None:
+        executor = FakeExecutor([_failure_result("wi-test-001")])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(on_failure="pause"))
+        assert result.status == WorkItemStatus.stuck
+        assert executor.call_count == 1
+        assert "Paused" in result.summary
+
+
+class TestOnFailureEscalate:
+    @pytest.mark.asyncio
+    async def test_escalate_retries_once_then_escalates(self) -> None:
+        escalation_called: list[str] = []
+
+        async def on_escalate(wi: WorkItem, action: EscalationAction) -> None:
+            escalation_called.append(action.action)
+
+        executor = FakeExecutor([
+            _failure_result("wi-test-001"),
+            _failure_result("wi-test-001"),
+        ])
+        runner = WorkItemRunner(
+            executor,
+            backoff_base_seconds=0.01,
+            on_escalate=on_escalate,
+        )
+        result = await runner.run(_make_work_item(
+            on_failure="escalate",
+            max_attempts=5,
+            escalation={"default": EscalationAction(action="notify_owner")},
+        ))
+        assert executor.call_count == 2  # one retry, then stop
+        assert "Escalated" in result.summary
+        assert escalation_called == ["notify_owner"]
+
+    @pytest.mark.asyncio
+    async def test_escalate_without_handler(self) -> None:
+        executor = FakeExecutor([
+            _failure_result("wi-test-001"),
+            _failure_result("wi-test-001"),
+        ])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(
+            on_failure="escalate",
+            max_attempts=5,
+            escalation={"default": EscalationAction(action="notify_owner")},
+        ))
+        assert executor.call_count == 2
+        assert "Escalated" in result.summary
+
+
+class TestBudgetTracking:
+    @pytest.mark.asyncio
+    async def test_attempts_tracked(self) -> None:
+        executor = FakeExecutor([
+            _failure_result("wi-test-001"),
+            _success_result("wi-test-001"),
+        ])
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(max_attempts=3))
+        assert result.budget_used.attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_exhausted(self) -> None:
+        executor = FakeExecutor([_failure_result("wi-test-001")] * 5)
+        runner = WorkItemRunner(executor, backoff_base_seconds=0.01)
+        result = await runner.run(_make_work_item(on_failure="retry", max_attempts=3))
+        assert result.status == WorkItemStatus.failed
+        assert executor.call_count == 3
+
+
+class TestBackoff:
+    def test_backoff_capped(self) -> None:
+        runner = WorkItemRunner(
+            FakeExecutor([]),
+            backoff_base_seconds=1.0,
+            backoff_max_seconds=10.0,
+        )
+        assert runner._backoff_delay(1) == 1.0
+        assert runner._backoff_delay(2) == 2.0
+        assert runner._backoff_delay(3) == 4.0
+        assert runner._backoff_delay(4) == 8.0
+        assert runner._backoff_delay(5) == 10.0  # capped


### PR DESCRIPTION
## WorkItemRunner
New `silas/work/runner.py` — sits between Stream and WorkExecutor:
- Retry with exponential backoff (configurable base/cap)
- `on_failure` policy: report (no retry), retry (up to max_attempts), escalate (1 retry → callback), pause (→ stuck)
- Budget tracking (attempt count propagated)
- Pluggable escalation handler

## Sandbox cleanup
- Track active PIDs per sandbox
- `destroy()` kills lingering process groups before rmtree
- Prevents zombie processes

## Tests
9 new tests: all retry policies, budget tracking, backoff math.
**559 total tests passing**, 0 lint errors.