### PR TITLE
feat: WI-1 Durable Queue Store + Message Types

### DIFF
--- a/silas/queue/router.py
+++ b/silas/queue/router.py
@@ -1,0 +1,67 @@
+"""Queue routing table for the Silas runtime bus.
+
+Maps message_kind to destination queue name per specs/agent-loop-architecture.md
+§2.3. The router is the single source of truth for where each message type goes;
+agents never hard-code queue names directly.
+
+Why a static table instead of dynamic routing: the routing topology is fixed by
+the architecture spec. Dynamic routing would add complexity without benefit and
+make message flow harder to reason about.
+"""
+
+from __future__ import annotations
+
+from silas.queue.store import DurableQueueStore
+from silas.queue.types import QueueMessage
+
+# Why a plain dict: it's the simplest correct representation. The keys are
+# exhaustive over MessageKind (enforced by tests). A class or registry would
+# add abstraction without value.
+ROUTE_TABLE: dict[str, str] = {
+    "plan_request": "planner_queue",
+    "plan_result": "proxy_queue",
+    "execution_request": "executor_queue",
+    "execution_status": "proxy_queue",
+    "research_request": "executor_queue",
+    "research_result": "planner_queue",
+    "planner_guidance": "runtime_queue",
+    "replan_request": "planner_queue",
+    "approval_request": "proxy_queue",
+    "approval_result": "runtime_queue",
+    "user_message": "proxy_queue",
+    "agent_response": "proxy_queue",
+    "system_event": "proxy_queue",
+}
+
+
+class QueueRouter:
+    """Routes messages to the correct queue based on message_kind.
+
+    Thin layer over DurableQueueStore that sets queue_name from the routing
+    table before enqueueing. This keeps routing logic centralized and prevents
+    agents from needing to know queue names.
+    """
+
+    def __init__(self, store: DurableQueueStore) -> None:
+        self._store = store
+
+    async def route(self, msg: QueueMessage) -> None:
+        """Set queue_name from the routing table and enqueue.
+
+        Raises KeyError if message_kind is not in the routing table,
+        which indicates a programming error (unknown message type).
+        """
+        msg.queue_name = ROUTE_TABLE[msg.message_kind]
+        await self._store.enqueue(msg)
+
+    async def route_with_trace(self, msg: QueueMessage, trace_id: str) -> None:
+        """Set trace_id for cross-hop correlation, then route.
+
+        Used when the runtime needs to propagate an existing trace_id
+        to a new message (e.g., plan_request derived from user_message).
+        """
+        msg.trace_id = trace_id
+        await self.route(msg)
+
+
+__all__ = ["ROUTE_TABLE", "QueueRouter"]

--- a/silas/queue/store.py
+++ b/silas/queue/store.py
@@ -1,0 +1,350 @@
+"""SQLite-backed durable queue with lease semantics for crash recovery.
+
+Implements the DurableQueueStore contract from specs/agent-loop-architecture.md
+§2.2. Messages are persisted to SQLite so they survive process restarts.
+Lease-based consumption ensures at-least-once delivery: if a consumer crashes
+mid-processing, the lease expires and another consumer can pick up the message.
+
+Why SQLite: Silas is a single-process runtime. SQLite gives us ACID durability
+without an external broker dependency. The aiosqlite wrapper provides async
+compatibility with the rest of the codebase.
+
+Why a single connection per operation (context manager pattern): matches the
+existing persistence stores (work_item_store, chronicle_store). For the
+expected throughput (<100 msgs/sec), connection-per-op is fine and avoids
+connection lifecycle complexity.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from silas.queue.types import QueueMessage
+
+# Why ISO format with 'T' separator: SQLite stores datetimes as text,
+# and ISO 8601 sorts lexicographically which matters for ORDER BY created_at.
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+
+def _now_utc() -> datetime:
+    """Timezone-aware UTC now."""
+    return datetime.now(UTC)
+
+
+def _dt_to_str(dt: datetime) -> str:
+    """Serialize datetime to ISO 8601 string for SQLite storage."""
+    return dt.strftime(_DATETIME_FORMAT)
+
+
+def _str_to_dt(s: str) -> datetime:
+    """Deserialize ISO 8601 string from SQLite back to datetime."""
+    return datetime.fromisoformat(s)
+
+
+def _row_to_message(row: aiosqlite.Row) -> QueueMessage:
+    """Reconstruct a QueueMessage from a SQLite row.
+
+    Why manual reconstruction instead of model_validate: we need to handle
+    the JSON-encoded payload and datetime string conversions explicitly.
+    """
+    return QueueMessage(
+        id=row["id"],
+        queue_name=row["queue_name"],
+        message_kind=row["message_kind"],
+        sender=row["sender"],
+        trace_id=row["trace_id"],
+        payload=json.loads(row["payload"]),
+        created_at=_str_to_dt(row["created_at"]),
+        lease_id=row["lease_id"],
+        lease_expires_at=_str_to_dt(row["lease_expires_at"]) if row["lease_expires_at"] else None,
+        attempt_count=row["attempt_count"],
+    )
+
+
+class DurableQueueStore:
+    """Persistent message queue backed by SQLite with lease-based consumption.
+
+    Lifecycle: enqueue → lease → (ack | nack) → (dead_letter if max attempts).
+    On startup, call initialize() to create tables and requeue_expired() to
+    recover from any previous crash.
+
+    Each queue is identified by name (e.g., 'proxy_queue', 'planner_queue').
+    Messages are ordered FIFO by created_at within each queue.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def initialize(self) -> None:
+        """Create queue tables if they don't exist.
+
+        Called once on runtime startup. Idempotent via IF NOT EXISTS.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            # Why separate tables for queue_messages vs dead_letters: dead
+            # letters are kept indefinitely for debugging, while queue_messages
+            # are deleted on ack. Mixing them would complicate lease queries.
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS queue_messages (
+                    id TEXT PRIMARY KEY,
+                    queue_name TEXT NOT NULL,
+                    message_kind TEXT NOT NULL,
+                    sender TEXT NOT NULL,
+                    trace_id TEXT NOT NULL,
+                    payload TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    lease_id TEXT,
+                    lease_expires_at TEXT,
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    max_attempts INTEGER NOT NULL DEFAULT 5
+                )
+            """)
+            # Why index on queue_name + lease: the lease query filters by
+            # queue_name and lease state, so this index makes it efficient.
+            await db.execute("""
+                CREATE INDEX IF NOT EXISTS idx_queue_messages_lease
+                ON queue_messages (queue_name, lease_id, lease_expires_at, created_at)
+            """)
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS dead_letters (
+                    id TEXT PRIMARY KEY,
+                    queue_name TEXT NOT NULL,
+                    message_kind TEXT NOT NULL,
+                    sender TEXT NOT NULL,
+                    trace_id TEXT NOT NULL,
+                    payload TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    lease_id TEXT,
+                    lease_expires_at TEXT,
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    max_attempts INTEGER NOT NULL DEFAULT 5,
+                    dead_letter_reason TEXT NOT NULL,
+                    dead_lettered_at TEXT NOT NULL
+                )
+            """)
+            # Why unique constraint on (consumer, message_id): the idempotency
+            # contract (§2.2.1) requires exactly-once processing per consumer.
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS processed_messages (
+                    consumer TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    processed_at TEXT NOT NULL,
+                    PRIMARY KEY (consumer, message_id)
+                )
+            """)
+            await db.commit()
+
+    async def enqueue(self, msg: QueueMessage) -> None:
+        """Insert a message into the queue.
+
+        The message's queue_name must already be set (by the router or caller).
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """INSERT INTO queue_messages
+                   (id, queue_name, message_kind, sender, trace_id, payload,
+                    created_at, lease_id, lease_expires_at, attempt_count, max_attempts)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    msg.id,
+                    msg.queue_name,
+                    msg.message_kind,
+                    msg.sender,
+                    msg.trace_id,
+                    json.dumps(msg.payload),
+                    _dt_to_str(msg.created_at),
+                    None,
+                    None,
+                    msg.attempt_count,
+                    5,
+                ),
+            )
+            await db.commit()
+
+    async def lease(
+        self, queue_name: str, lease_duration_s: int = 60
+    ) -> QueueMessage | None:
+        """Atomically lease the oldest available message from a queue.
+
+        A message is available if it has no lease or its lease has expired.
+        Returns None if no messages are available.
+
+        Why UPDATE+RETURNING instead of SELECT+UPDATE: atomic lease prevents
+        two consumers from grabbing the same message in concurrent scenarios.
+        SQLite serializes writes, so this is safe even with multiple coroutines.
+        """
+        now = _now_utc()
+        now_str = _dt_to_str(now)
+        lease_id = str(uuid.uuid4())
+        expires_str = _dt_to_str(
+            now + __import__("datetime").timedelta(seconds=lease_duration_s)
+        )
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            # Why subquery with MIN(rowid): SQLite doesn't support
+            # UPDATE ... ORDER BY ... LIMIT 1 RETURNING in all versions.
+            # Using a subquery to find the target row is universally supported.
+            cursor = await db.execute(
+                """UPDATE queue_messages
+                   SET lease_id = ?, lease_expires_at = ?
+                   WHERE id = (
+                       SELECT id FROM queue_messages
+                       WHERE queue_name = ?
+                         AND (lease_id IS NULL OR lease_expires_at < ?)
+                       ORDER BY created_at
+                       LIMIT 1
+                   )
+                   RETURNING *""",
+                (lease_id, expires_str, queue_name, now_str),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            await db.commit()
+            return _row_to_message(row)
+
+    async def ack(self, message_id: str) -> None:
+        """Remove a successfully processed message from the queue.
+
+        Per §2.2: ack means the consumer has finished all side effects
+        and called mark_processed. The message is permanently deleted.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("DELETE FROM queue_messages WHERE id = ?", (message_id,))
+            await db.commit()
+
+    async def nack(self, message_id: str) -> None:
+        """Release a message's lease and increment its attempt count.
+
+        The message returns to the queue for another consumer to pick up.
+        If the consumer failed to process it, nack allows retry.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """UPDATE queue_messages
+                   SET lease_id = NULL, lease_expires_at = NULL,
+                       attempt_count = attempt_count + 1
+                   WHERE id = ?""",
+                (message_id,),
+            )
+            await db.commit()
+
+    async def dead_letter(self, message_id: str, reason: str) -> None:
+        """Move a message to the dead letter table.
+
+        Called when a message has exceeded max_attempts or is otherwise
+        unprocessable. Preserves the full message for debugging.
+        """
+        now_str = _dt_to_str(_now_utc())
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT * FROM queue_messages WHERE id = ?", (message_id,)
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return
+            await db.execute(
+                """INSERT INTO dead_letters
+                   (id, queue_name, message_kind, sender, trace_id, payload,
+                    created_at, lease_id, lease_expires_at, attempt_count,
+                    max_attempts, dead_letter_reason, dead_lettered_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    row["id"],
+                    row["queue_name"],
+                    row["message_kind"],
+                    row["sender"],
+                    row["trace_id"],
+                    row["payload"],
+                    row["created_at"],
+                    row["lease_id"],
+                    row["lease_expires_at"],
+                    row["attempt_count"],
+                    row["max_attempts"],
+                    reason,
+                    now_str,
+                ),
+            )
+            await db.execute("DELETE FROM queue_messages WHERE id = ?", (message_id,))
+            await db.commit()
+
+    async def heartbeat(self, message_id: str, extend_s: int = 60) -> None:
+        """Extend a message's lease to prevent expiry during long processing.
+
+        Per §2.2.2: consumers with runs longer than lease_duration/3 must
+        send periodic heartbeats to signal they're still alive.
+        """
+        new_expires = _dt_to_str(
+            _now_utc() + __import__("datetime").timedelta(seconds=extend_s)
+        )
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE queue_messages SET lease_expires_at = ? WHERE id = ?",
+                (new_expires, message_id),
+            )
+            await db.commit()
+
+    async def has_processed(self, consumer: str, message_id: str) -> bool:
+        """Check if a consumer has already processed a message.
+
+        Per §2.2.1: every consumer must check this before executing side
+        effects to ensure exactly-once processing semantics.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM processed_messages WHERE consumer = ? AND message_id = ?",
+                (consumer, message_id),
+            )
+            return await cursor.fetchone() is not None
+
+    async def mark_processed(self, consumer: str, message_id: str) -> None:
+        """Record that a consumer has successfully processed a message.
+
+        Must be called after side effects succeed but before ack, per §2.2.1.
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """INSERT OR IGNORE INTO processed_messages (consumer, message_id, processed_at)
+                   VALUES (?, ?, ?)""",
+                (consumer, message_id, _dt_to_str(_now_utc())),
+            )
+            await db.commit()
+
+    async def pending_count(self, queue_name: str) -> int:
+        """Count unleased messages in a queue. Used for telemetry/monitoring."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """SELECT COUNT(*) FROM queue_messages
+                   WHERE queue_name = ? AND lease_id IS NULL""",
+                (queue_name,),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+
+    async def requeue_expired(self) -> int:
+        """Release all expired leases. Called on startup for crash recovery.
+
+        Any message whose lease has expired is assumed to be from a crashed
+        consumer. We clear the lease so it can be picked up again.
+        Returns the number of messages requeued.
+        """
+        now_str = _dt_to_str(_now_utc())
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """UPDATE queue_messages
+                   SET lease_id = NULL, lease_expires_at = NULL
+                   WHERE lease_id IS NOT NULL AND lease_expires_at < ?""",
+                (now_str,),
+            )
+            count = cursor.rowcount
+            await db.commit()
+            return count
+
+
+__all__ = ["DurableQueueStore"]

--- a/silas/queue/telemetry.py
+++ b/silas/queue/telemetry.py
@@ -1,0 +1,90 @@
+"""Telemetry and audit event schemas for queue operations.
+
+Defines structured event types emitted by the queue infrastructure for
+observability. These are data containers only — the actual emission/storage
+is handled by the telemetry sink (not yet implemented).
+
+Spec reference: §2.4 (QueueTelemetryEvent) and §2.5 (RuntimeAuditEvent).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+def _utc_now() -> datetime:
+    """Timezone-aware UTC now for event timestamps."""
+    return datetime.now(UTC)
+
+
+# Why Literal for event types: these are a closed set defined by the spec.
+# Using Literal catches typos at type-check time and documents the valid values.
+
+QueueEventKind = Literal[
+    "enqueue",
+    "dequeue",
+    "ack",
+    "nack",
+    "dead_letter",
+    "heartbeat",
+    "expired",
+]
+
+AuditEventKind = Literal[
+    "enqueue",
+    "dequeue",
+    "approval",
+    "verify",
+    "check",
+    "gate_block",
+]
+
+
+class QueueTelemetryEvent(BaseModel):
+    """Structured telemetry event emitted by queue operations.
+
+    Used for monitoring queue health: depth, wait times, lease durations.
+    Each event captures a single observable moment in the queue lifecycle.
+
+    Why a flat model with optional detail fields: telemetry events need to be
+    cheap to create and easy to aggregate. Nested structures would complicate
+    metric extraction.
+    """
+
+    queue_name: str
+    event: QueueEventKind
+    message_id: str
+    trace_id: str
+    timestamp: datetime = Field(default_factory=_utc_now)
+    # Why optional detail fields instead of a generic dict: typed fields
+    # enable downstream dashboards to query without JSON parsing.
+    queue_depth: int | None = None
+    wait_ms: float | None = None
+    lease_duration_s: float | None = None
+
+
+class RuntimeAuditEvent(BaseModel):
+    """Audit trail event for security-relevant runtime actions.
+
+    Captures who did what and when for compliance and debugging.
+    Distinct from telemetry: audit events are about authorization
+    and control flow, not performance metrics.
+    """
+
+    event: AuditEventKind
+    trace_id: str
+    agent: str
+    message_id: str
+    timestamp: datetime = Field(default_factory=_utc_now)
+    detail: str | None = None
+
+
+__all__ = [
+    "AuditEventKind",
+    "QueueEventKind",
+    "QueueTelemetryEvent",
+    "RuntimeAuditEvent",
+]

--- a/silas/queue/types.py
+++ b/silas/queue/types.py
@@ -1,0 +1,152 @@
+"""Typed queue message contracts for the Silas runtime bus.
+
+Defines the canonical message envelope and payload types that flow between
+agents (proxy, planner, executor) and the runtime. These mirror the contracts
+in specs/agent-loop-architecture.md §2.1, adapted as Pydantic models for
+validation and serialization.
+
+Why Pydantic instead of dataclasses: the rest of Silas uses Pydantic for
+serialization (work items, context items), so we stay consistent. Pydantic
+also gives us automatic JSON round-tripping for SQLite storage.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Why Literal over Enum for ErrorCode/MessageKind: these are wire-format
+# strings that appear in JSON payloads and SQLite columns. Literal keeps
+# them as plain strings without .value gymnastics.
+
+ErrorCode = Literal[
+    "tool_failure",
+    "budget_exceeded",
+    "gate_blocked",
+    "approval_denied",
+    "verification_failed",
+    "timeout",
+]
+
+MessageKind = Literal[
+    "plan_request",
+    "plan_result",
+    "execution_request",
+    "execution_status",
+    "research_request",
+    "research_result",
+    "planner_guidance",
+    "replan_request",
+    "approval_request",
+    "approval_result",
+    "user_message",
+    "agent_response",
+    "system_event",
+]
+
+Sender = Literal["user", "proxy", "planner", "executor", "runtime"]
+
+
+class ExecutionStatus(enum.StrEnum):
+    """Possible states for a work item execution.
+
+    Maps to the execution_status payload in §2.1. Uses str mixin so
+    enum values serialize as plain strings in JSON/SQLite.
+    """
+
+    running = "running"
+    done = "done"
+    failed = "failed"
+    stuck = "stuck"
+    blocked = "blocked"
+    verification_failed = "verification_failed"
+
+
+class ErrorPayload(BaseModel):
+    """Structured error information attached to failure messages.
+
+    Carried as QueueMessage.payload when an agent or runtime needs to
+    communicate a typed error with retry guidance.
+    """
+
+    error_code: ErrorCode
+    message: str
+    origin_agent: Sender
+    retryable: bool
+    detail: str | None = None
+
+
+class StatusPayload(BaseModel):
+    """Execution status update for a work item.
+
+    Carried as QueueMessage.payload for message_kind='execution_status'.
+    The spec (§2.1) requires status messages to include attempt info.
+    """
+
+    status: ExecutionStatus
+    work_item_id: str
+    attempt: int
+    detail: str | None = None
+
+
+# Why a Union alias: consumers can narrow on the payload type to determine
+# whether they're handling an error vs. a status update, without inspecting
+# message_kind separately.
+QueuePayload = ErrorPayload | StatusPayload
+
+
+def _generate_uuid() -> str:
+    """Generate a new UUID4 string for message IDs."""
+    return str(uuid.uuid4())
+
+
+def _utc_now() -> datetime:
+    """Return current UTC datetime (timezone-aware)."""
+    return datetime.now(UTC)
+
+
+class QueueMessage(BaseModel):
+    """Canonical message envelope for the durable queue bus.
+
+    Every inter-agent communication flows through this type. The runtime
+    serializes it to JSON for SQLite persistence, and deserializes on lease.
+
+    Design rationale:
+    - `id` is auto-generated to guarantee uniqueness (idempotency key).
+    - `trace_id` propagates unchanged across all hops for distributed tracing.
+    - `payload` is dict[str, object] rather than QueuePayload because the
+      store serializes to JSON; consumers cast to the appropriate typed
+      payload based on message_kind.
+    - `lease_id` and `lease_expires_at` are queue infrastructure fields,
+      set by the store during lease operations, not by producers.
+    """
+
+    id: str = Field(default_factory=_generate_uuid)
+    queue_name: str = ""
+    message_kind: MessageKind
+    sender: Sender
+    trace_id: str = Field(default_factory=_generate_uuid)
+    # Why dict[str, object] instead of Any: object is the most permissive
+    # type that still communicates "structured data", and avoids a blanket
+    # Any that would suppress all type checking on consumers.
+    payload: dict[str, object] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    lease_id: str | None = None
+    lease_expires_at: datetime | None = None
+    attempt_count: int = 0
+
+
+__all__ = [
+    "ErrorCode",
+    "ErrorPayload",
+    "ExecutionStatus",
+    "MessageKind",
+    "QueueMessage",
+    "QueuePayload",
+    "Sender",
+    "StatusPayload",
+]

--- a/tests/test_queue_store.py
+++ b/tests/test_queue_store.py
@@ -1,0 +1,278 @@
+"""Tests for the durable queue store, router, and message types.
+
+Covers the full lifecycle, concurrency, crash recovery, and routing
+correctness per specs/agent-loop-architecture.md §2.1-2.5.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+from silas.queue.router import ROUTE_TABLE, QueueRouter
+from silas.queue.store import DurableQueueStore
+from silas.queue.types import (
+    ExecutionStatus,
+    MessageKind,
+    QueueMessage,
+)
+
+
+def _make_msg(
+    kind: MessageKind = "user_message",
+    sender: str = "proxy",
+    queue_name: str = "test_queue",
+) -> QueueMessage:
+    """Helper to create a QueueMessage with sensible defaults."""
+    return QueueMessage(
+        queue_name=queue_name,
+        message_kind=kind,
+        sender=sender,
+    )
+
+
+@pytest.fixture
+async def store(tmp_path: object) -> DurableQueueStore:
+    """Create an initialized DurableQueueStore backed by a temp SQLite DB."""
+    # Why str() cast: tmp_path is a pathlib.Path, but store expects str.
+    db_path = str(tmp_path / "test_queue.db")  # type: ignore[operator]
+    s = DurableQueueStore(db_path)
+    await s.initialize()
+    return s
+
+
+@pytest.fixture
+async def router(store: DurableQueueStore) -> QueueRouter:
+    """Create a QueueRouter wired to the test store."""
+    return QueueRouter(store)
+
+
+class TestFullLifecycle:
+    """Enqueue → lease → ack removes the message permanently."""
+
+    async def test_enqueue_lease_ack(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+
+        leased = await store.lease("test_queue")
+        assert leased is not None
+        assert leased.id == msg.id
+        assert leased.lease_id is not None
+
+        await store.ack(msg.id)
+
+        # Why lease again: confirms the message is truly gone, not just re-leasable.
+        again = await store.lease("test_queue")
+        assert again is None
+
+    async def test_lease_empty_queue_returns_none(self, store: DurableQueueStore) -> None:
+        result = await store.lease("nonexistent_queue")
+        assert result is None
+
+
+class TestLeaseExpiry:
+    """Expired leases allow other consumers to pick up messages."""
+
+    async def test_expired_lease_allows_release(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+
+        # Lease with a very short duration.
+        leased = await store.lease("test_queue", lease_duration_s=1)
+        assert leased is not None
+
+        # Why sleep: we need the lease to actually expire in SQLite's time domain.
+        await asyncio.sleep(1.1)
+
+        # Another consumer should be able to lease the same message.
+        re_leased = await store.lease("test_queue")
+        assert re_leased is not None
+        assert re_leased.id == msg.id
+        # Why different lease_id: proves it's a new lease, not the old one.
+        assert re_leased.lease_id != leased.lease_id
+
+
+class TestNack:
+    """Nack releases the lease and increments attempt_count."""
+
+    async def test_nack_releases_and_increments(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+
+        leased = await store.lease("test_queue")
+        assert leased is not None
+        assert leased.attempt_count == 0
+
+        await store.nack(msg.id)
+
+        # Why lease again: nack should make the message available immediately.
+        re_leased = await store.lease("test_queue")
+        assert re_leased is not None
+        assert re_leased.attempt_count == 1
+        assert re_leased.id == msg.id
+
+
+class TestDeadLetter:
+    """Messages moved to dead_letters are removed from the main queue."""
+
+    async def test_dead_letter_removes_from_queue(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+        await store.lease("test_queue")
+
+        await store.dead_letter(msg.id, reason="max retries exceeded")
+
+        # Why check both: message must be gone from queue AND present in dead_letters.
+        leased = await store.lease("test_queue")
+        assert leased is None
+
+        # Verify it landed in the dead_letters table.
+        import aiosqlite
+
+        async with aiosqlite.connect(store.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM dead_letters WHERE id = ?", (msg.id,))
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row["dead_letter_reason"] == "max retries exceeded"
+
+
+class TestHeartbeat:
+    """Heartbeat extends lease expiry to prevent timeout during long processing."""
+
+    async def test_heartbeat_extends_lease(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+
+        # Lease with short duration so it would expire without heartbeat.
+        leased = await store.lease("test_queue", lease_duration_s=1)
+        assert leased is not None
+
+        # Extend the lease well into the future.
+        await store.heartbeat(msg.id, extend_s=300)
+
+        # Why sleep: proves the original 1s lease would have expired,
+        # but the heartbeat extended it so no one else can lease it.
+        await asyncio.sleep(1.1)
+
+        other = await store.lease("test_queue")
+        # Why None: the heartbeat extended the lease, so no message is available.
+        assert other is None
+
+
+class TestIdempotency:
+    """has_processed / mark_processed ensure exactly-once side effects."""
+
+    async def test_idempotency_lifecycle(self, store: DurableQueueStore) -> None:
+        msg = _make_msg()
+
+        # Why check before mark: this is the exact sequence consumers must follow (§2.2.1).
+        assert await store.has_processed("consumer_a", msg.id) is False
+        await store.mark_processed("consumer_a", msg.id)
+        assert await store.has_processed("consumer_a", msg.id) is True
+
+        # Why different consumer: idempotency is per-consumer, not global.
+        assert await store.has_processed("consumer_b", msg.id) is False
+
+
+class TestStartupRecovery:
+    """requeue_expired clears stale leases from a previous crash."""
+
+    async def test_requeue_expired_clears_stale_leases(
+        self, store: DurableQueueStore
+    ) -> None:
+        msg = _make_msg()
+        await store.enqueue(msg)
+
+        # Lease with short duration and let it expire.
+        await store.lease("test_queue", lease_duration_s=1)
+        await asyncio.sleep(1.1)
+
+        count = await store.requeue_expired()
+        assert count == 1
+
+        # Why lease again: the requeued message should now be available.
+        leased = await store.lease("test_queue")
+        assert leased is not None
+        assert leased.id == msg.id
+        assert leased.lease_id is not None
+
+
+class TestRouting:
+    """All message kinds route to the correct queue per the spec."""
+
+    async def test_all_kinds_route_correctly(
+        self, store: DurableQueueStore, router: QueueRouter
+    ) -> None:
+        for kind, expected_queue in ROUTE_TABLE.items():
+            msg = QueueMessage(
+                message_kind=kind,  # type: ignore[arg-type]
+                sender="runtime",
+            )
+            await router.route(msg)
+            assert msg.queue_name == expected_queue, (
+                f"{kind} should route to {expected_queue}, got {msg.queue_name}"
+            )
+
+    async def test_route_with_trace_sets_trace_id(
+        self, store: DurableQueueStore, router: QueueRouter
+    ) -> None:
+        msg = _make_msg(kind="plan_request")
+        trace = "custom-trace-id-123"
+        await router.route_with_trace(msg, trace_id=trace)
+        assert msg.trace_id == trace
+        assert msg.queue_name == "planner_queue"
+
+
+class TestConcurrentLease:
+    """Two leases on the same queue return different messages."""
+
+    async def test_two_leases_get_different_messages(
+        self, store: DurableQueueStore
+    ) -> None:
+        msg1 = _make_msg()
+        msg2 = _make_msg()
+        await store.enqueue(msg1)
+        await store.enqueue(msg2)
+
+        leased1 = await store.lease("test_queue")
+        leased2 = await store.lease("test_queue")
+
+        assert leased1 is not None
+        assert leased2 is not None
+        # Why set comparison: we don't care about order, just that they're distinct.
+        assert {leased1.id, leased2.id} == {msg1.id, msg2.id}
+
+
+class TestPendingCount:
+    """pending_count reflects only unleased messages."""
+
+    async def test_pending_count_accuracy(self, store: DurableQueueStore) -> None:
+        assert await store.pending_count("test_queue") == 0
+
+        await store.enqueue(_make_msg())
+        await store.enqueue(_make_msg())
+        assert await store.pending_count("test_queue") == 2
+
+        # Leasing one should decrease pending count.
+        await store.lease("test_queue")
+        assert await store.pending_count("test_queue") == 1
+
+
+class TestMessageTypes:
+    """Verify message type construction and enum values."""
+
+    def test_execution_status_values(self) -> None:
+        # Why check all values: ensures the enum matches the spec exactly.
+        expected = {"running", "done", "failed", "stuck", "blocked", "verification_failed"}
+        actual = {s.value for s in ExecutionStatus}
+        assert actual == expected
+
+    def test_queue_message_defaults(self) -> None:
+        msg = QueueMessage(message_kind="user_message", sender="proxy")
+        assert msg.id  # Why: auto-generated UUID should be non-empty.
+        assert msg.trace_id
+        assert msg.attempt_count == 0
+        assert msg.lease_id is None
+        assert isinstance(msg.created_at, datetime)


### PR DESCRIPTION
## What
Implements the queue infrastructure from specs/agent-loop-architecture.md §2.1-2.5.

## Files Created
- `silas/queue/__init__.py` — package init
- `silas/queue/types.py` — QueueMessage, ErrorPayload, StatusPayload, ExecutionStatus, MessageKind
- `silas/queue/store.py` — DurableQueueStore (SQLite + aiosqlite, lease semantics)
- `silas/queue/router.py` — QueueRouter with ROUTE_TABLE mapping message_kind → queue
- `silas/queue/telemetry.py` — QueueTelemetryEvent, RuntimeAuditEvent schemas
- `tests/test_queue_store.py` — 14 tests covering all specified scenarios

## Tests (14)
- Full lifecycle (enqueue→lease→ack)
- Empty queue returns None
- Lease expiry allows re-lease
- Nack releases + increments attempt_count
- Dead letter moves to dead_letters table
- Heartbeat extends lease
- Idempotency (has_processed/mark_processed)
- Startup recovery (requeue_expired)
- All message kinds route correctly
- route_with_trace sets trace_id
- Concurrent leases get different messages
- Pending count accuracy
- ExecutionStatus enum values
- QueueMessage default generation

## Design Decisions
- Used `dict[str, object]` for payload instead of `Any` — communicates structured data without suppressing type checking
- Connection-per-operation pattern (matching work_item_store/chronicle_store)
- Subquery-based atomic lease instead of UPDATE...ORDER BY...LIMIT 1 RETURNING for broader SQLite version compatibility
- Static ROUTE_TABLE dict — routing topology is fixed by spec, no dynamic routing needed