### PR TITLE
feat: onboarding flow — CLI wizard + web endpoint + PWA UI

### DIFF
--- a/config/silas.yaml
+++ b/config/silas.yaml
@@ -1,5 +1,7 @@
 silas:
   owner_id: "owner"
+  agent_name: "Silas"
+  owner_name: ""
   data_dir: "./data"
 
   models:

--- a/silas/config.py
+++ b/silas/config.py
@@ -116,6 +116,8 @@ class StreamConfig(BaseModel):
 
 class SilasSettings(BaseSettings):
     owner_id: str = "owner"
+    agent_name: str = "Silas"
+    owner_name: str = ""
     data_dir: Path = Path("./data")
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,140 @@
+"""Tests for onboarding — CLI (main.py) and web endpoint (web.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+from silas.main import cli
+
+# ---------------------------------------------------------------------------
+# CLI onboarding tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    """Create a minimal silas.yaml with default owner_id."""
+    cfg = tmp_path / "silas.yaml"
+    cfg.write_text(
+        yaml.safe_dump({"silas": {"owner_id": "owner", "data_dir": str(tmp_path / "data")}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_init_skips_when_already_configured(tmp_path: Path) -> None:
+    """If owner_id != 'owner', onboarding is skipped."""
+    cfg = tmp_path / "silas.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {"silas": {"owner_id": "real-user", "agent_name": "Pal", "data_dir": str(tmp_path / "data")}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--config", str(cfg)], input="\n")
+    assert "Already configured" in result.output
+
+
+def test_init_writes_config(config_file: Path) -> None:
+    """Onboarding prompts write agent_name, owner_name, and api_key to YAML."""
+    runner = CliRunner()
+    with patch("silas.main._validate_openrouter_api_key", return_value=True):
+        result = runner.invoke(
+            cli,
+            ["init", "--config", str(config_file)],
+            input="TestBot\nAlice\nsk-fake-key\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    loaded = yaml.safe_load(config_file.read_text())
+    assert loaded["silas"]["agent_name"] == "TestBot"
+    assert loaded["silas"]["owner_name"] == "Alice"
+    assert loaded["silas"]["models"]["api_key"] == "sk-fake-key"
+
+
+def test_init_retries_invalid_key(config_file: Path) -> None:
+    """Invalid API key triggers retry prompt."""
+    runner = CliRunner()
+    with patch("silas.main._validate_openrouter_api_key", side_effect=[False, True]):
+        result = runner.invoke(
+            cli,
+            ["init", "--config", str(config_file)],
+            input="Bot\nBob\nbad-key\ngood-key\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Invalid OpenRouter API key" in result.output
+    loaded = yaml.safe_load(config_file.read_text())
+    assert loaded["silas"]["models"]["api_key"] == "good-key"
+
+
+# ---------------------------------------------------------------------------
+# Web onboarding endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def web_config_file(tmp_path: Path) -> Path:
+    cfg = tmp_path / "silas.yaml"
+    cfg.write_text(
+        yaml.safe_dump({"silas": {"owner_id": "owner"}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+@pytest.fixture
+def web_channel(web_config_file: Path):
+    from silas.channels.web import WebChannel
+
+    return WebChannel(host="127.0.0.1", port=0, config_path=web_config_file)
+
+
+@pytest.mark.anyio
+async def test_onboard_endpoint_success(web_channel, web_config_file: Path) -> None:
+    from fastapi.testclient import TestClient
+
+    with patch.object(web_channel, "_validate_openrouter_key", new_callable=AsyncMock, return_value=True):
+        client = TestClient(web_channel.app)
+        resp = client.post(
+            "/api/onboard",
+            json={"agent_name": "Pal", "api_key": "sk-test", "owner_name": "Tester"},
+        )
+
+    assert resp.status_code == 200
+    loaded = yaml.safe_load(web_config_file.read_text())
+    assert loaded["silas"]["agent_name"] == "Pal"
+    assert loaded["silas"]["models"]["api_key"] == "sk-test"
+
+
+@pytest.mark.anyio
+async def test_onboard_endpoint_invalid_key(web_channel) -> None:
+    from fastapi.testclient import TestClient
+
+    with patch.object(web_channel, "_validate_openrouter_key", new_callable=AsyncMock, return_value=False):
+        client = TestClient(web_channel.app)
+        resp = client.post(
+            "/api/onboard",
+            json={"agent_name": "Pal", "api_key": "bad", "owner_name": "Tester"},
+        )
+
+    assert resp.status_code == 400
+    assert "Invalid" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_onboard_endpoint_blank_name(web_channel) -> None:
+    from fastapi.testclient import TestClient
+
+    client = TestClient(web_channel.app)
+    resp = client.post(
+        "/api/onboard",
+        json={"agent_name": "  ", "api_key": "sk-x", "owner_name": "Tester"},
+    )
+    assert resp.status_code == 422  # Pydantic validation

--- a/web/index.html
+++ b/web/index.html
@@ -345,6 +345,61 @@
 
     <div id="live-region" class="sr-only-live" aria-live="polite" aria-atomic="true"></div>
 
+    <div id="onboarding-overlay" class="onboarding-overlay" hidden>
+      <div class="onboarding-backdrop" aria-hidden="true"></div>
+      <section
+        id="onboarding-card"
+        class="onboarding-card glass-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+      >
+        <p id="onboarding-step-indicator" class="onboarding-step-indicator">Step 1 of 2</p>
+        <form id="onboarding-form" class="onboarding-form">
+          <div id="onboarding-step-1" class="onboarding-step" data-onboarding-step="1">
+            <h2 id="onboarding-title" class="onboarding-title">What should I call myself?</h2>
+            <p class="onboarding-copy">You can change this later.</p>
+            <label for="onboarding-agent-name" class="onboarding-label">Agent name</label>
+            <input
+              id="onboarding-agent-name"
+              class="onboarding-input"
+              type="text"
+              value="Silas"
+              minlength="1"
+              maxlength="64"
+              autocomplete="off"
+            />
+            <div class="onboarding-actions">
+              <button id="onboarding-next-btn" type="button" class="card-cta-primary">Next</button>
+            </div>
+          </div>
+
+          <div
+            id="onboarding-step-2"
+            class="onboarding-step hidden"
+            data-onboarding-step="2"
+            aria-hidden="true"
+          >
+            <h2 class="onboarding-title">OpenRouter API key</h2>
+            <p class="onboarding-copy">Used to validate and enable model access.</p>
+            <label for="onboarding-api-key" class="onboarding-label">API key</label>
+            <input
+              id="onboarding-api-key"
+              class="onboarding-input"
+              type="password"
+              minlength="1"
+              autocomplete="off"
+            />
+            <div class="onboarding-actions">
+              <button id="onboarding-back-btn" type="button" class="card-cta-secondary">Back</button>
+              <button id="onboarding-finish-btn" type="submit" class="card-cta-primary">Finish</button>
+            </div>
+          </div>
+          <p id="onboarding-error" class="onboarding-error" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+    </div>
+
     <script src="/app.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## What

Combined output from two Codex sessions (amber-rook + gentle-breeze), rescued and merged.

### CLI Backend (`silas/main.py`)
- `silas init` now runs interactive onboarding before migrations
- Prompts: agent name (default: Silas), owner name, OpenRouter API key
- API key validated via `httpx.get` to OpenRouter `/api/v1/models`
- Retries on invalid key
- Skips if already configured (owner_id ≠ 'owner')
- Writes to `config/silas.yaml` (keyring migration planned as follow-up)

### Web Backend (`silas/channels/web.py`)
- `POST /api/onboard` endpoint with `OnboardPayload` Pydantic model
- Async OpenRouter key validation
- Writes config to YAML (same approach as CLI, keyring follow-up)
- Blank field validation via Pydantic `field_validator`

### PWA Frontend (`web/index.html` + `web/app.js`)
- Glass card overlay with 2-step flow (agent name → API key)
- Step indicator, back/next navigation
- Error display, busy state management
- localStorage flag to skip on revisit
- Accessible: `role=dialog`, `aria-modal`, `aria-live` error region

### Config (`silas/config.py` + `config/silas.yaml`)
- Added `agent_name: str` and `owner_name: str` to `SilasSettings`

### Tests (6 new)
- CLI: skip-when-configured, config writing, API key retry
- Web: success, invalid key (400), blank name (422)

## Known Limitation
API key is written to `silas.yaml` instead of OS keyring. This is intentional for now — two-tier key storage (§1.5.3) is a separate PR.