### PR TITLE
fix: secret isolation — API keys to SecretStore, not YAML (§0.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Thumbs.db
 
 # Custom skills (user-installed, promote to shipped/ to version)
 silas/skills/custom/*/
+data/.secrets.enc
+*.secrets.enc

--- a/silas/secrets.py
+++ b/silas/secrets.py
@@ -1,0 +1,201 @@
+"""Secret storage with OS keyring primary and encrypted-file fallback.
+
+Implements §0.5 secret isolation: credentials stored via opaque ref_id,
+never in config files or LLM context. Headless environments without a
+system keyring fall back to a Fernet-encrypted JSON file keyed by
+machine-id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+from base64 import urlsafe_b64encode
+from pathlib import Path
+from typing import Protocol
+
+from cryptography.fernet import Fernet, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_NAME = "silas"
+
+
+class SecretBackend(Protocol):
+    """Protocol for pluggable secret backends."""
+
+    def get(self, ref_id: str) -> str | None:
+        """Retrieve a secret by ref_id. Returns None if not found."""
+        ...
+
+    def set(self, ref_id: str, value: str) -> None:
+        """Store a secret under ref_id."""
+        ...
+
+    def delete(self, ref_id: str) -> None:
+        """Remove a secret by ref_id. No-op if absent."""
+        ...
+
+
+class KeyringBackend:
+    """OS keyring via the ``keyring`` library."""
+
+    def get(self, ref_id: str) -> str | None:
+        import keyring  # lazy import — may not be available
+
+        return keyring.get_password(_SERVICE_NAME, ref_id)
+
+    def set(self, ref_id: str, value: str) -> None:
+        import keyring
+
+        keyring.set_password(_SERVICE_NAME, ref_id, value)
+
+    def delete(self, ref_id: str) -> None:
+        import contextlib
+
+        import keyring
+
+        with contextlib.suppress(keyring.errors.PasswordDeleteError):
+            keyring.delete_password(_SERVICE_NAME, ref_id)
+
+
+class EncryptedFileBackend:
+    """Fernet-encrypted JSON file, keyed by machine-id.
+
+    Suitable for headless servers where no system keyring is available.
+    The encryption key is derived from ``/etc/machine-id`` (Linux),
+    ``IOPlatformUUID`` (macOS), or hostname + OS as last resort.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fernet = Fernet(self._derive_key())
+
+    def get(self, ref_id: str) -> str | None:
+        store = self._load()
+        return store.get(ref_id)
+
+    def set(self, ref_id: str, value: str) -> None:
+        store = self._load()
+        store[ref_id] = value
+        self._save(store)
+
+    def delete(self, ref_id: str) -> None:
+        store = self._load()
+        if ref_id in store:
+            del store[ref_id]
+            self._save(store)
+
+    def _load(self) -> dict[str, str]:
+        if not self._path.exists():
+            return {}
+        try:
+            ct = self._path.read_bytes()
+            pt = self._fernet.decrypt(ct)
+            data = json.loads(pt)
+        except (InvalidToken, json.JSONDecodeError, OSError):
+            logger.warning("Encrypted secret store corrupted or unreadable — starting fresh")
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    def _save(self, store: dict[str, str]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        pt = json.dumps(store, sort_keys=True).encode()
+        ct = self._fernet.encrypt(pt)
+        self._path.write_bytes(ct)
+
+    @staticmethod
+    def _derive_key() -> bytes:
+        """Derive a Fernet key from the machine identity.
+
+        Not meant to resist a determined local attacker — just ensures
+        secrets aren't plain-text on disk and can't be read after
+        migrating the data dir to a different machine.
+        """
+        raw = _get_machine_id()
+        # SHA-256 → 32 bytes → url-safe base64 = valid Fernet key
+        digest = hashlib.sha256(raw.encode()).digest()
+        return urlsafe_b64encode(digest)
+
+
+def _get_machine_id() -> str:
+    """Best-effort stable machine identifier."""
+    # Linux: /etc/machine-id
+    machine_id_path = Path("/etc/machine-id")
+    if machine_id_path.exists():
+        mid = machine_id_path.read_text().strip()
+        if mid:
+            return mid
+
+    # macOS: IOPlatformUUID via ioreg
+    if platform.system() == "Darwin":
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            for line in result.stdout.splitlines():
+                if "IOPlatformUUID" in line:
+                    return line.split('"')[-2]
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    # Fallback: hostname + OS (weak but stable)
+    return f"{platform.node()}-{platform.system()}-{os.getuid()}"
+
+
+class SecretStore:
+    """Unified secret store: tries OS keyring, falls back to encrypted file.
+
+    Usage::
+
+        store = SecretStore(data_dir=Path("./data"))
+        store.set("openrouter-api-key", "sk-or-...")
+        key = store.get("openrouter-api-key")
+    """
+
+    def __init__(self, data_dir: Path) -> None:
+        self._backend = self._select_backend(data_dir)
+
+    def get(self, ref_id: str) -> str | None:
+        """Retrieve secret by opaque ref_id."""
+        return self._backend.get(ref_id)
+
+    def set(self, ref_id: str, value: str) -> None:
+        """Store secret under opaque ref_id."""
+        self._backend.set(ref_id, value)
+
+    def delete(self, ref_id: str) -> None:
+        """Delete secret by ref_id."""
+        self._backend.delete(ref_id)
+
+    @property
+    def backend_name(self) -> str:
+        return type(self._backend).__name__
+
+    @staticmethod
+    def _select_backend(data_dir: Path) -> SecretBackend:
+        """Pick OS keyring if available, else encrypted file."""
+        try:
+            import keyring
+            from keyring.backends.fail import Keyring as FailKeyring
+
+            kr = keyring.get_keyring()
+            if not isinstance(kr, FailKeyring):
+                logger.info("Using OS keyring backend: %s", type(kr).__name__)
+                return KeyringBackend()
+        except ImportError:
+            pass
+
+        file_path = data_dir / ".secrets.enc"
+        logger.info("No OS keyring available — using encrypted file backend: %s", file_path)
+        return EncryptedFileBackend(file_path)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from silas.main import cli
+from silas.secrets import SecretStore
 
 # ---------------------------------------------------------------------------
 # CLI onboarding tests
@@ -20,7 +21,10 @@ def config_file(tmp_path: Path) -> Path:
     """Create a minimal silas.yaml with default owner_id."""
     cfg = tmp_path / "silas.yaml"
     cfg.write_text(
-        yaml.safe_dump({"silas": {"owner_id": "owner", "data_dir": str(tmp_path / "data")}}, sort_keys=False),
+        yaml.safe_dump(
+            {"silas": {"owner_id": "owner", "data_dir": str(tmp_path / "data")}},
+            sort_keys=False,
+        ),
         encoding="utf-8",
     )
     return cfg
@@ -41,8 +45,8 @@ def test_init_skips_when_already_configured(tmp_path: Path) -> None:
     assert "Already configured" in result.output
 
 
-def test_init_writes_config(config_file: Path) -> None:
-    """Onboarding prompts write agent_name, owner_name, and api_key to YAML."""
+def test_init_writes_config_and_secret(config_file: Path, tmp_path: Path) -> None:
+    """Onboarding writes agent_name/owner_name to YAML and API key to SecretStore."""
     runner = CliRunner()
     with patch("silas.main._validate_openrouter_api_key", return_value=True):
         result = runner.invoke(
@@ -55,7 +59,14 @@ def test_init_writes_config(config_file: Path) -> None:
     loaded = yaml.safe_load(config_file.read_text())
     assert loaded["silas"]["agent_name"] == "TestBot"
     assert loaded["silas"]["owner_name"] == "Alice"
-    assert loaded["silas"]["models"]["api_key"] == "sk-fake-key"
+    # API key must NOT be in YAML — only a ref_id
+    assert "api_key" not in loaded["silas"].get("models", {})
+    assert loaded["silas"]["models"]["api_key_ref"] == "openrouter-api-key"
+
+    # Verify the key is in SecretStore
+    data_dir = Path(loaded["silas"]["data_dir"])
+    store = SecretStore(data_dir)
+    assert store.get("openrouter-api-key") == "sk-fake-key"
 
 
 def test_init_retries_invalid_key(config_file: Path) -> None:
@@ -71,7 +82,7 @@ def test_init_retries_invalid_key(config_file: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "Invalid OpenRouter API key" in result.output
     loaded = yaml.safe_load(config_file.read_text())
-    assert loaded["silas"]["models"]["api_key"] == "good-key"
+    assert loaded["silas"]["models"]["api_key_ref"] == "openrouter-api-key"
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +94,7 @@ def test_init_retries_invalid_key(config_file: Path) -> None:
 def web_config_file(tmp_path: Path) -> Path:
     cfg = tmp_path / "silas.yaml"
     cfg.write_text(
-        yaml.safe_dump({"silas": {"owner_id": "owner"}}, sort_keys=False),
+        yaml.safe_dump({"silas": {"owner_id": "owner", "data_dir": str(tmp_path / "data")}}, sort_keys=False),
         encoding="utf-8",
     )
     return cfg
@@ -110,7 +121,9 @@ async def test_onboard_endpoint_success(web_channel, web_config_file: Path) -> N
     assert resp.status_code == 200
     loaded = yaml.safe_load(web_config_file.read_text())
     assert loaded["silas"]["agent_name"] == "Pal"
-    assert loaded["silas"]["models"]["api_key"] == "sk-test"
+    # API key must NOT be in YAML
+    assert "api_key" not in loaded["silas"].get("models", {})
+    assert loaded["silas"]["models"]["api_key_ref"] == "openrouter-api-key"
 
 
 @pytest.mark.anyio
@@ -138,3 +151,72 @@ async def test_onboard_endpoint_blank_name(web_channel) -> None:
         json={"agent_name": "  ", "api_key": "sk-x", "owner_name": "Tester"},
     )
     assert resp.status_code == 422  # Pydantic validation
+
+
+# ---------------------------------------------------------------------------
+# SecretStore tests
+# ---------------------------------------------------------------------------
+
+
+def test_secret_store_roundtrip(tmp_path: Path) -> None:
+    """Set, get, delete cycle works with encrypted file backend."""
+    store = SecretStore(tmp_path)
+    assert store.get("test-key") is None
+
+    store.set("test-key", "secret-value")
+    assert store.get("test-key") == "secret-value"
+
+    store.delete("test-key")
+    assert store.get("test-key") is None
+
+
+def test_secret_store_encrypted_file_exists(tmp_path: Path) -> None:
+    """Encrypted file is created on first write."""
+    store = SecretStore(tmp_path)
+    store.set("k", "v")
+    enc_file = tmp_path / ".secrets.enc"
+    assert enc_file.exists()
+    # File content must not contain the plaintext value
+    raw = enc_file.read_bytes()
+    assert b"secret-value" not in raw
+    assert b'"v"' not in raw  # also not the JSON representation
+
+
+def test_secret_store_persists_across_instances(tmp_path: Path) -> None:
+    """A new SecretStore instance reads secrets from the same file."""
+    store1 = SecretStore(tmp_path)
+    store1.set("persistent", "stays")
+
+    store2 = SecretStore(tmp_path)
+    assert store2.get("persistent") == "stays"
+
+
+def test_secrets_endpoint(web_channel) -> None:
+    """POST /secrets/{ref_id} stores secret in SecretStore."""
+    from fastapi.testclient import TestClient
+
+    client = TestClient(web_channel.app)
+    resp = client.post("/secrets/my-ref", json={"value": "my-secret"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ref_id"] == "my-ref"
+    assert data["success"] is True
+
+
+def test_api_key_ref_resolution(tmp_path: Path) -> None:
+    """ModelsConfig.resolve_api_key() resolves ref_id from SecretStore."""
+    from silas.config import ModelsConfig
+
+    store = SecretStore(tmp_path)
+    store.set("openrouter-api-key", "sk-resolved")
+
+    config = ModelsConfig(api_key_ref="openrouter-api-key")
+    assert config.resolve_api_key(data_dir=tmp_path) == "sk-resolved"
+
+
+def test_api_key_ref_fallback_to_direct(tmp_path: Path) -> None:
+    """When ref_id not found, falls back to direct api_key."""
+    from silas.config import ModelsConfig
+
+    config = ModelsConfig(api_key="sk-direct", api_key_ref="missing-ref")
+    assert config.resolve_api_key(data_dir=tmp_path) == "sk-direct"


### PR DESCRIPTION
## Problem

PR #48 wrote API keys directly to `silas.yaml`. This violates §0.5 (secret isolation rule): credentials must go through OS keyring with opaque ref_ids, never in config files or LLM context.

## Fix

### New: `silas/secrets.py` — SecretStore
- **OS keyring primary** (via `keyring` lib) — used when a real backend is available
- **Encrypted file fallback** — Fernet encryption with machine-id-derived key for headless servers
- Auto-selects backend at init (checks for `FailKeyring`)

### New: `POST /secrets/{ref_id}` endpoint
- Per spec: secure credential ingestion that bypasses WebSocket
- Secret never enters agent pipeline

### Changed: Onboarding (CLI + Web)
- API key → `SecretStore.set('openrouter-api-key', key)`
- YAML stores only `api_key_ref: openrouter-api-key` (opaque ref)
- No raw secret values in config files

### Changed: `ModelsConfig`
- New `api_key_ref` field (takes precedence over direct `api_key`)
- `resolve_api_key(data_dir)` resolves ref → SecretStore → fallback
- `inject_api_key_env(data_dir)` wired at config load

### Tests: 12 (was 6)
- SecretStore: roundtrip, encrypted file creation, cross-instance persistence
- Endpoint: `POST /secrets/{ref_id}`
- Resolution: ref_id → SecretStore, fallback to direct api_key
- All existing onboarding tests updated to verify no raw key in YAML