### PR TITLE
feat: Ed25519 approval token signing + verification (§3.6, §5.8)

### DIFF
--- a/silas/approval/__init__.py
+++ b/silas/approval/__init__.py
@@ -1,3 +1,4 @@
 from silas.approval.manager import LiveApprovalManager
+from silas.approval.verifier import SilasApprovalVerifier
 
-__all__ = ["LiveApprovalManager"]
+__all__ = ["LiveApprovalManager", "SilasApprovalVerifier"]

--- a/silas/approval/verifier.py
+++ b/silas/approval/verifier.py
@@ -1,0 +1,213 @@
+"""Ed25519-backed approval token issuer and verifier."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from silas.models.approval import ApprovalDecision, ApprovalScope, ApprovalToken
+from silas.models.work import WorkItem
+from silas.protocols.approval import NonceStore
+
+
+class SilasApprovalVerifier:
+    """Binds approvals to immutable plan content and enforces replay-safe consumption."""
+
+    def __init__(
+        self,
+        signing_key: Ed25519PrivateKey,
+        nonce_store: NonceStore,
+    ) -> None:
+        """Keep signing material local so only canonical payloads can authorize execution."""
+        self._signing_key: Ed25519PrivateKey = signing_key
+        self._public_key: Ed25519PublicKey = signing_key.public_key()
+        self._nonce_store: NonceStore = nonce_store
+
+    async def issue_token(
+        self,
+        work_item: WorkItem,
+        decision: ApprovalDecision,
+        scope: ApprovalScope = ApprovalScope.full_plan,
+    ) -> ApprovalToken:
+        """Mint a signed token so later verification can detect any payload tampering."""
+        plan_hash: str = work_item.plan_hash()
+        token_id: str = uuid4().hex
+        nonce: str = uuid4().hex
+        issued_at: datetime = datetime.now(UTC)
+        expires_at: datetime = issued_at + timedelta(hours=1)
+        max_executions: int = self._resolve_max_executions(decision.conditions)
+        conditions: dict[str, object] = self._resolve_conditions(
+            plan_hash=plan_hash,
+            scope=scope,
+            decision_conditions=decision.conditions,
+        )
+
+        canonical_bytes: bytes = self._canonical_bytes(
+            plan_hash=plan_hash,
+            work_item_id=work_item.id,
+            scope=scope,
+            verdict=decision.verdict,
+            nonce=nonce,
+            approval_strength=decision.approval_strength,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            max_executions=max_executions,
+            conditions=conditions,
+        )
+        signature: bytes = self._signing_key.sign(canonical_bytes)
+
+        return ApprovalToken(
+            token_id=token_id,
+            plan_hash=plan_hash,
+            work_item_id=work_item.id,
+            scope=scope,
+            verdict=decision.verdict,
+            signature=signature,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            nonce=nonce,
+            approval_strength=decision.approval_strength,
+            conditions=conditions,
+            max_executions=max_executions,
+        )
+
+    async def verify(
+        self,
+        token: ApprovalToken,
+        work_item: WorkItem,
+        spawned_task: WorkItem | None = None,
+    ) -> tuple[bool, str]:
+        """Perform consuming verification so each successful authorization is single-use tracked."""
+        is_signature_valid: bool = self._verify_signature(token)
+        if not is_signature_valid:
+            return False, "invalid_signature"
+
+        current_plan_hash: str = work_item.plan_hash()
+        if token.plan_hash != current_plan_hash:
+            return False, "plan_hash_mismatch"
+
+        now: datetime = datetime.now(UTC)
+        if now >= token.expires_at:
+            return False, "token_expired"
+
+        if token.executions_used >= token.max_executions:
+            return False, "execution_limit_reached"
+
+        if token.scope == ApprovalScope.standing:
+            if spawned_task is None:
+                return False, "standing_requires_spawned_task"
+            if spawned_task.parent != token.work_item_id:
+                return False, "standing_parent_mismatch"
+
+        execution_nonce: str = uuid4().hex
+        bound_plan_hash: str = (
+            spawned_task.plan_hash() if spawned_task is not None else current_plan_hash
+        )
+        # Bind replay protection to token + plan context, not just raw nonce bytes.
+        binding_key: str = f"{token.token_id}:{bound_plan_hash}:{execution_nonce}"
+        if await self._nonce_store.is_used("exec", binding_key):
+            return False, "execution_nonce_replay"
+
+        await self._nonce_store.record("exec", binding_key)
+        token.execution_nonces.append(execution_nonce)
+        token.executions_used += 1
+        return True, "ok"
+
+    async def check(self, token: ApprovalToken, work_item: WorkItem) -> tuple[bool, str]:
+        """Validate a previously-consumed token without consuming additional replay state."""
+        is_signature_valid: bool = self._verify_signature(token)
+        if not is_signature_valid:
+            return False, "invalid_signature"
+
+        if token.scope == ApprovalScope.standing:
+            if work_item.parent != token.work_item_id:
+                return False, "standing_parent_mismatch"
+        elif token.plan_hash != work_item.plan_hash():
+            return False, "plan_hash_mismatch"
+
+        now: datetime = datetime.now(UTC)
+        if now >= token.expires_at:
+            return False, "token_expired"
+
+        if token.executions_used < 1:
+            return False, "token_not_consumed"
+        if token.executions_used > token.max_executions:
+            return False, "execution_limit_exceeded"
+        return True, "ok"
+
+    def _verify_signature(self, token: ApprovalToken) -> bool:
+        canonical_bytes: bytes = self._canonical_bytes(
+            plan_hash=token.plan_hash,
+            work_item_id=token.work_item_id,
+            scope=token.scope,
+            verdict=token.verdict,
+            nonce=token.nonce,
+            approval_strength=token.approval_strength,
+            issued_at=token.issued_at,
+            expires_at=token.expires_at,
+            max_executions=token.max_executions,
+            conditions=token.conditions,
+        )
+        try:
+            self._public_key.verify(token.signature, canonical_bytes)
+        except (InvalidSignature, TypeError, ValueError):
+            return False
+        return True
+
+    def _canonical_bytes(
+        self,
+        *,
+        plan_hash: str,
+        work_item_id: str,
+        scope: ApprovalScope,
+        verdict: str,
+        nonce: str,
+        approval_strength: str,
+        issued_at: datetime,
+        expires_at: datetime,
+        max_executions: int,
+        conditions: dict[str, object],
+    ) -> bytes:
+        canonical_payload: dict[str, object] = {
+            "plan_hash": plan_hash,
+            "work_item_id": work_item_id,
+            "scope": scope.value,
+            "verdict": str(verdict),
+            "nonce": nonce,
+            "approval_strength": approval_strength,
+            "issued_at": issued_at.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "max_executions": max_executions,
+            "conditions": conditions,
+        }
+        return json.dumps(canonical_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def _resolve_conditions(
+        self,
+        *,
+        plan_hash: str,
+        scope: ApprovalScope,
+        decision_conditions: dict[str, object],
+    ) -> dict[str, object]:
+        conditions: dict[str, object] = dict(decision_conditions)
+        if scope == ApprovalScope.standing and "spawn_policy_hash" not in conditions:
+            conditions["spawn_policy_hash"] = plan_hash
+        return conditions
+
+    def _resolve_max_executions(self, conditions: dict[str, object]) -> int:
+        raw_max_executions: object | None = conditions.get("max_executions")
+        if isinstance(raw_max_executions, bool):
+            return 1
+        if isinstance(raw_max_executions, int) and raw_max_executions > 0:
+            return raw_max_executions
+        return 1
+
+
+__all__ = ["SilasApprovalVerifier"]

--- a/tests/test_approval_verifier.py
+++ b/tests/test_approval_verifier.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from silas.approval.verifier import SilasApprovalVerifier
+from silas.models.approval import ApprovalDecision, ApprovalScope, ApprovalToken, ApprovalVerdict
+from silas.models.work import WorkItem, WorkItemType
+
+pytestmark = pytest.mark.asyncio
+
+
+class _InMemoryNonceStore:
+    def __init__(self) -> None:
+        self._keys: set[str] = set()
+
+    async def is_used(self, domain: str, nonce: str) -> bool:
+        return f"{domain}:{nonce}" in self._keys
+
+    async def record(self, domain: str, nonce: str) -> None:
+        self._keys.add(f"{domain}:{nonce}")
+
+    async def prune_expired(self, older_than: datetime) -> int:
+        del older_than
+        return 0
+
+
+@pytest.fixture
+def signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def verifier(signing_key: Ed25519PrivateKey) -> SilasApprovalVerifier:
+    return SilasApprovalVerifier(signing_key=signing_key, nonce_store=_InMemoryNonceStore())
+
+
+def _work_item(
+    item_id: str,
+    *,
+    body: str = "Run approval-protected task",
+    parent: str | None = None,
+    item_type: WorkItemType = WorkItemType.task,
+) -> WorkItem:
+    return WorkItem(
+        id=item_id,
+        type=item_type,
+        title=f"Work Item {item_id}",
+        body=body,
+        parent=parent,
+    )
+
+
+def _token_canonical_bytes(token: ApprovalToken) -> bytes:
+    payload: dict[str, object] = {
+        "plan_hash": token.plan_hash,
+        "work_item_id": token.work_item_id,
+        "scope": token.scope.value,
+        "verdict": token.verdict.value,
+        "nonce": token.nonce,
+        "approval_strength": token.approval_strength,
+        "issued_at": token.issued_at.isoformat(),
+        "expires_at": token.expires_at.isoformat(),
+        "max_executions": token.max_executions,
+        "conditions": token.conditions,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _resign(token: ApprovalToken, signing_key: Ed25519PrivateKey) -> ApprovalToken:
+    signature: bytes = signing_key.sign(_token_canonical_bytes(token))
+    return token.model_copy(update={"signature": signature})
+
+
+async def test_issue_and_verify_roundtrip(verifier: SilasApprovalVerifier) -> None:
+    work_item = _work_item("wi-roundtrip")
+    decision = ApprovalDecision(verdict=ApprovalVerdict.approved)
+
+    token = await verifier.issue_token(work_item, decision)
+    valid, reason = await verifier.verify(token, work_item)
+
+    assert valid is True
+    assert reason == "ok"
+    assert token.plan_hash == work_item.plan_hash()
+    assert token.executions_used == 1
+    assert len(token.execution_nonces) == 1
+
+
+async def test_verify_rejects_expired_token(
+    verifier: SilasApprovalVerifier,
+    signing_key: Ed25519PrivateKey,
+) -> None:
+    work_item = _work_item("wi-expired")
+    decision = ApprovalDecision(verdict=ApprovalVerdict.approved)
+    token = await verifier.issue_token(work_item, decision)
+
+    expired_token = token.model_copy(
+        update={"expires_at": datetime.now(UTC) - timedelta(minutes=1)}
+    )
+    expired_token = _resign(expired_token, signing_key)
+
+    valid, reason = await verifier.verify(expired_token, work_item)
+
+    assert valid is False
+    assert reason == "token_expired"
+
+
+async def test_verify_rejects_tampered_plan_hash(verifier: SilasApprovalVerifier) -> None:
+    work_item = _work_item("wi-planhash")
+    decision = ApprovalDecision(verdict=ApprovalVerdict.approved)
+    token = await verifier.issue_token(work_item, decision)
+    tampered_work_item = work_item.model_copy(update={"body": "Tampered plan body"})
+
+    valid, reason = await verifier.verify(token, tampered_work_item)
+
+    assert valid is False
+    assert reason == "plan_hash_mismatch"
+
+
+async def test_verify_consumes_execution_nonce(verifier: SilasApprovalVerifier) -> None:
+    work_item = _work_item("wi-single-use")
+    decision = ApprovalDecision(verdict=ApprovalVerdict.approved)
+    token = await verifier.issue_token(work_item, decision)
+
+    first_valid, first_reason = await verifier.verify(token, work_item)
+    second_valid, second_reason = await verifier.verify(token, work_item)
+
+    assert first_valid is True
+    assert first_reason == "ok"
+    assert second_valid is False
+    assert second_reason == "execution_limit_reached"
+    assert token.executions_used == 1
+    assert len(token.execution_nonces) == 1
+
+
+async def test_check_does_not_consume_nonce(verifier: SilasApprovalVerifier) -> None:
+    work_item = _work_item("wi-check")
+    decision = ApprovalDecision(verdict=ApprovalVerdict.approved)
+    token = await verifier.issue_token(work_item, decision)
+
+    valid_after_verify, reason_after_verify = await verifier.verify(token, work_item)
+    assert valid_after_verify is True
+    assert reason_after_verify == "ok"
+
+    before_nonces = list(token.execution_nonces)
+    before_used = token.executions_used
+
+    check_valid, check_reason = await verifier.check(token, work_item)
+
+    assert check_valid is True
+    assert check_reason == "ok"
+    assert token.execution_nonces == before_nonces
+    assert token.executions_used == before_used
+
+
+async def test_standing_token_multiple_executions(verifier: SilasApprovalVerifier) -> None:
+    goal = _work_item("goal-standing", body="Monitor drift", item_type=WorkItemType.goal)
+    decision = ApprovalDecision(
+        verdict=ApprovalVerdict.approved,
+        conditions={"spawn_policy_hash": "policy-v1", "max_executions": 3},
+    )
+    token = await verifier.issue_token(goal, decision, scope=ApprovalScope.standing)
+
+    spawned_tasks = [
+        _work_item("spawn-1", body="Fix check 1", parent=goal.id),
+        _work_item("spawn-2", body="Fix check 2", parent=goal.id),
+        _work_item("spawn-3", body="Fix check 3", parent=goal.id),
+        _work_item("spawn-4", body="Fix check 4", parent=goal.id),
+    ]
+
+    for spawned_task in spawned_tasks[:3]:
+        valid, reason = await verifier.verify(token, goal, spawned_task=spawned_task)
+        assert valid is True
+        assert reason == "ok"
+
+    final_valid, final_reason = await verifier.verify(token, goal, spawned_task=spawned_tasks[3])
+
+    assert final_valid is False
+    assert final_reason == "execution_limit_reached"
+    assert token.executions_used == 3
+    assert len(token.execution_nonces) == 3


### PR DESCRIPTION
Closes spec compliance gap #2 from audit.

## SilasApprovalVerifier

Implements `ApprovalVerifier` protocol from `silas/protocols/approval.py`:

### `issue_token(work_item, decision, scope)`
- Computes `plan_hash` via `work_item.plan_hash()`
- Builds canonical JSON payload (10 signed fields, sorted keys, compact separators)
- Signs with Ed25519 private key
- Returns fully populated `ApprovalToken`

### `verify(token, work_item, spawned_task=None)`
Consuming verification — checks in order:
1. Ed25519 signature over canonical bytes
2. `plan_hash` matches current `work_item.plan_hash()`
3. Not expired (`now < expires_at`)
4. Execution count not exhausted
5. Standing token: `spawned_task.parent == token.work_item_id`
6. Generate + consume execution nonce via `NonceStore` (binding: `token_id:plan_hash:nonce`)
7. Increment `executions_used`, append to `execution_nonces`

### `check(token, work_item)`
Non-consuming validation:
- Signature, expiry, `1 <= executions_used <= max_executions`
- No nonce consumption

## Tests (6)
- Roundtrip issue → verify
- Expired token rejection
- Tampered plan hash rejection
- Single-use nonce consumption (2nd verify fails)
- Non-consuming check preserves state
- Standing token with `max_executions=3`

Codex-generated, rescued after OOM kill.