### PR TITLE
feat: eviction feedback loop (§19) + benchmarking harness (§20) specs

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,15 @@
+# Specs Companion Index
+
+This folder holds companion documents extracted from `specs.md` to keep the core spec shorter and easier to scan.
+
+- `project-structure.md` — Section 1 project tree and onboarding/frontend structure
+- `models.md` — Section 3 data models (`3.1` to `3.12`)
+- `protocols.md` — Section 4 protocol contracts (`4.1` to `4.24`)
+- `examples.md` — Section 13 example plans
+- `testing.md` — Section 14 testing strategy
+- `security-model.md` — Section 15 security model summary and prohibited-capability matrix
+- `adrs.md` — Section 16 architecture decisions and tradeoffs
+- `operations-roadmap.md` — Sections 17-18 operations, reliability, and roadmap
+- `benchmarking.md` — Sections 19-20 context eviction feedback loop and agent/skill benchmarking
+
+Section numbering is preserved inside each companion file for stable cross-references.

--- a/specs/benchmarking.md
+++ b/specs/benchmarking.md
@@ -1,0 +1,240 @@
+## 19. Context Eviction Feedback Loop
+
+### 19.1 Architecture
+
+Two-tier eviction (§5.7) already separates heuristic pre-filtering from scorer-model eviction. This section extends that with a **feedback collection layer** that turns eviction overrides into calibration data.
+
+**Role separation:**
+
+| Actor | Responsibility |
+|---|---|
+| Heuristic / cheap scorer model | Continuously scores chunks, proposes eviction candidates (background, never burns main-LLM tokens) |
+| Main LLM | Triggers flush when it needs context space — does NOT decide what to evict |
+| Main LLM (at flush time) | May **exclude** items from the proposed eviction list (keep-backs) |
+| Feedback store | Records every exclusion as a training signal for scorer calibration |
+
+The cheap scorer (configured via `models.scorer`, default `claude-haiku-4-5`) runs asynchronously. It maintains a ranked eviction queue per scope. When the main LLM triggers a flush (explicitly or via token pressure at turn step 5), the system presents the eviction candidates. The LLM can exclude items it still needs — those exclusions are the feedback signal.
+
+### 19.2 Data Models
+
+```python
+class EvictionProposal(BaseModel):
+    """A batch of chunks proposed for eviction by the scorer."""
+    proposal_id: str              # Unique ID for this proposal batch
+    scope_id: str
+    turn_number: int
+    proposed_at: datetime
+    scorer_model: str             # Model that scored (e.g. "claude-haiku-4-5")
+    candidates: list[EvictionCandidate]
+
+class EvictionCandidate(BaseModel):
+    """A single chunk proposed for eviction."""
+    ctx_id: str
+    zone: ContextZone
+    relevance_score: float        # Scorer's relevance estimate (0.0 = irrelevant, 1.0 = critical)
+    age_turns: int                # Turns since last reference
+    token_count: int
+
+class EvictionFeedback(BaseModel):
+    """Recorded when an eviction proposal is resolved."""
+    proposal_id: str
+    scope_id: str
+    resolved_at: datetime
+    resolved_by: str              # "llm" | "user" | "auto" (no exclusions, timeout)
+    evicted: list[str]            # ctx_ids actually evicted
+    excluded: list[EvictionExclusion]  # ctx_ids kept back
+
+class EvictionExclusion(BaseModel):
+    """A single keep-back: scorer wanted to evict, but it was overridden."""
+    ctx_id: str
+    relevance_score: float        # Scorer's original score (what it thought)
+    exclude_reason: str | None    # Optional reason from LLM ("still needed for X")
+```
+
+### 19.3 Feedback Collection Protocol
+
+1. Scorer produces `EvictionProposal` with ranked candidates.
+2. At flush time, harness presents candidates to main LLM as part of the turn context (lightweight — just `ctx_id` + `relevance_score` + summary snippet).
+3. LLM responds with optional `exclude_ctx_ids: list[str]` in its structured output (new field on `AgentResponse`).
+4. Harness evicts non-excluded candidates, records `EvictionFeedback` to SQLite.
+5. If LLM doesn't respond within `eviction_feedback_timeout_ms` (default 2000), auto-resolve: evict all candidates, record `resolved_by: "auto"`.
+
+### 19.4 Scorer Calibration
+
+Feedback records accumulate in `eviction_feedback` table. Calibration uses them as follows:
+
+- **Exclusion rate by zone**: If the LLM consistently keeps back `chronicle` items scored < 0.3, the scorer's zone weighting is miscalibrated.
+- **Exclusion rate by age**: If old items are frequently excluded, the age-decay factor is too aggressive.
+- **Per-scope patterns**: Some scopes (e.g., long-running projects) have different retention needs than ephemeral conversations.
+
+Calibration can be:
+- **Offline**: Export feedback dataset, fine-tune scorer prompt / heuristic weights, deploy updated config.
+- **Online (R14)**: Periodic background job adjusts scorer weights based on rolling exclusion statistics. Requires ablation validation (§20) before enabling.
+
+### 19.5 Ablation Requirements
+
+**No calibration method may be deployed without ablation study.** Specifically:
+
+- Baseline: current heuristic-only eviction (no feedback loop)
+- Variant A: feedback-calibrated scorer weights
+- Variant B: feedback-calibrated scorer prompt
+- Variant C: online auto-adjustment
+
+Each variant must be evaluated on the benchmarking harness (§20) using context quality metrics:
+- Retrieval relevance (does the retained context help the LLM answer correctly?)
+- Token efficiency (tokens retained vs. task completion rate)
+- Exclusion prediction accuracy (can the scorer learn to predict what the LLM would exclude?)
+
+See §20.4 for integration with the benchmarking framework.
+
+
+## 20. Agent & Skill Benchmarking
+
+### 20.1 Overview
+
+A standardized evaluation framework for measuring agent and skill performance. Covers correctness, efficiency, regression detection, and ablation studies for system components (including eviction calibration per §19).
+
+### 20.2 Data Models
+
+```python
+class BenchmarkSuite(BaseModel):
+    """A collection of benchmark cases for one agent or skill."""
+    suite_id: str
+    name: str                     # e.g. "planner-decomposition", "shell-skill-v2"
+    target: str                   # Agent or skill identifier being evaluated
+    version: str                  # Suite version (SemVer)
+    cases: list[BenchmarkCase]
+    metadata: dict[str, str]      # Tags: domain, difficulty tier, source
+
+class BenchmarkCase(BaseModel):
+    """A single input→expected-output pair."""
+    case_id: str
+    description: str
+    input: BenchmarkInput
+    expected: BenchmarkExpected
+    tags: list[str]               # ["multi-step", "error-recovery", "edge-case"]
+    difficulty: str               # "easy" | "medium" | "hard" | "adversarial"
+    source: str                   # "synthetic" | "organic" | "regression"
+
+class BenchmarkInput(BaseModel):
+    """Standardized input for a benchmark case."""
+    goal: str                     # Natural language goal / prompt
+    context: list[dict] | None    # Optional pre-loaded context items
+    config_overrides: dict | None # Optional config overrides for this case
+    skill_args: dict | None       # For skill-level benchmarks
+
+class BenchmarkExpected(BaseModel):
+    """Expected outcome definition — supports multiple evaluation modes."""
+    mode: str                     # "exact" | "contains" | "llm_judge" | "metric_threshold" | "human"
+    value: str | dict | None      # Expected value (for exact/contains) or judge criteria
+    metric_thresholds: dict[str, float] | None  # e.g. {"latency_ms": 5000, "token_cost": 1000}
+
+class BenchmarkRun(BaseModel):
+    """A single execution of a suite against a configuration."""
+    run_id: str
+    suite_id: str
+    started_at: datetime
+    completed_at: datetime | None
+    config_snapshot: dict         # Model, prompt version, scorer weights — full reproducibility
+    results: list[BenchmarkResult]
+    summary: BenchmarkSummary | None
+
+class BenchmarkResult(BaseModel):
+    """Result of a single case execution."""
+    case_id: str
+    status: str                   # "pass" | "fail" | "error" | "timeout" | "skipped"
+    actual_output: str | None
+    latency_ms: float
+    token_cost: int               # Total tokens consumed
+    llm_judge_score: float | None # 0.0–1.0 if mode is llm_judge
+    human_label: str | None       # Optional post-hoc human annotation
+    error: str | None
+    retries: int
+
+class BenchmarkSummary(BaseModel):
+    """Aggregate metrics for a run."""
+    pass_rate: float
+    mean_latency_ms: float
+    p95_latency_ms: float
+    total_token_cost: int
+    mean_quality_score: float | None  # Average llm_judge_score where available
+    failure_categories: dict[str, int]  # Error type → count
+```
+
+### 20.3 Per-Agent Benchmark Targets
+
+| Agent | Key Metrics | Example Cases |
+|---|---|---|
+| **Proxy** | Route accuracy, latency, false-positive tool calls | Ambiguous queries, multi-intent messages, adversarial injections |
+| **Planner** | Plan quality (step count, dependency correctness), decomposition accuracy | Multi-step goals, goals requiring parallel execution, under-specified goals |
+| **Executor** | Task completion rate, sandbox escape attempts, verification pass rate | Shell commands, Python execution, error recovery, permission boundaries |
+| **Scorer** | Eviction accuracy (vs. human labels), exclusion prediction, token efficiency | Context windows at various fill levels, mixed-zone content, stale vs. active items |
+
+### 20.4 Per-Skill Benchmarks
+
+Each skill MAY define a `benchmarks/` directory alongside its `SKILL.md`:
+
+```
+skills/
+  shell/
+    SKILL.md
+    benchmarks/
+      suite.json          # BenchmarkSuite definition
+      cases/
+        pipe-chain.json
+        error-recovery.json
+        sudo-boundary.json
+```
+
+Skill benchmarks are loaded by the harness and executed in the skill's sandbox environment. Skills without benchmarks are flagged in quality reports but not blocked.
+
+### 20.5 Regression Detection
+
+**Trigger:** Any change to model config, system prompts, scorer weights, or gate predicates.
+
+**Process:**
+1. Run all affected suites against the new configuration.
+2. Compare against the **baseline run** (last accepted run on `dev`).
+3. Flag regressions: any case that was `pass` → `fail`, or where `llm_judge_score` drops > 0.1, or latency increases > 50%.
+4. Regression report is appended to PR description.
+5. Regressions block merge unless explicitly overridden with `benchmark:accept-regression` label.
+
+**Baseline management:** Each suite stores its last-accepted `BenchmarkRun` as `baseline.json` in the suite directory. Updated on merge to `dev`.
+
+### 20.6 Ablation Study Protocol
+
+For evaluating system changes (eviction calibration §19, prompt tuning, model swaps):
+
+1. **Define variants**: Control (current) + 1–N treatment configurations.
+2. **Select suites**: All suites tagged with the affected component.
+3. **Run each variant** N times (configurable, default 5) to account for LLM non-determinism.
+4. **Statistical comparison**: Mean ± stddev for each metric. Flag significant differences (p < 0.05 where sample size permits).
+5. **Report**: Markdown table comparing variants, auto-generated by `silas benchmark ablation` CLI command.
+
+**Hard rule:** No calibration or tuning change ships without an ablation run showing non-negative impact on the relevant suites.
+
+### 20.7 Dataset Sources
+
+| Source | Description | Privacy |
+|---|---|---|
+| **Synthetic** | Hand-crafted or LLM-generated edge cases | No PII, committed to repo |
+| **Organic** | Anonymized real session logs (goal + outcome pairs) | PII-scrubbed, stored in `data/benchmarks/` (gitignored), requires explicit opt-in |
+| **Regression** | Auto-generated from production failures | Anonymized, tagged with failure category |
+
+### 20.8 Integration with Monitoring (§18.4)
+
+Benchmark results feed into the monitoring pipeline:
+- Suite pass rates exposed as metrics (`silas_benchmark_pass_rate{suite, agent}`)
+- Regression alerts integrate with existing alert channels
+- Ablation reports stored in `data/ablation/` for historical comparison
+
+### 20.9 CLI Interface
+
+```
+silas benchmark run <suite>          # Run a single suite
+silas benchmark run --all            # Run all suites
+silas benchmark compare <run1> <run2> # Compare two runs
+silas benchmark ablation <config1> <config2> [--runs N]
+silas benchmark report <run>         # Generate markdown report
+silas benchmark baseline <run>       # Set run as new baseline
+```

--- a/specs/operations-roadmap.md
+++ b/specs/operations-roadmap.md
@@ -1,0 +1,111 @@
+## 17. Operations & Reliability
+
+### 17.1 Error Handling Strategy
+
+Silas uses a unified error taxonomy with deterministic handling:
+
+- `E_CFG_*` (configuration/startup): fail fast, refuse start
+- `E_LLM_*` (model API, parse, timeout): retry with bounded backoff, then degrade/fallback route
+- `E_DB_*` (SQLite lock/corruption/query): retry transient locks, fail closed on corruption and mark service degraded
+- `E_SANDBOX_*` (executor/verification sandbox): fail current work item as `blocked` or `failed`, never bypass verification
+- `E_GATE_*` (provider failures): policy lane fails closed, quality lane fails open with audit flag
+- `E_CHANNEL_*` (disconnect/timeouts): safe defaults (`decline`/`block`) for pending approvals and card decisions
+- `E_APPROVAL_*` (signature/hash/nonce mismatch): hard deny with audit event
+
+All raised errors must map to one taxonomy code, include correlation IDs (`turn_id`, `work_item_id`, `scope_id`), and emit structured audit + metrics events.
+
+### 17.2 Graceful Shutdown
+
+On `SIGTERM`/`SIGINT`:
+
+1. Stop accepting new channel messages.
+2. Close approval/card intake with safe declines for unresolved prompts.
+3. Let in-flight turns finish up to `shutdown_grace_seconds` (default 30s); then cancel.
+4. Persist in-memory state (`work_items`, scoped context cursors, scheduler state) and write audit checkpoint.
+5. Drain and close WebSocket connections with close code 1001.
+6. Stop scheduler and sandbox workers, then exit.
+
+Crash recovery relies on rehydration from SQLite stores and idempotent approval/execution checks.
+
+### 17.3 Deployment
+
+Supported deployment targets:
+
+- Local/systemd service (single binary + SQLite data dir)
+- Docker Compose (app + optional reverse proxy)
+
+Baseline requirements:
+
+- TLS termination at reverse proxy for remote access
+- periodic backups of `silas.db` + config + skills directories
+- rolling upgrade path: run migrations, verify checksum table, restart with graceful drain
+- explicit host/auth policy: remote bind requires auth token
+
+### 17.4 Monitoring
+
+Expose metrics and structured logs for:
+
+- turn latency (p50/p95/p99), queue depth, active scopes
+- gate actions (`continue`/`block`/`require_approval`) and quality flags
+- approval outcomes and verification failures
+- budget consumption (tokens/cost/time) per work item
+- sandbox failures/timeouts by backend
+- memory growth, chronicle retention, nonce prune counts
+- suggestion acceptance/defer/dismiss rates and cooldown suppressions
+- autonomy calibration stats (correction rates, widen/tighten proposals, applied deltas)
+
+Alerts:
+
+- sustained gate block spikes
+- approval verification failures
+- scorer circuit breaker open
+- queue depth/backpressure thresholds exceeded
+- autonomy proposal spikes or oscillation (repeated widen/tighten churn)
+- DB migration/checksum failures
+
+### 17.5 Rate Limiting
+
+Required limits (configurable):
+
+- inbound WebSocket messages per scope and per IP
+- approval/card submissions per scope
+- LLM calls per minute per scope + global cap
+- web-search calls per minute per scope
+- memory ops per turn and per minute
+- gate evaluations per turn (hard cap)
+- proactive suggestion cards per hour per scope
+- autonomy-threshold proposals per week per scope
+
+Limit violations return deterministic safe responses and are logged as security events.
+
+### 17.6 Backpressure
+
+Backpressure policy protects availability under load:
+
+- per-scope bounded turn queue (`max_pending_turns_per_scope`)
+- global bounded queue (`max_pending_turns_total`)
+- if per-scope queue is full: reject newest message with `busy_retry` response
+- if global queue is full: reject lowest-priority non-owner traffic first
+- long-running background executions publish status without blocking foreground message handling
+
+Queue pressure state is surfaced in `/health` and metrics for autoscaling/operator action.
+
+## 18. Roadmap
+
+Roadmap items intentionally excluded from current implementation scope:
+
+- `R1`: Additional approval strength integrations (for example WebAuthn/passkey enrollment and policy mapping)
+- `R2`: Exact token pre-counting integration path (SDK/provider-backed precise counters)
+- `R3`: Side-session routing and dedicated side-session execution surface
+- `R4`: Memory strategy expansion beyond current set (entity/causal graph traversal)
+- `R5`: Context subscription semantic anchors and enhanced stale-detection semantics
+- `R6`: Optional async gate lane for non-blocking telemetry-only checks
+- `R7`: `WorkItemType.system` orchestration and broader autonomous proposal framework
+- `R8`: Non-essential PWA offline queue/push orchestration enhancements
+- `R9`: Gate model refactor (`Gate`) into discriminated unions for stricter schema ergonomics
+- `R10`: Key-rotation lifecycle (active + next key, rollover window, audit policy)
+- `R11`: Re-evaluate `AgentResponse.needs_approval`; remove if redundant after runtime override hardening
+- `R12`: Personality simplification pass after production telemetry
+- `R13`: Safety-gated dynamic skill context injection (`{{script}}`/command expansion) with read-only execution, strict output caps, taint enforcement, and full audit traces
+- `R14`: Context eviction feedback loop — exclusion-based scorer calibration with ablation validation (§19)
+- `R15`: Agent and skill benchmarking harness — eval suites, regression detection, ablation protocol (§20)


### PR DESCRIPTION
## What

Two new spec sections based on David's design input:

### §19 — Context Eviction Feedback Loop
- **Cheap scorer/heuristic** proposes eviction candidates in background (never burns main LLM tokens)
- **Main LLM** triggers flush when it needs space — doesn't decide what to evict
- At flush time, LLM can **exclude** items from eviction list (keep-backs)
- Exclusions recorded as `EvictionFeedback` → calibration signal for scorer tuning
- **Hard rule: no calibration ships without ablation study** (→ §20)
- Data models: `EvictionProposal`, `EvictionCandidate`, `EvictionFeedback`, `EvictionExclusion`

### §20 — Agent & Skill Benchmarking
- Eval harness with standardized input→output pairs per agent type
- Per-agent metrics: latency, token cost, quality (LLM-as-judge + human), failure rate
- Per-skill benchmarks: each skill can define its own eval suite
- Regression detection: blocks merge if cases regress without explicit override
- Ablation study protocol: control + variants, N runs, statistical comparison
- Dataset sources: synthetic, organic (anonymized), regression (from prod failures)
- CLI: `silas benchmark run/compare/ablation/report/baseline`

### Roadmap
- R14: Eviction feedback loop implementation
- R15: Benchmarking harness implementation