### PR TITLE
fix: enforce WebSocket auth + server-side sender identity + approval auth

### DIFF
--- a/silas/core/stream.py
+++ b/silas/core/stream.py
@@ -35,6 +35,7 @@ from silas.protocols.proactivity import AutonomyCalibrator, SuggestionEngine
 
 _counter = HeuristicTokenCounter()
 _MENTION_PATTERN = re.compile(r"@([A-Za-z0-9_:-]+)")
+_WEBSOCKET_AUTH_BOUNDARY_SIGNATURE = b"ws-auth-boundary"
 
 
 @dataclass(slots=True)
@@ -152,7 +153,14 @@ class Stream:
         await self._audit("phase1a_noop", step=1, note="input gates skipped")
 
         taint = TaintLevel.owner if message.sender_id == self.owner_id else TaintLevel.external
-        signed = SignedMessage(message=message, signature=b"", nonce=uuid.uuid4().hex, taint=taint)
+        # TODO: Replace this placeholder with per-message signing. For now, websocket auth and
+        # server-assigned sender identity are the active trust boundary for inbound messages.
+        signed = SignedMessage(
+            message=message,
+            signature=_WEBSOCKET_AUTH_BOUNDARY_SIGNATURE,
+            nonce=uuid.uuid4().hex,
+            taint=taint,
+        )
         cm = self._get_context_manager()
 
         self.turn_context.turn_number += 1

--- a/silas/main.py
+++ b/silas/main.py
@@ -44,6 +44,7 @@ def build_stream(settings: SilasSettings) -> tuple[Stream, WebChannel]:
         port=web_cfg.port,
         web_dir=Path("web"),
         scope_id=settings.owner_id,
+        auth_token=web_cfg.auth_token,
     )
 
     proxy = build_proxy_agent(

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -92,3 +92,20 @@ def test_build_stream_wires_output_gate_runner(
     stream, _ = build_stream(settings)
 
     assert stream.output_gate_runner is not None
+
+
+def test_build_stream_passes_web_auth_token_to_channel(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SilasSettings.model_validate(
+        {
+            "data_dir": str(tmp_path / "data"),
+            "channels": {"web": {"auth_token": "secret-token"}},
+        }
+    )
+    monkeypatch.setattr("silas.main.build_proxy_agent", lambda model, default_context_profile: TestModel())
+
+    _, channel = build_stream(settings)
+
+    assert channel.auth_token == "secret-token"


### PR DESCRIPTION
## Security Fixes (Criticals 1-3)

Closes the full impersonation attack chain from the security audit.

### Changes
- **WebSocket auth**: `WebChannel` accepts `auth_token` param; rejects unauthenticated connections with code 1008
- **Config wiring**: `main.py` passes `auth_token` from `WebChannelConfig` into `WebChannel`
- **Server-side identity**: Payload `sender_id` is ignored; server assigns identity from `scope_id`
- **Approval auth**: `resolved_by` uses server identity, not client payload
- **stream.py**: Placeholder signature replaced with `ws-auth-boundary` marker + TODO for future per-message signing

### Tests
- WS rejected without token (parameterized: no token + wrong token)
- WS accepted with valid token
- Payload sender_id ignored (server-assigned)
- Approval resolved_by uses server identity
- Config wiring test (auth_token flows to channel)

### xfail removed
The signing xfail in test_security.py is replaced with real auth enforcement tests.