### PR TITLE
feat: two-tier key storage — Tier 1 auto-unlock + Tier 2 passphrase

### DIFF
--- a/silas/secrets.py
+++ b/silas/secrets.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Protocol
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 logger = logging.getLogger(__name__)
 
@@ -153,8 +154,81 @@ def _get_machine_id() -> str:
     return f"{platform.node()}-{platform.system()}-{os.getuid()}"
 
 
+class PassphraseBackend:
+    """Fernet-encrypted file keyed by a user-provided passphrase.
+
+    Tier 2 storage: requires explicit user action to unlock.  The
+    passphrase is stretched via PBKDF2-HMAC-SHA256 (600 000 iterations)
+    with a persistent salt.  Used for Ed25519 signing keys and other
+    high-sensitivity material that must not auto-unlock.
+    """
+
+    _ITERATIONS = 600_000
+
+    def __init__(self, path: Path, passphrase: str) -> None:
+        self._path = path
+        self._salt_path = path.with_suffix(".salt")
+        self._fernet = Fernet(self._derive_key(passphrase))
+
+    def get(self, ref_id: str) -> str | None:
+        store = self._load()
+        return store.get(ref_id)
+
+    def set(self, ref_id: str, value: str) -> None:
+        store = self._load()
+        store[ref_id] = value
+        self._save(store)
+
+    def delete(self, ref_id: str) -> None:
+        store = self._load()
+        if ref_id in store:
+            del store[ref_id]
+            self._save(store)
+
+    def _load(self) -> dict[str, str]:
+        if not self._path.exists():
+            return {}
+        try:
+            ct = self._path.read_bytes()
+            pt = self._fernet.decrypt(ct)
+            data = json.loads(pt)
+        except (InvalidToken, json.JSONDecodeError, OSError):
+            logger.warning("Tier-2 store corrupted or wrong passphrase")
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    def _save(self, store: dict[str, str]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        pt = json.dumps(store, sort_keys=True).encode()
+        ct = self._fernet.encrypt(pt)
+        self._path.write_bytes(ct)
+
+    def _derive_key(self, passphrase: str) -> bytes:
+        """PBKDF2 stretch the passphrase into a Fernet key."""
+        import hashlib as _hashlib
+
+        salt = self._load_or_create_salt()
+        dk = _hashlib.pbkdf2_hmac(
+            "sha256", passphrase.encode(), salt, self._ITERATIONS,
+        )
+        return urlsafe_b64encode(dk)
+
+    def _load_or_create_salt(self) -> bytes:
+        if self._salt_path.exists():
+            return self._salt_path.read_bytes()
+        salt = os.urandom(32)
+        self._salt_path.parent.mkdir(parents=True, exist_ok=True)
+        self._salt_path.write_bytes(salt)
+        return salt
+
+
 class SecretStore:
-    """Unified secret store: tries OS keyring, falls back to encrypted file.
+    """Tier 1 — auto-unlock secret store for API keys and service tokens.
+
+    Tries OS keyring, falls back to machine-id-encrypted file.
+    Secrets stored here are accessible without user interaction.
 
     Usage::
 
@@ -199,3 +273,80 @@ class SecretStore:
         file_path = data_dir / ".secrets.enc"
         logger.info("No OS keyring available — using encrypted file backend: %s", file_path)
         return EncryptedFileBackend(file_path)
+
+
+class SigningKeyStore:
+    """Tier 2 — passphrase-protected store for Ed25519 signing keys.
+
+    Requires a user-provided passphrase to unlock.  The passphrase is
+    obtained from (in order):
+
+    1. Explicit ``passphrase`` argument (CLI ``silas start --passphrase``)
+    2. ``SILAS_SIGNING_PASSPHRASE`` environment variable (headless/CI)
+    3. Interactive prompt at startup
+
+    The signing key never leaves this store in plaintext — callers receive
+    an ``Ed25519PrivateKey`` object that stays in process memory only.
+    """
+
+    _PRIVATE_KEY_REF = "ed25519:private"
+    _PUBLIC_KEY_REF = "ed25519:public"
+
+    def __init__(self, data_dir: Path, passphrase: str) -> None:
+        path = data_dir / ".signing.enc"
+        self._backend = PassphraseBackend(path, passphrase)
+
+    def has_keypair(self) -> bool:
+        """Check if a signing keypair exists."""
+        return self._backend.get(self._PRIVATE_KEY_REF) is not None
+
+    def generate_keypair(self) -> str:
+        """Generate and store a new Ed25519 keypair.  Returns public key hex."""
+        import base64
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        private_key = Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+
+        private_raw = private_key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        public_raw = public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
+        self._backend.set(self._PRIVATE_KEY_REF, base64.b64encode(private_raw).decode())
+        self._backend.set(self._PUBLIC_KEY_REF, public_raw.hex())
+        return public_raw.hex()
+
+    def load_private_key(self) -> Ed25519PrivateKey:
+        """Load the Ed25519 private key from the passphrase-protected store."""
+        import base64
+
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        encoded = self._backend.get(self._PRIVATE_KEY_REF)
+        if encoded is None:
+            raise KeyError("no signing key found — run 'silas init' first")
+        raw = base64.b64decode(encoded.encode(), validate=True)
+        return Ed25519PrivateKey.from_private_bytes(raw)
+
+    def get_public_key_hex(self) -> str:
+        """Load the public key hex string."""
+        pub_hex = self._backend.get(self._PUBLIC_KEY_REF)
+        if pub_hex is None:
+            # Derive from private key
+            pk = self.load_private_key()
+            from cryptography.hazmat.primitives import serialization
+
+            raw = pk.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+            return raw.hex()
+        return pub_hex


### PR DESCRIPTION
## Architecture

### Tier 1 — Auto-unlock (existing SecretStore)
API keys, service tokens, connection credentials. Machine unlocks automatically.
- OS keyring primary, machine-id encrypted file fallback
- Used by: onboarding API key, connection setup, `POST /secrets/{ref_id}`

### Tier 2 — User-unlock (new SigningKeyStore)
Ed25519 signing key for approval tokens. **Cannot auto-unlock** — requires explicit passphrase.
- PBKDF2-HMAC-SHA256 (600,000 iterations) + random 32-byte salt
- Fernet encryption of the key store file
- Passphrase resolution: env var `SILAS_SIGNING_PASSPHRASE` → interactive prompt

### Why two tiers?
API keys need to be available at startup without interaction (Tier 1). But the Ed25519 signing key is the security boundary for the entire approval system — if it auto-unlocks, a compromised process could forge approval tokens. Tier 2 ensures the signing key requires human involvement to access.

## Changes

### `silas/secrets.py`
- `PassphraseBackend`: PBKDF2-derived Fernet encryption with persistent salt
- `SigningKeyStore`: `generate_keypair()`, `load_private_key()`, `get_public_key_hex()`, `has_keypair()`

### `silas/main.py`
- `silas init`: prompts for signing passphrase (with confirmation), generates Ed25519 keypair
- `silas start`: resolves passphrase from env/prompt, loads signing key
- `_resolve_signing_passphrase()`: env var → interactive fallback

### Tests (5 new, 17 total in file)
- Roundtrip: generate → load → sign → verify
- Wrong passphrase: can't read back key
- Persistence: same passphrase across instances
- On-disk encryption: no plaintext key material in file
- End-to-end: Tier 2 key → ApprovalVerifier → issue → verify