### PR TITLE
fix: prevent plan self-approval + await persistence + path traversal guard

### DIFF
--- a/silas/skills/executor.py
+++ b/silas/skills/executor.py
@@ -38,6 +38,11 @@ class SkillExecutor:
     def register_handler(self, skill_name: str, handler: SkillHandler) -> None:
         self._handlers[skill_name] = handler
 
+    def skill_requires_approval(self, skill_name: str) -> bool:
+        """Return whether skill metadata requires explicit approval at execution time."""
+        definition = self._skill_registry.get(skill_name)
+        return bool(definition is not None and definition.requires_approval)
+
     async def execute(self, skill_name: str, inputs: dict[str, object]) -> SkillResult:
         started_at = datetime.now(UTC)
         definition = self._skill_registry.get(skill_name)

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from silas.core.plan_executor import build_skill_work_item
+
+
+def test_build_skill_work_item_metadata_approval_cannot_be_downgraded() -> None:
+    action = {
+        "title": "Store sensitive memory",
+        "body": "Persist memory payload.",
+        "needs_approval": False,
+        "work_item": {"needs_approval": False},
+    }
+
+    work_item = build_skill_work_item(
+        "memory_store",
+        action,
+        turn_number=12,
+        requires_approval=True,
+    )
+
+    assert work_item.needs_approval is True
+
+
+def test_build_skill_work_item_accepts_stricter_planner_request() -> None:
+    action = {
+        "title": "Run safe skill with extra caution",
+        "body": "Explicitly request approval anyway.",
+        "needs_approval": True,
+    }
+
+    work_item = build_skill_work_item(
+        "web_search",
+        action,
+        turn_number=12,
+        requires_approval=False,
+    )
+
+    assert work_item.needs_approval is True

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -411,8 +411,8 @@ class PlannerRouteWithPlanActionsModel:
             routed,
             "plan_actions",
             [
-                {"id": "plan-a", "type": "task", "title": "Run first action", "body": "Execute first planner action.", "skills": ["skill_a"]},
-                {"id": "plan-b", "type": "task", "title": "Run second action", "body": "Execute second planner action.", "skills": ["skill_b"], "depends_on": ["plan-a"]},
+                {"id": "plan-a", "type": "task", "title": "Run first action", "body": "Execute first planner action.", "needs_approval": False, "skills": ["skill_a"]},
+                {"id": "plan-b", "type": "task", "title": "Run second action", "body": "Execute second planner action.", "needs_approval": False, "skills": ["skill_b"], "depends_on": ["plan-a"]},
             ],
         )
         return RunResult(output=routed)


### PR DESCRIPTION
## Security Fixes (Highs #4-5, Medium #6)

### Plan self-approval bypass (High)
- `_resolve_skill_needs_approval()` in plan_executor treats skill metadata as floor — planner can request stricter, never weaker
- Work executor checks skill registry at execution time via `skill_requires_approval()`
- Work items with approval-required skills are blocked without a token

### Persistence before completion (High)
- `_finalize_success()` persists the done state before returning success
- If persistence fails, returns failed status with error detail
- No more fire-and-forget saves

### Path traversal guard (Medium)
- `_resolve_script()` now validates both skill_name and script_name stay within skills_dir
- Uses `.resolve().relative_to()` containment check

### Tests (+10 new)
- Plan actions cannot downgrade approval (test_plan_executor.py)
- Planner can request stricter approval
- needs_approval=true without token → blocked
- Skill metadata requires_approval cannot be downgraded at executor level
- Persistence failure prevents completion marking
- Path traversal rejected for skill_name and script_name
- Stream plan action test updated for explicit needs_approval field