### PR TITLE
feat: implement memory steps 9, 10, 11.5 in turn pipeline

### DIFF
--- a/silas/core/stream.py
+++ b/silas/core/stream.py
@@ -38,7 +38,15 @@ from silas.core.plan_executor import (
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.core.turn_context import TurnContext
 from silas.gates import OutputGateRunner
-from silas.models.agents import AgentResponse, InteractionMode, PlanAction, RouteDecision
+from silas.memory.retriever import SilasMemoryRetriever
+from silas.models.agents import (
+    AgentResponse,
+    InteractionMode,
+    MemoryOp,
+    MemoryOpType,
+    PlanAction,
+    RouteDecision,
+)
 from silas.models.approval import ApprovalScope, ApprovalVerdict
 from silas.models.connections import ConnectionFailure
 from silas.models.context import ContextItem, ContextSubscription, ContextZone
@@ -55,6 +63,7 @@ from silas.models.work import WorkItem, WorkItemStatus, WorkItemType
 from silas.protocols.approval import NonceStore
 from silas.protocols.channels import ChannelAdapterCore
 from silas.protocols.connections import ConnectionManager
+from silas.protocols.memory import MemoryStore
 from silas.protocols.proactivity import AutonomyCalibrator, SuggestionEngine
 from silas.protocols.scheduler import TaskScheduler
 from silas.protocols.work import PlanParser, WorkItemStore
@@ -1108,8 +1117,16 @@ class Stream:
                 turn_number,
             )
 
-            await self._audit("phase1a_noop", step=9, note="memory query processing skipped")
-            await self._audit("phase1a_noop", step=10, note="memory op processing skipped")
+            # Step 9 — execute memory queries the agent requested
+            await self._process_memory_queries(
+                routed.response, signed.taint, session_id, scope_id,
+                cm, turn_number,
+            )
+
+            # Step 10 — execute memory write ops (gated)
+            await self._process_memory_ops(
+                routed.response, signed.taint, session_id, turn_number,
+            )
 
             response_item = ContextItem(
                 ctx_id=f"chronicle:{turn_number}:resp:{uuid.uuid4().hex}",
@@ -1127,7 +1144,10 @@ class Stream:
             if tc.chronicle_store is not None:
                 await tc.chronicle_store.append(scope_id, response_item)
 
-            await self._audit("phase1a_noop", step=11.5, note="raw output ingest skipped")
+            # Step 11.5 — ingest agent output as raw memory for future recall
+            await self._ingest_raw_memory(
+                response_text, TaintLevel.owner, session_id, turn_number,
+            )
             await self.channel.send(connection_id, response_text, reply_to=message.reply_to)
             await self._audit("phase1a_noop", step=14, note="access state updates skipped")
             await self._record_autonomy_outcome(
@@ -1833,6 +1853,155 @@ class Stream:
                 source_kind="conversation_raw",
             ),
         )
+
+    async def _process_memory_queries(
+        self,
+        response: AgentResponse | None,
+        request_taint: TaintLevel,
+        session_id: str,
+        scope_id: str,
+        cm: LiveContextManager | None,
+        turn_number: int,
+    ) -> list[MemoryItem]:
+        """Step 9: run memory queries the agent attached to its response.
+
+        Taint gate: external-tainted contexts must not receive owner-tainted
+        memories, preventing data leakage across trust boundaries.
+        """
+        if response is None or not response.memory_queries:
+            await self._audit("memory_queries_skipped", step=9, reason="no queries")
+            return []
+
+        tc = self._turn_context()
+        memory_store = tc.memory_store
+        if memory_store is None:
+            await self._audit("memory_queries_skipped", step=9, reason="no memory store")
+            return []
+
+        retriever = SilasMemoryRetriever(memory_store)
+        all_results: list[MemoryItem] = []
+
+        for query in response.memory_queries:
+            results = await retriever.retrieve(query, scope_id=scope_id, session_id=session_id)
+
+            # Taint gate: strip owner memories when the request came from
+            # an external context — prevents cross-boundary data leakage.
+            if request_taint == TaintLevel.external:
+                results = [r for r in results if r.taint != TaintLevel.owner]
+
+            all_results.extend(results)
+            await self._audit(
+                "memory_query_executed",
+                step=9,
+                strategy=query.strategy.value,
+                query=query.query,
+                result_count=len(results),
+            )
+
+        # Inject retrieved memories into live context for the next turn.
+        if all_results and cm is not None:
+            for item in all_results:
+                cm.add(scope_id, ContextItem(
+                    ctx_id=f"mem_recall:{turn_number}:{item.memory_id}",
+                    zone=ContextZone.memory,
+                    content=item.content,
+                    token_count=_counter.count(item.content),
+                    created_at=datetime.now(UTC),
+                    turn_number=turn_number,
+                    source="memory:query_result",
+                    taint=item.taint,
+                    kind="memory",
+                ))
+
+        return all_results
+
+    async def _process_memory_ops(
+        self,
+        response: AgentResponse | None,
+        request_taint: TaintLevel,
+        session_id: str,
+        turn_number: int,
+    ) -> None:
+        """Step 10: execute memory write ops the agent requested.
+
+        All ops are gated: external-tainted requests cannot write memories
+        (prevents prompt-injection from persisting attacker content).
+        Store/update/delete each route to the appropriate MemoryStore method.
+        """
+        if response is None or not response.memory_ops:
+            await self._audit("memory_ops_skipped", step=10, reason="no ops")
+            return
+
+        tc = self._turn_context()
+        memory_store = tc.memory_store
+        if memory_store is None:
+            await self._audit("memory_ops_skipped", step=10, reason="no memory store")
+            return
+
+        # Hard gate: external contexts cannot write memories at all.
+        if request_taint == TaintLevel.external:
+            await self._audit(
+                "memory_ops_blocked",
+                step=10,
+                reason="external taint",
+                op_count=len(response.memory_ops),
+            )
+            return
+
+        for op in response.memory_ops:
+            try:
+                await self._execute_single_memory_op(memory_store, op, session_id, turn_number)
+                await self._audit(
+                    "memory_op_executed",
+                    step=10,
+                    op=op.op.value,
+                    memory_id=op.memory_id,
+                )
+            except Exception as exc:
+                await self._audit(
+                    "memory_op_failed",
+                    step=10,
+                    op=op.op.value,
+                    memory_id=op.memory_id,
+                    error=str(exc),
+                )
+
+    async def _execute_single_memory_op(
+        self,
+        memory_store: MemoryStore,
+        op: MemoryOp,
+        session_id: str,
+        turn_number: int,
+    ) -> None:
+        """Dispatch a single memory op to the store."""
+        if op.op == MemoryOpType.store:
+            tc = self._turn_context()
+            await memory_store.store(
+                MemoryItem(
+                    memory_id=f"agent_op:{tc.scope_id}:{turn_number}:{uuid.uuid4().hex}",
+                    content=op.content or "",
+                    memory_type=op.memory_type,
+                    taint=TaintLevel.owner,
+                    semantic_tags=op.tags,
+                    entity_refs=op.entity_refs,
+                    session_id=session_id,
+                    source_kind="agent_memory_op",
+                ),
+            )
+        elif op.op == MemoryOpType.update:
+            assert op.memory_id is not None  # validated by MemoryOp
+            await memory_store.update(op.memory_id, content=op.content)
+        elif op.op == MemoryOpType.delete:
+            assert op.memory_id is not None
+            await memory_store.delete(op.memory_id)
+        elif op.op == MemoryOpType.link:
+            # Link ops update causal_refs — the lightweight graph edge.
+            assert op.memory_id is not None
+            assert op.link_to is not None
+            existing = await memory_store.get(op.memory_id)
+            if existing is not None:
+                new_refs = [*existing.causal_refs, op.link_to]
+                await memory_store.update(op.memory_id, causal_refs=new_refs)
 
     def _take_evicted_context_items(
         self,

--- a/tests/test_memory_steps.py
+++ b/tests/test_memory_steps.py
@@ -1,0 +1,328 @@
+"""Tests for memory steps 9, 10, and 11.5 in the turn pipeline.
+
+Covers: query execution, taint filtering, op gating, op execution,
+and raw output ingest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from silas.core.stream import Stream
+from silas.core.turn_context import TurnContext
+from silas.models.agents import (
+    AgentResponse,
+    InteractionMode,
+    InteractionRegister,
+    MemoryOp,
+    MemoryOpType,
+    MemoryQuery,
+    MemoryQueryStrategy,
+    RouteDecision,
+)
+from silas.models.memory import MemoryItem, MemoryType
+from silas.models.messages import ChannelMessage, TaintLevel
+
+from tests.fakes import (
+    InMemoryAuditLog,
+    InMemoryChannel,
+    InMemoryContextManager,
+    InMemoryMemoryStore,
+    RunResult,
+    sample_memory_item,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(text: str, sender_id: str = "owner") -> ChannelMessage:
+    return ChannelMessage(
+        channel="web",
+        sender_id=sender_id,
+        text=text,
+        timestamp=datetime.now(UTC),
+    )
+
+
+def _stream(
+    channel: InMemoryChannel,
+    turn_context: TurnContext,
+) -> Stream:
+    return Stream(
+        channel=channel,
+        turn_context=turn_context,
+        owner_id="owner",
+        default_context_profile="conversation",
+    )
+
+
+class MemoryQueryModel:
+    """Proxy model that emits memory_queries in its response."""
+
+    def __init__(self, queries: list[MemoryQuery]) -> None:
+        self._queries = queries
+
+    async def run(self, prompt: str) -> RunResult:
+        return RunResult(
+            output=RouteDecision(
+                route="direct",
+                reason="test",
+                response=AgentResponse(
+                    message="response with queries",
+                    memory_queries=self._queries,
+                    needs_approval=False,
+                ),
+                interaction_register=InteractionRegister.status,
+                interaction_mode=InteractionMode.default_and_offer,
+                context_profile="conversation",
+            ),
+        )
+
+
+class MemoryOpModel:
+    """Proxy model that emits memory_ops in its response."""
+
+    def __init__(self, ops: list[MemoryOp]) -> None:
+        self._ops = ops
+
+    async def run(self, prompt: str) -> RunResult:
+        return RunResult(
+            output=RouteDecision(
+                route="direct",
+                reason="test",
+                response=AgentResponse(
+                    message="response with ops",
+                    memory_ops=self._ops,
+                    needs_approval=False,
+                ),
+                interaction_register=InteractionRegister.status,
+                interaction_mode=InteractionMode.default_and_offer,
+                context_profile="conversation",
+            ),
+        )
+
+
+class PlainModel:
+    """Proxy model that returns a plain response (no queries/ops)."""
+
+    def __init__(self, message: str = "plain response") -> None:
+        self._message = message
+
+    async def run(self, prompt: str) -> RunResult:
+        return RunResult(
+            output=RouteDecision(
+                route="direct",
+                reason="test",
+                response=AgentResponse(
+                    message=self._message,
+                    needs_approval=False,
+                ),
+                interaction_register=InteractionRegister.status,
+                interaction_mode=InteractionMode.default_and_offer,
+                context_profile="conversation",
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — Memory query execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_step9_memory_queries_executed() -> None:
+    """Memory queries from the agent response should hit the store and be audited."""
+    store = InMemoryMemoryStore()
+    # Seed a memory that matches the keyword query.
+    await store.store(sample_memory_item("mem-1", "the capital of France is Paris"))
+
+    queries = [MemoryQuery(strategy=MemoryQueryStrategy.keyword, query="France")]
+    model = MemoryQueryModel(queries)
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+
+    await stream._process_turn(_msg("hello"), "conn-1")
+
+    # Verify the query was executed — audit should contain the event.
+    query_events = [e for e in audit.events if e["event"] == "memory_query_executed"]
+    assert len(query_events) == 1
+    assert query_events[0]["data"]["result_count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_step9_taint_filters_owner_memories() -> None:
+    """External-tainted requests must not receive owner-tainted memories."""
+    store = InMemoryMemoryStore()
+    # Owner-tainted memory should be filtered out.
+    owner_mem = sample_memory_item("mem-owner", "secret owner data about cats")
+    await store.store(owner_mem)
+
+    # Also store an external-tainted memory that should pass through.
+    ext_mem = MemoryItem(
+        memory_id="mem-ext",
+        content="public info about cats",
+        memory_type=MemoryType.fact,
+        taint=TaintLevel.external,
+        source_kind="conversation_raw",
+    )
+    await store.store(ext_mem)
+
+    queries = [MemoryQuery(strategy=MemoryQueryStrategy.keyword, query="cats")]
+    model = MemoryQueryModel(queries)
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+    # External sender triggers external taint classification.
+    stream.owner_id = "owner"
+
+    await stream._process_turn(_msg("tell me about cats", sender_id="stranger"), "conn-1")
+
+    query_events = [e for e in audit.events if e["event"] == "memory_query_executed"]
+    assert len(query_events) == 1
+    # Owner-tainted memories must be excluded; step 3.5's raw ingest also
+    # matches "cats" with external taint, so >=1 non-owner results pass.
+    result_count = query_events[0]["data"]["result_count"]
+    assert result_count >= 1
+    # The seeded owner memory must NOT be in the results — verify the count
+    # is less than total "cats" matches (which includes the owner one).
+    all_cats = await store.search_keyword("cats", limit=10)
+    owner_cats = [i for i in all_cats if i.taint == TaintLevel.owner]
+    assert len(owner_cats) >= 1, "sanity: owner memory exists"
+    assert result_count == len(all_cats) - len(owner_cats)
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — Memory op execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_step10_memory_ops_executed() -> None:
+    """Memory store ops from the agent are executed when owner-tainted."""
+    store = InMemoryMemoryStore()
+    ops = [
+        MemoryOp(op=MemoryOpType.store, content="remember this fact", memory_type=MemoryType.fact),
+    ]
+    model = MemoryOpModel(ops)
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+
+    await stream._process_turn(_msg("store something"), "conn-1")
+
+    op_events = [e for e in audit.events if e["event"] == "memory_op_executed"]
+    assert len(op_events) == 1
+    # The fact should be in the store.
+    agent_items = [i for i in store.items.values() if i.source_kind == "agent_memory_op"]
+    assert len(agent_items) == 1
+    assert agent_items[0].content == "remember this fact"
+
+
+@pytest.mark.asyncio
+async def test_step10_memory_ops_blocked_for_external() -> None:
+    """External-tainted requests must not be allowed to write memories."""
+    store = InMemoryMemoryStore()
+    ops = [
+        MemoryOp(op=MemoryOpType.store, content="injected content", memory_type=MemoryType.fact),
+    ]
+    model = MemoryOpModel(ops)
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+    stream.owner_id = "owner"
+
+    await stream._process_turn(_msg("inject this", sender_id="attacker"), "conn-1")
+
+    blocked_events = [e for e in audit.events if e["event"] == "memory_ops_blocked"]
+    assert len(blocked_events) == 1
+    # Nothing should have been stored.
+    agent_items = [i for i in store.items.values() if i.source_kind == "agent_memory_op"]
+    assert len(agent_items) == 0
+
+
+@pytest.mark.asyncio
+async def test_step10_delete_op() -> None:
+    """Delete ops should remove items from the store."""
+    store = InMemoryMemoryStore()
+    await store.store(sample_memory_item("mem-del", "to be deleted"))
+    assert await store.get("mem-del") is not None
+
+    ops = [MemoryOp(op=MemoryOpType.delete, memory_id="mem-del")]
+    model = MemoryOpModel(ops)
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+
+    await stream._process_turn(_msg("delete that"), "conn-1")
+
+    assert await store.get("mem-del") is None
+
+
+# ---------------------------------------------------------------------------
+# Step 11.5 — Raw output ingest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_step11_5_output_ingested_as_raw_memory() -> None:
+    """The agent's response text should be stored as a raw memory item."""
+    store = InMemoryMemoryStore()
+    model = PlainModel(message="I will remember this response")
+    audit = InMemoryAuditLog()
+    channel = InMemoryChannel()
+    tc = TurnContext(
+        scope_id="owner",
+        context_manager=InMemoryContextManager(),
+        memory_store=store,
+        proxy=model,
+        audit=audit,
+    )
+    stream = _stream(channel, tc)
+
+    await stream._process_turn(_msg("say something"), "conn-1")
+
+    # There should be raw items: one for input (step 3.5) and one for output (step 11.5).
+    raw_items = [i for i in store.items.values() if i.source_kind == "conversation_raw"]
+    # At least the output should be there.
+    output_raws = [i for i in raw_items if "I will remember this response" in i.content]
+    assert len(output_raws) == 1
+    assert output_raws[0].taint == TaintLevel.owner

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -508,9 +508,10 @@ async def test_process_turn_stores_raw_memory_with_session_id(
         item for item in memory_store.items.values()
         if item.source_kind == "conversation_raw"
     ]
-    assert len(raw_items) == 1
-    assert raw_items[0].session_id == stream.session_id
-    assert raw_items[0].session_id is not None
+    # Step 3.5 ingests input, step 11.5 ingests output — expect 2.
+    assert len(raw_items) == 2
+    assert all(item.session_id == stream.session_id for item in raw_items)
+    assert all(item.session_id is not None for item in raw_items)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replaces phase1a_noop stubs with real implementations.

- Step 9: memory queries executed via SilasMemoryRetriever, taint gate filters owner memories from external contexts
- Step 10: memory ops dispatched to MemoryStore, hard gate blocks external-tainted writes
- Step 11.5: agent response ingested as raw memory (owner taint)
- 6 new tests, all 757 passing, ruff clean