### PR TITLE
feat: registration gate — first-user onboarding closes registration

### DIFF
--- a/config/silas.yaml
+++ b/config/silas.yaml
@@ -2,6 +2,7 @@ silas:
   owner_id: "owner"
   agent_name: "Silas"
   owner_name: ""
+  registration_open: true
   data_dir: "./data"
 
   models:

--- a/silas/config.py
+++ b/silas/config.py
@@ -132,6 +132,7 @@ class SilasSettings(BaseSettings):
     owner_id: str = "owner"
     agent_name: str = "Silas"
     owner_name: str = ""
+    registration_open: bool = True
     data_dir: Path = Path("./data")
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)

--- a/silas/main.py
+++ b/silas/main.py
@@ -186,6 +186,8 @@ def _write_onboarding_config(
 
     silas_mapping["agent_name"] = agent_name
     silas_mapping["owner_name"] = owner_name
+    # First successful onboarding closes registration until manually reopened.
+    silas_mapping["registration_open"] = False
 
     # Store API key in SecretStore (§0.5 — never in config files)
     data_dir = Path(silas_mapping.get("data_dir", "./data"))

--- a/web/index.html
+++ b/web/index.html
@@ -402,6 +402,17 @@
           <div id="onboarding-step-1" class="onboarding-step" data-onboarding-step="1">
             <h2 id="onboarding-title" class="onboarding-title">What should I call myself?</h2>
             <p class="onboarding-copy">You can change this later.</p>
+            <label for="onboarding-owner-name" class="onboarding-label">Your Name</label>
+            <input
+              id="onboarding-owner-name"
+              class="onboarding-input"
+              type="text"
+              placeholder="Your name"
+              minlength="1"
+              maxlength="64"
+              autocomplete="name"
+              required
+            />
             <label for="onboarding-agent-name" class="onboarding-label">Agent name</label>
             <input
               id="onboarding-agent-name"


### PR DESCRIPTION
## What
Registration gating for first-user onboarding. First user to complete onboarding becomes owner, registration auto-closes.

## Changes
- `registration_open: bool = True` config field on `SilasSettings`
- `GET /api/registration-status` — reads from disk each request (supports manual reopen)
- `POST /api/onboard` — rejects 403 when closed; sets `registration_open: false` after success
- CLI onboarding also closes registration
- Owner name input field added to onboarding step 1
- Frontend fetches registration status before showing overlay
- `_onboarding_lock` serializes concurrent onboard writes

## Tests
4 new tests covering open/closed/post-onboard states

## Review Notes
- Fail-open on config read errors (acceptable: onboarding still requires valid API key)
- String normalization for YAML truthy values is defense-in-depth (Pydantic already coerces)