### PR TITLE
refactor: unify output gates into SilasGateRunner two-lane model

### DIFF
--- a/reports/gap-review-2026-02-13.md
+++ b/reports/gap-review-2026-02-13.md
@@ -1,0 +1,308 @@
+# Silas Runtime — Gap Review 2026-02-13
+
+**Reviewer:** Silas (self-audit)  
+**Scope:** specs.md, specs/*.md, ARCHITECTURE.md, STATUS.md vs actual code in silas/, tests/, config/  
+**Verdict:** The project has solid foundations but STATUS.md significantly overstates completion. The queue system exists but isn't wired end-to-end. Several security invariants are partially enforced. Multiple spec sections have zero implementation.
+
+---
+
+## 1. Executive Summary
+
+**Overall health: 55-60% of spec implemented. Core scaffolding is real; the autonomous loop is not.**
+
+The project has ~20K lines of Python across ~130 modules and ~14K lines of tests (~690 tests). The approval engine, gate system, work item executor, context manager, memory store, and basic agents are implemented and tested. The queue infrastructure (WI-1 through WI-4) exists as code but the integration is shallow — the `QueueBridge.collect_response()` polls proxy_queue by leasing *any* message and nacking non-matches, which is O(n) in queue depth and will break under concurrent traces.
+
+**Biggest risks:**
+1. **Queue integration is a facade.** STATUS.md marks WI-1 through WI-4 as "✅ Done" but agents still run as one-shot structured output in the main path. The queue bridge is a thin wrapper that doesn't actually run agents through the queue loop in production.
+2. **Memory steps 9-10 are no-ops.** The Stream logs `phase1a_noop` for memory query processing and memory op processing. The agent's `memory_queries` and `memory_ops` are never executed post-response.
+3. **No taint propagation system.** INV-05 claims "taint propagation remains outside agent control" but there is no taint tracker in the codebase. Taint is set on messages and memory items but never propagated through tool call chains.
+4. **Spec uses `pynacl` but code uses `cryptography` library.** The Ed25519 implementation works but diverges from the stated dependency.
+
+---
+
+## 2. Spec vs Code Matrix
+
+### 2.1 Core Turn Pipeline (specs.md §5.1)
+
+| Step | Spec | Code Status | Notes |
+|------|------|-------------|-------|
+| 0. Precompile gates | Required | ✅ Implemented | `_precompile_active_gates()` |
+| 0.5 Review/proactive queue | Required | ⚠️ Partial | Suggestions collected, but batch reviews, draft reviews, connection warnings not polled |
+| 1. Input gates | Two-lane | ✅ Implemented | Policy + quality lanes, approval flow |
+| 2. Sign/taint | Ed25519 + nonce | ✅ Implemented | But Stream self-signs inbound messages (signs its own input), which is architecturally wrong — the spec envisions the *client* signing |
+| 3. Chronicle | Required | ✅ Implemented | |
+| 3.5 Raw memory ingest | Required | ✅ Implemented | |
+| 4. Auto-retrieve memories | Required | ✅ Implemented | Keyword + entity mention matching |
+| 5. Budget enforcement | Two-tier eviction | ⚠️ Partial | Heuristic eviction exists, scorer model (tier 2) not implemented |
+| 6. Build toolset pipeline | Wrapper chain | ⚠️ Partial | Tools exist but full SkillToolset→PreparedToolset→FilteredToolset→ApprovalRequired chain is declared, not fully wired in Stream |
+| 6.5 Skill-aware toolsets | Required | 🔴 Stub | Logged as `phase1a_noop` |
+| 7. Proxy + personality | Required | ⚠️ Partial | Proxy runs, personality engine exists, but directive injection into system zone not confirmed in turn pipeline |
+| 8. Output gates | Two-lane | ⚠️ Partial | Output gate runner exists but uses a separate `OutputGateRunner` class, not the same two-lane `SilasGateRunner` |
+| 9. Memory queries | Required | 🔴 No-op | Logged as `phase1a_noop` |
+| 10. Memory ops (gated) | Required | 🔴 No-op | Logged as `phase1a_noop` |
+| 11. Response chronicle | Required | ✅ Implemented | |
+| 11.5 Raw output ingest | Required | 🔴 No-op | Logged as `phase1a_noop` |
+| 12. Plan/approval flow | Required | ✅ Implemented | Planner route + skill execution + approval |
+
+### 2.2 Agent Loop Architecture (specs/agent-loop-architecture.md)
+
+| Component | Spec | Code Status | Notes |
+|-----------|------|-------------|-------|
+| DurableQueueStore | §2.2 | ✅ Implemented | SQLite-backed, lease/ack/nack/dead-letter, heartbeat |
+| QueueMessage types | §2.1 | ⚠️ Divergent | Code uses Pydantic `QueueMessage` with `dict[str,object]` payload, not the typed `StatusPayload`/`ErrorPayload` from spec. Missing fields: `scope_id`, `taint`, `task_id`, `parent_task_id`, `work_item`, `plan_markdown`, `approval_token`, `artifacts`, `constraints`, `urgency` |
+| Queue routing | §2.3 | ✅ Implemented | `QueueRouter` with routing table |
+| Proxy consumer | §3 | ⚠️ Partial | `ProxyConsumer` exists but doesn't use `ContextManager.render()` for history — it passes raw prompt to agent |
+| Planner consumer | §4 | ⚠️ Partial | `PlannerConsumer` exists but research state machine (§4.8: planning→awaiting_research→ready_to_finalize→expired) not implemented |
+| Executor consumer | §5 | ⚠️ Partial | `ExecutorConsumer` exists but research mode enforcement is prompt-based ("RESEARCH MODE" prefix) not toolset-level (`RESEARCH_TOOL_ALLOWLIST` clamping) |
+| Consult-planner | §5.2.1 on_stuck | ⚠️ Exists | `ConsultManager` in queue/consult.py, but not wired into executor retry loop |
+| Replan cascade | §4.6.1 | ⚠️ Exists | `ReplanManager` in queue/replan.py, but not wired into execution failure path |
+| Telemetry events | §2.4 | ⚠️ Exists | `QueueTelemetryEvent` schema defined but telemetry emission points not wired |
+| Audit events | §2.5 | ⚠️ Partial | Audit events logged throughout Stream but not using `RuntimeAuditEvent` schema from spec |
+| QueueOrchestrator | Needed | ✅ Implemented | Consumer lifecycle management with backoff |
+| QueueBridge | Integration | ⚠️ Fragile | `collect_response` leases any proxy_queue message, nacks non-matches — O(n) and racy |
+
+### 2.3 Data Models (specs/models.md)
+
+| Model | Spec | Code Status |
+|-------|------|-------------|
+| ChannelMessage, SignedMessage, TaintLevel | §3.1 | ✅ |
+| AgentResponse, RouteDecision, PlanAction | §3.2 | ✅ |
+| WorkItem, Budget, BudgetUsed, Expectation | §3.3 | ✅ |
+| VerificationCheck, EscalationAction | §3.3 | ✅ |
+| ApprovalToken, ApprovalDecision | §3.6 | ✅ |
+| ContextItem, ContextZone, ContextSubscription | §3.7 | ✅ |
+| MemoryItem, MemoryQuery, MemoryOp | §3.4 | ✅ |
+| Gate, GateResult, GateConfig | §3.5 | ✅ |
+| PersonalityAxes, MoodState | §3.8 | ✅ |
+| BatchProposal, DraftVerdict, DecisionOption | §3.9-3.10 | ✅ |
+| SuggestionProposal, AutonomyThresholdProposal | §3.11 | ✅ |
+| ConnectionPermission, AuthStrategy | §3.12 | ✅ |
+| UndoAction | §0.5.5 | ✅ (model exists) |
+
+### 2.4 Protocols (specs/protocols.md)
+
+| Protocol | Spec | Implementation | Notes |
+|----------|------|----------------|-------|
+| ChannelAdapterCore | §4.1 | ✅ WebChannel | |
+| RichCardChannel | §4.1.1 | ✅ WebChannel | Most methods implemented |
+| MemoryStore | §4.2 | ✅ SQLiteMemoryStore | |
+| MemoryRetriever | §4.2.1 | ✅ SilasMemoryRetriever | |
+| MemoryConsolidator | §4.2.2 | ✅ SilasMemoryConsolidator | |
+| MemoryPortability | §4.2.3 | 🔴 Protocol only | No implementation of export_bundle/import_bundle |
+| ContextManager | §4.3 | ✅ LiveContextManager | |
+| ApprovalVerifier | §4.4 | ✅ SilasApprovalVerifier | |
+| NonceStore | §4.5 | ✅ SQLiteNonceStore | |
+| EphemeralExecutor | §4.6 | ✅ ShellExecutor, PythonExecutor | |
+| SandboxManager | §4.7 | ✅ SubprocessSandboxManager | No Docker backend |
+| GateCheckProvider | §4.8 | ✅ PredicateChecker, ScriptChecker | |
+| GateRunner | §4.9 | ✅ SilasGateRunner | |
+| VerificationRunner | §4.10 | ✅ | |
+| AccessController | §4.11 | ✅ SilasAccessController | |
+| WorkItemExecutor | §4.12 | ✅ LiveWorkItemExecutor | |
+| WorkItemStore | §4.13 | ✅ SQLiteWorkItemStore | |
+| ChronicleStore | §4.14 | ✅ SQLiteChronicleStore | |
+| PlanParser | §4.15 | ✅ MarkdownPlanParser | |
+| PersonalityEngine | §4.16 | ✅ SilasPersonalityEngine | |
+| Scheduler | §4.17 | ✅ SilasScheduler (APScheduler) | |
+
+---
+
+## 3. Security Invariants — Code Path Tracing
+
+### INV-01: Executable actions require cryptographically verified approval tokens (Ed25519)
+
+**Status: ✅ Enforced**
+
+Code path: `LiveWorkItemExecutor._execute_single()` → `_check_execution_approval()` → `ApprovalVerifier.check()` → signature verification via `cryptography.hazmat.primitives.asymmetric.ed25519`. Without a valid token, execution returns `blocked` status.
+
+**Caveat:** The spec says `pynacl` (libsodium) but code uses `cryptography` library. Functionally equivalent but a dependency divergence.
+
+### INV-02: Approval tokens are content-bound and replay-protected
+
+**Status: ✅ Enforced**
+
+`SilasApprovalVerifier.verify()` checks: signature validity → plan_hash binding → expiry → execution count → nonce domain binding (`exec:{token_id}:{plan_hash}:{nonce}`). Standing token verification checks `spawned_task.parent == token.work_item_id`.
+
+`SilasApprovalVerifier.check()` (non-consuming) validates: signature → plan_hash → expiry → `1 <= executions_used <= max_executions`.
+
+### INV-03: Completion truth is external deterministic verification
+
+**Status: ✅ Enforced**
+
+`LiveWorkItemExecutor._execute_single()` runs `_run_external_verification()` after successful execution attempt. Uses `VerificationRunner.run_checks()` which runs checks outside the agent's sandbox. Agent cannot influence verification.
+
+**Caveat:** If no verification checks are defined (`work_item.verify` is empty), verification is skipped and execution is marked as done. This is by design per spec but worth noting — work items without verification checks bypass INV-03.
+
+### INV-04: Policy gates run deterministically; quality gates are advisory
+
+**Status: ✅ Enforced**
+
+`SilasGateRunner.check_gates()` evaluates policy-lane gates first (can block/require_approval), then quality-lane gates (always return `action="continue"`, mutations ignored). Quality gate actions are overridden in `_normalize_quality_result()`. Mutation allowlist (`ALLOWED_MUTATIONS`) enforced in `_sanitize_policy_mutation()`.
+
+### INV-05: Execution isolation and taint propagation remain outside agent control
+
+**Status: ⚠️ Partially enforced**
+
+- **Execution isolation:** ✅ `SubprocessSandboxManager` creates isolated working directories, sets resource limits (memory, CPU), blocks network via `unshare -n`, blocks `bash -c` shell injection. Each sandbox gets a tempdir that's destroyed on cleanup.
+- **Taint propagation:** 🔴 **Not implemented.** There is no `TaintTracker` class. Taint is assigned at message ingestion (`owner`/`auth`/`external`) and stored on `MemoryItem` and `ContextItem`, but there is no mechanism to propagate taint through tool call chains or data flows. If an external-tainted message produces a tool result, that result's taint is not automatically set to `external`.
+
+### INV-06: Skill activation requires deterministic validation, approval, and hash-bound versioning
+
+**Status: ⚠️ Partial**
+
+- Skill validation: `SkillValidator` exists in `silas/skills/validator.py`
+- Skill approval: Wired in Stream via `ApprovalFlow.request_skill_approval()`
+- Hash-bound versioning: Not confirmed — no evidence of content-hash tracking on installed skills
+
+---
+
+## 4. Dead Specs (Zero Code Backing)
+
+| Spec Section | Description | Status |
+|---|---|---|
+| §0.5.1 Three persistent UI surfaces (Stream/Review/Activity) | Frontend surfaces described in detail | Frontend exists but the Review and Activity surfaces as distinct decision cockpit surfaces are not confirmed as separate implementations |
+| §0.5.2 Risk ladder (low/medium/high/irreversible interaction patterns) | Slide-to-confirm, biometric auth | No UI interaction pattern enforcement — approval is binary tap |
+| §0.5.3 Card contract (max height, details expansion rules) | Enforced card anatomy | No card rendering enforcement in code |
+| §0.5.4 Approval fatigue mitigation (cadence tracking, queue density cues) | Tracking median decision time | No implementation of approval cadence tracking |
+| §0.5.5 Undo/recover pattern | 5-minute undo window, reverse action log | `UndoAction` model exists, but no undo execution logic found |
+| §0.5.6 UX quality metrics | Decision time, taps per batch, decline rate etc. | No metrics collection |
+| §2.5 Connection framework lifecycle | Connections as skills, health checks, token refresh | `ConnectionManager` protocol exists, no concrete lifecycle implementation found in code |
+| §4.2.3 MemoryPortability | export_bundle/import_bundle | Protocol defined, zero implementation |
+| §5.7 Two-tier eviction (scorer model) | Heuristic + scorer model eviction | Heuristic tier exists, scorer model tier not implemented |
+| §9 Docker sandbox backend | Optional Docker isolation | No Docker integration in codebase |
+| §10.4/10.4.1 Skill import/adaptation | External skill normalization, transformation report | No implementation |
+| §5.10.1 Secure-input endpoint | `POST /secrets/{ref_id}` bypassing WebSocket | `_SecretPayload` model in web.py suggests partial, but full flow unconfirmed |
+| Guardrails-AI integration | `guardrails-ai` as gate provider | Only referenced in `models/gates.py` as a `GateProvider` enum value; no actual guardrails-ai library integration |
+| Planner research state machine | §4.8: planning→awaiting_research→ready_to_finalize→expired | Not implemented |
+| Autonomy threshold proposals | §5.1.6 | Model + protocol exists, no calibration logic |
+
+---
+
+## 5. Undocumented Code
+
+| Code | Description | Spec Coverage |
+|------|-------------|---------------|
+| `silas/manual_harness.py` (602 lines) | Manual testing harness | Not in any spec |
+| `silas/stubs.py` | In-memory stubs for testing | Not spec'd (reasonable) |
+| `silas/core/plan_executor.py` | Plan action execution, skill work item building | Implements spec logic but file not mentioned in project structure |
+| `silas/core/approval_flow.py` | Approval flow management | Not in project structure spec |
+| `silas/queue/bridge.py` | Queue-to-Stream integration bridge | Not in agent-loop-architecture spec |
+| `silas/queue/status_router.py` | Status event routing to surfaces | Implements §6.3 but file not in spec project structure |
+| `silas/queue/consult.py` | Consult-planner manager | Implements spec concept but file not in project structure |
+| `silas/gates/output.py` | OutputGateRunner | Separate from SilasGateRunner — spec says one runner for both |
+| `silas/proactivity/ux_metrics.py` | UX metrics collection stubs | Exists but likely empty/minimal |
+| `silas/tools/backends.py` | Tool backend abstractions | Not spec'd |
+
+---
+
+## 6. Test Coverage Gaps
+
+**Overall: ~690 tests, most test happy paths with some edge cases.**
+
+| Area | Test File | Gap |
+|------|-----------|-----|
+| Stream turn pipeline | `test_stream.py` (855 lines) | Good coverage of main flow but steps 9, 10, 11.5 are no-ops so untestable. No tests for concurrent multi-connection turns |
+| Queue consumers | `test_queue_consumers.py` (715 lines) | Tests consumer dispatch but not the full proxy→planner→executor→proxy loop end-to-end through queues |
+| QueueBridge | `test_integration_queue.py` (379 lines) | Tests dispatch/collect but not concurrent trace isolation or the nack-storm problem |
+| Taint propagation | — | **Zero tests** because feature doesn't exist |
+| Memory portability | — | **Zero tests** because feature doesn't exist |
+| Docker sandbox | — | **Zero tests** because feature doesn't exist |
+| Undo flow | — | **Zero tests** beyond model validation |
+| Research state machine | — | **Zero tests** because feature doesn't exist |
+| Replan cascade (wired) | `test_queue_consumers.py` | ReplanManager unit tested but not integration-tested in execution failure path |
+| Output gates | `test_output_gates.py` | Tests OutputGateRunner but not the two-lane policy/quality model |
+| Security edge cases | `test_security.py`, `test_security_fixes.py` | Good but no test for: expired nonce pruning under load, concurrent approval token races, taint escalation via memory injection |
+| Sandbox escape | `test_sandbox.py` | Tests resource limits and network isolation but no adversarial escape tests (symlinks, path traversal, signal abuse) |
+
+---
+
+## 7. Architecture Drift
+
+### 7.1 Queue Integration is Overlay, Not Core
+
+ARCHITECTURE.md describes three agents connected by a message bus as the fundamental architecture. But the actual execution path in `Stream._process_turn_with_active_context()` is a direct procedural pipeline: proxy → planner → executor, all via `run_structured_agent()`. The queue path only activates when `queue_bridge is not None`, and even then, `collect_response` uses a fragile poll-and-nack pattern.
+
+**The code is a monolithic turn processor with a queue system bolted on the side.** STATUS.md marking WI-1 through WI-4 as "Done" is misleading — the queue *components* exist but the *integration* into the main execution path is incomplete.
+
+### 7.2 Two Output Gate Implementations
+
+The spec describes one `GateRunner` for both input and output gates. The code has:
+- `SilasGateRunner` — used for input gates (two-lane, policy/quality)
+- `OutputGateRunner` — separate class in `silas/gates/output.py` used for output gates
+
+This means output gates may not follow the same two-lane evaluation model as input gates.
+
+### 7.3 Ed25519 Library Mismatch
+
+Spec §2 lists `pynacl` (libsodium) for Ed25519. Code uses `cryptography` library (`cryptography.hazmat.primitives.asymmetric.ed25519`). Both are installed (`pynacl` in venv, `cryptography` in pyproject.toml). The actual signing code uses `cryptography`, not `pynacl`.
+
+### 7.4 QueueMessage Schema Divergence
+
+The spec's `QueueMessage` (dataclass in agent-loop-architecture.md §2.1) has 20+ fields including `scope_id`, `taint`, `task_id`, `work_item`, `approval_token`, `artifacts`, `constraints`, `urgency`. The code's `QueueMessage` (Pydantic model in queue/types.py) has 10 fields with a generic `payload: dict[str, object]`. Critical metadata like `scope_id` and `taint` are not first-class fields.
+
+### 7.5 Stream Self-Signs Messages
+
+The spec (§5.1 step 2) envisions inbound messages being signed by the *client* (owner's Ed25519 key) and the Stream *verifying* that signature. Instead, `Stream._sign_inbound_message()` signs the message *itself* with its own key and then verifies its own signature. This makes the inbound signing step a no-op for trust — it will always pass because the Stream is signing and verifying with the same key.
+
+### 7.6 Memory Operations Are No-Ops
+
+Steps 9 (memory queries) and 10 (memory ops) in the turn pipeline are logged as `phase1a_noop`. The agent's `AgentResponse` includes `memory_queries` and `memory_ops` fields, but the Stream never processes them after receiving the response. This means the agent cannot request memory retrieval or persist memories through the designed mechanism.
+
+---
+
+## 8. Prioritized Action Items
+
+### Critical (Security/Correctness)
+
+| # | Item | Risk | Effort |
+|---|------|------|--------|
+| 1 | **Implement taint propagation** (INV-05) | External data can be stored as `owner`-tainted in memory, enabling prompt injection persistence | High — needs a TaintTracker threaded through tool calls |
+| 2 | **Fix inbound message signing** | Stream self-signs then self-verifies, making trust classification meaningless for non-WebSocket channels | Medium |
+| 3 | **Implement memory steps 9-10** | Agent's memory queries and ops are silently dropped every turn | Medium |
+| 4 | **Fix QueueBridge.collect_response** | Poll-and-nack pattern is O(n) and causes message reordering under concurrent traces | Medium |
+
+### High (Functionality)
+
+| # | Item | Risk | Effort |
+|---|------|------|--------|
+| 5 | **Wire queue consumers into main execution path** | The "autonomous runtime" claimed in STATUS.md doesn't actually run through queues | High |
+| 6 | **Implement scorer model (tier-2 eviction)** | Context eviction is heuristic-only; long conversations will lose important context | Medium |
+| 7 | **Unify output gate runner** | Two gate runner implementations may enforce different policies | Low |
+| 8 | **Implement research state machine** | Planner can't delegate research to executor through the queue | High |
+| 9 | **Wire consult-planner and replan cascade** | Self-healing cascade (Design Principle #8) exists as code but isn't connected | Medium |
+
+### Medium (Completeness)
+
+| # | Item | Risk | Effort |
+|---|------|------|--------|
+| 10 | **Align QueueMessage schema with spec** | Missing `scope_id`, `taint` causes lost context across queue hops | Medium |
+| 11 | **Implement MemoryPortability** | No way to export/import agent memory | Medium |
+| 12 | **Implement skill hash-bound versioning** (INV-06) | Installed skills can be modified without detection | Low |
+| 13 | **Add Docker sandbox backend** | Only subprocess sandbox; no container isolation option | Medium |
+| 14 | **Update STATUS.md to reflect reality** | Claims WI-1–WI-4 "Done" when integration is incomplete | Trivial |
+
+### Low (Polish)
+
+| # | Item | Risk | Effort |
+|---|------|------|--------|
+| 15 | Implement UX quality metrics | No observability into approval patterns | Low |
+| 16 | Implement undo/recover pattern | No undo for reversible actions | Medium |
+| 17 | Guardrails-AI gate provider | Only predicate and script gate providers exist | Medium |
+| 18 | Telegram/CLI channels | Only web channel implemented | Medium |
+| 19 | Approval fatigue mitigation | No cadence tracking | Low |
+| 20 | Connection lifecycle management | Connections as skills not implemented | High |
+
+---
+
+## Appendix: Test Run Verification
+
+```
+Total test files: 57
+Total tests: ~690
+Lint status: 0 errors (ruff strict)
+Code lines: ~20,304 (silas/)
+Test lines: ~13,948 (tests/)
+Test:code ratio: 0.69:1
+```
+
+STATUS.md claims are mostly directionally correct for *component existence* but overstate *integration completeness*. The queue system components work individually (well-tested), but the end-to-end autonomous loop through queues is not the production path.

--- a/silas/core/stream.py
+++ b/silas/core/stream.py
@@ -37,7 +37,7 @@ from silas.core.plan_executor import (
 )
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.core.turn_context import TurnContext
-from silas.gates import OutputGateRunner
+from silas.gates import SilasGateRunner
 from silas.memory.retriever import SilasMemoryRetriever
 from silas.models.agents import (
     AgentResponse,
@@ -133,7 +133,7 @@ class Stream:
     queue_bridge: QueueBridge | None = None
     owner_id: str = "owner"
     default_context_profile: str = "conversation"
-    output_gate_runner: OutputGateRunner | None = None
+    output_gate_runner: SilasGateRunner | None = None
     session_id: str | None = None
     _approval_flow: ApprovalFlow | None = None
     _pending_persona_scopes: set[str] = field(default_factory=set, init=False, repr=False)
@@ -1783,7 +1783,7 @@ class Stream:
             await self._audit("output_gates_evaluated", turn_number=turn_number, results=[], configured=False)
             return response_text, blocked_gate_names
 
-        response_text, gate_results = self.output_gate_runner.evaluate(
+        response_text, gate_results = self.output_gate_runner.evaluate_output(
             response_text=response_text, response_taint=response_taint, sender_id=sender_id,
         )
         results_payload = [r.model_dump(mode="json") for r in gate_results]

--- a/silas/gates/output.py
+++ b/silas/gates/output.py
@@ -28,7 +28,12 @@ class _Escalation:
 
 
 class OutputGateRunner:
-    """Deterministic output-gate evaluator for the Stream response path."""
+    """Deterministic output-gate evaluator for the Stream response path.
+
+    .. deprecated::
+        Use ``SilasGateRunner.evaluate_output`` instead. This class exists
+        only for backward compatibility and will be removed in a future release.
+    """
 
     def __init__(
         self,

--- a/silas/gates/runner.py
+++ b/silas/gates/runner.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from silas.core.token_counter import HeuristicTokenCounter
 from silas.gates.guardrails_provider import GuardrailsChecker
 from silas.gates.predicates import PredicateChecker
 from silas.gates.script import ScriptChecker
@@ -14,14 +17,40 @@ from silas.models.gates import (
     GateResult,
     GateTrigger,
 )
+from silas.models.messages import TaintLevel
 from silas.protocols.gates import GateCheckProvider, GateRunner
 
 if TYPE_CHECKING:
     from silas.models.work import WorkItem
 
+# PII patterns live here so both input and output paths share one definition.
+_EMAIL_PATTERN = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_PATTERN = re.compile(
+    r"\b(?:\+?\d{1,2}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b"
+)
+_API_KEY_PATTERN = re.compile(r"\bsk-[A-Za-z0-9]{16,}\b")
+_TAINT_ORDER: dict[TaintLevel, int] = {
+    TaintLevel.owner: 0,
+    TaintLevel.auth: 1,
+    TaintLevel.external: 2,
+}
+_DEFAULT_BLOCK_MESSAGE = "I cannot share that"
+
+
+@dataclass(frozen=True)
+class _Escalation:
+    action: str
+    message: str | None = None
+
 
 class SilasGateRunner(GateRunner):
-    """Two-lane gate runner for policy enforcement and quality observability."""
+    """Two-lane gate runner for both input and output gate evaluation.
+
+    Why one runner: the spec mandates a single policy+quality lane model.
+    Output-specific checks (PII, taint ceiling, length) are built-in
+    providers keyed off GateTrigger.every_agent_response so they follow
+    the same escalation and mutation-sanitisation pipeline as input gates.
+    """
 
     def __init__(
         self,
@@ -29,10 +58,14 @@ class SilasGateRunner(GateRunner):
         predicate_checker: PredicateChecker | None = None,
         script_checker: ScriptChecker | None = None,
         llm_checker: GateCheckProvider | None = None,
+        token_counter: HeuristicTokenCounter | None = None,
+        escalation_map: Mapping[str, object] | None = None,
     ) -> None:
         self._providers: dict[str, GateCheckProvider] = {}
         self.quality_log: list[GateResult] = []
         self.rejected_mutations: list[tuple[str, str]] = []
+        self._token_counter = token_counter or HeuristicTokenCounter()
+        self._escalation_map: dict[str, object] = dict(escalation_map or {})
 
         self.register_provider(GateProvider.predicate, predicate_checker or PredicateChecker())
         self.register_provider(GateProvider.script, script_checker or ScriptChecker())
@@ -272,6 +305,407 @@ class SilasGateRunner(GateRunner):
         if isinstance(provider_name, GateProvider):
             return provider_name.value
         return str(provider_name).strip().lower()
+
+    # ── Output gate evaluation ─────────────────────────────────────────
+    # Why built-in: output checks (PII, taint, length) are deterministic
+    # and don't need pluggable providers — they operate on the response
+    # text directly.  Keeping them here preserves the two-lane model.
+
+    def set_output_gates(self, gates: Sequence[Gate]) -> None:
+        """Configure which gates run during output evaluation."""
+        self._output_gates = list(gates)
+
+    def evaluate_output(
+        self,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+        gates: Sequence[Gate] | None = None,
+    ) -> tuple[str, list[GateResult]]:
+        """Synchronous output gate pipeline mirroring the async input path.
+
+        Returns the (possibly rewritten) response and all gate results.
+        """
+        working_response = response_text
+        active_gates = list(gates if gates is not None else getattr(self, "_output_gates", []))
+        policy_results: list[GateResult] = []
+        quality_results: list[GateResult] = []
+
+        for gate in active_gates:
+            if gate.lane != GateLane.policy:
+                continue
+            result = self._evaluate_output_policy_gate(
+                gate, working_response, response_taint, sender_id,
+            )
+            policy_results.append(result)
+            if result.action == "continue":
+                updated = self._extract_response_mutation(result)
+                if updated is not None:
+                    working_response = updated
+
+        for gate in active_gates:
+            if gate.lane != GateLane.quality:
+                continue
+            quality_results.append(
+                self._evaluate_output_quality_gate(
+                    gate, working_response, response_taint, sender_id,
+                )
+            )
+
+        self.quality_log.extend(quality_results)
+        return working_response, [*policy_results, *quality_results]
+
+    def _evaluate_output_policy_gate(
+        self,
+        gate: Gate,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+    ) -> GateResult:
+        result = self._evaluate_output_gate_check(
+            gate, response_text, response_taint, sender_id,
+        )
+        if result.action != "block":
+            return result
+        return self._apply_escalation(gate, result, response_text)
+
+    def _evaluate_output_quality_gate(
+        self,
+        gate: Gate,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+    ) -> GateResult:
+        raw = self._evaluate_output_gate_check(
+            gate, response_text, response_taint, sender_id,
+        )
+        return self._normalize_quality_result(gate, raw)
+
+    def _evaluate_output_gate_check(
+        self,
+        gate: Gate,
+        response_text: str,
+        response_taint: TaintLevel,
+        sender_id: str,
+    ) -> GateResult:
+        if gate.on != GateTrigger.every_agent_response:
+            return self._output_continue(
+                gate.name, f"skipped trigger={gate.on.value}",
+            )
+
+        check_name = self._output_check_name(gate)
+        if check_name == "taint_ceiling":
+            return self._taint_ceiling(gate, response_taint)
+        if check_name == "length_limit":
+            return self._length_limit(gate, response_text)
+        if check_name == "pii_marker":
+            return self._pii_marker(gate, response_text)
+
+        return self._output_continue(
+            gate.name,
+            f"unknown output gate check: {check_name}",
+            flags=["warn", "unknown_output_gate"],
+            value=sender_id,
+        )
+
+    # ── Built-in output checks ─────────────────────────────────────────
+
+    def _taint_ceiling(self, gate: Gate, response_taint: TaintLevel) -> GateResult:
+        raw_threshold = (
+            gate.config.get("threshold")
+            or gate.config.get("max_taint")
+            or gate.config.get("taint_ceiling")
+            or TaintLevel.external.value
+        )
+        threshold = self._to_taint(raw_threshold)
+        if threshold is None:
+            return self._output_continue(
+                gate.name,
+                f"invalid taint threshold: {raw_threshold!r}",
+                flags=["warn", "invalid_gate_config"],
+            )
+
+        taint_rank = _TAINT_ORDER[response_taint]
+        threshold_rank = _TAINT_ORDER[threshold]
+        if taint_rank > threshold_rank:
+            return self._output_block(
+                gate.name,
+                f"response taint {response_taint.value} exceeds threshold {threshold.value}",
+                value=response_taint.value,
+            )
+        return self._output_continue(
+            gate.name,
+            f"response taint {response_taint.value} within threshold {threshold.value}",
+            value=response_taint.value,
+        )
+
+    def _length_limit(self, gate: Gate, response_text: str) -> GateResult:
+        raw_limit = gate.config.get("max_tokens")
+        if not isinstance(raw_limit, int) or raw_limit <= 0:
+            return self._output_continue(
+                gate.name,
+                f"invalid max_tokens: {raw_limit!r}",
+                flags=["warn", "invalid_gate_config"],
+            )
+
+        token_count = self._token_counter.count(response_text)
+        if token_count <= raw_limit:
+            return self._output_continue(
+                gate.name,
+                f"response length {token_count} <= limit {raw_limit}",
+                value=float(token_count),
+            )
+
+        mode = str(gate.config.get("mode", "truncate")).strip().lower()
+        if mode == "warn":
+            return self._output_continue(
+                gate.name,
+                f"response length {token_count} exceeds limit {raw_limit}",
+                flags=["warn", "length_exceeded"],
+                value=float(token_count),
+            )
+        if mode == "block":
+            return self._output_block(
+                gate.name,
+                f"response length {token_count} exceeds limit {raw_limit}",
+                value=float(token_count),
+            )
+
+        truncated = self._truncate_to_token_limit(response_text, raw_limit)
+        return self._output_continue(
+            gate.name,
+            f"response length {token_count} truncated to <= {raw_limit} tokens",
+            flags=["warn", "length_exceeded", "truncated"],
+            value=float(token_count),
+            modified_context={"response": truncated},
+        )
+
+    def _pii_marker(self, gate: Gate, response_text: str) -> GateResult:
+        has_email = bool(_EMAIL_PATTERN.search(response_text))
+        has_phone = bool(_PHONE_PATTERN.search(response_text))
+
+        if not has_email and not has_phone:
+            return self._output_continue(gate.name, "no PII marker detected")
+
+        flags = ["warn", "pii_detected"]
+        kinds: list[str] = []
+        if has_email:
+            flags.append("pii_email")
+            kinds.append("email")
+        if has_phone:
+            flags.append("pii_phone")
+            kinds.append("phone")
+
+        if self._has_explicit_escalation(gate):
+            return self._output_block(
+                gate.name,
+                f"PII markers detected: {', '.join(kinds)}",
+                flags=flags,
+                value=", ".join(kinds),
+            )
+        return self._output_continue(
+            gate.name,
+            f"PII markers detected: {', '.join(kinds)}",
+            flags=flags,
+            value=", ".join(kinds),
+        )
+
+    # ── Escalation (shared by output policy gates) ─────────────────────
+
+    def _apply_escalation(
+        self,
+        gate: Gate,
+        result: GateResult,
+        response_text: str,
+    ) -> GateResult:
+        escalation = self._resolve_escalation(gate)
+        escalation_flag = f"escalation:{escalation.action}"
+        flags = sorted({*result.flags, escalation_flag})
+
+        if escalation.action == "redact":
+            redacted = self._redact_sensitive_content(response_text)
+            return GateResult(
+                gate_name=result.gate_name,
+                lane=GateLane.policy,
+                action="continue",
+                reason=f"{result.reason} (redacted)",
+                value=result.value,
+                score=result.score,
+                flags=flags,
+                modified_context={"response": redacted},
+            )
+
+        if escalation.action == "require_approval":
+            fallback_message = escalation.message or _DEFAULT_BLOCK_MESSAGE
+            return GateResult(
+                gate_name=result.gate_name,
+                lane=GateLane.policy,
+                action="require_approval",
+                reason=f"{result.reason} (approval required)",
+                value=result.value,
+                score=result.score,
+                flags=flags,
+                modified_context={"response": fallback_message},
+            )
+
+        if escalation.action == "log_and_pass":
+            passthrough_flags = sorted({*flags, "warn", "logged_violation"})
+            return GateResult(
+                gate_name=result.gate_name,
+                lane=GateLane.policy,
+                action="continue",
+                reason=f"{result.reason} (logged and passed)",
+                value=result.value,
+                score=result.score,
+                flags=passthrough_flags,
+            )
+
+        block_message = escalation.message or _DEFAULT_BLOCK_MESSAGE
+        return GateResult(
+            gate_name=result.gate_name,
+            lane=GateLane.policy,
+            action="block",
+            reason=f"{result.reason} (blocked)",
+            value=result.value,
+            score=result.score,
+            flags=flags,
+            modified_context={"response": block_message},
+        )
+
+    def _resolve_escalation(self, gate: Gate) -> _Escalation:
+        configured = self._escalation_map.get(gate.name)
+        if configured is None:
+            configured = gate.config.get("escalation")
+        if configured is None:
+            configured = gate.config.get("on_block")
+        if configured is None and gate.on_block != "report":
+            configured = gate.on_block
+
+        parsed = self._parse_escalation(configured)
+        if parsed is not None:
+            return parsed
+        return _Escalation(action="block_with_message", message=_DEFAULT_BLOCK_MESSAGE)
+
+    def _parse_escalation(self, raw: object) -> _Escalation | None:
+        if isinstance(raw, str):
+            return self._parse_escalation_string(raw)
+        if isinstance(raw, Mapping):
+            action = self._normalize_escalation_action(raw.get("action") or raw.get("type"))
+            if action is None:
+                return None
+            message = self._message_from_raw(raw.get("message") or raw.get("msg") or raw.get("text"))
+            return _Escalation(action=action, message=message)
+        return None
+
+    def _parse_escalation_string(self, raw: str) -> _Escalation | None:
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        if stripped.startswith("block_with_message(") and stripped.endswith(")"):
+            inner = stripped.removeprefix("block_with_message(").removesuffix(")")
+            return _Escalation(action="block_with_message", message=self._message_from_raw(inner))
+        if stripped.startswith("block_with_message:"):
+            _, _, tail = stripped.partition(":")
+            return _Escalation(action="block_with_message", message=self._message_from_raw(tail))
+        action = self._normalize_escalation_action(stripped)
+        if action is None:
+            return None
+        return _Escalation(action=action)
+
+    def _normalize_escalation_action(self, raw: object) -> str | None:
+        if not isinstance(raw, str):
+            return None
+        normalized = raw.strip().lower().replace("-", "_").replace(" ", "_")
+        aliases = {"block": "block_with_message", "respond": "block_with_message", "report": "block_with_message"}
+        normalized = aliases.get(normalized, normalized)
+        if normalized not in {"block_with_message", "redact", "require_approval", "log_and_pass"}:
+            return None
+        return normalized
+
+    def _message_from_raw(self, raw: object) -> str | None:
+        if not isinstance(raw, str):
+            return None
+        message = raw.strip().strip('"').strip("'").strip()
+        return message or None
+
+    def _has_explicit_escalation(self, gate: Gate) -> bool:
+        if gate.name in self._escalation_map:
+            return True
+        if "escalation" in gate.config or "on_block" in gate.config:
+            return True
+        return gate.on_block != "report"
+
+    # ── Output-gate helpers ────────────────────────────────────────────
+
+    def _redact_sensitive_content(self, text: str) -> str:
+        redacted = _EMAIL_PATTERN.sub("[REDACTED_EMAIL]", text)
+        redacted = _PHONE_PATTERN.sub("[REDACTED_PHONE]", redacted)
+        return _API_KEY_PATTERN.sub("[REDACTED_KEY]", redacted)
+
+    def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:
+        if self._token_counter.count(text) <= max_tokens:
+            return text
+        max_chars = max(int(max_tokens * 3.5), 1)
+        truncated = text[:max_chars]
+        while truncated and self._token_counter.count(truncated) > max_tokens:
+            truncated = truncated[:-1]
+        return truncated
+
+    def _extract_response_mutation(self, result: GateResult) -> str | None:
+        if not isinstance(result.modified_context, dict):
+            return None
+        candidate = result.modified_context.get("response")
+        return candidate if isinstance(candidate, str) else None
+
+    def _output_check_name(self, gate: Gate) -> str:
+        source = gate.check or gate.name
+        return source.strip().lower().replace("-", "_").replace(" ", "_")
+
+    def _to_taint(self, raw: object) -> TaintLevel | None:
+        if isinstance(raw, TaintLevel):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return TaintLevel(raw.strip().lower())
+            except ValueError:
+                return None
+        return None
+
+    def _output_continue(
+        self,
+        gate_name: str,
+        reason: str,
+        *,
+        flags: list[str] | None = None,
+        value: str | float | None = None,
+        modified_context: dict[str, object] | None = None,
+    ) -> GateResult:
+        return GateResult(
+            gate_name=gate_name,
+            lane=GateLane.policy,
+            action="continue",
+            reason=reason,
+            value=value,
+            flags=flags or [],
+            modified_context=modified_context,
+        )
+
+    def _output_block(
+        self,
+        gate_name: str,
+        reason: str,
+        *,
+        flags: list[str] | None = None,
+        value: str | float | None = None,
+    ) -> GateResult:
+        return GateResult(
+            gate_name=gate_name,
+            lane=GateLane.policy,
+            action="block",
+            reason=reason,
+            value=value,
+            flags=flags or [],
+        )
 
 
 __all__ = ["SilasGateRunner"]

--- a/tests/test_output_gates.py
+++ b/tests/test_output_gates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from silas.core.token_counter import HeuristicTokenCounter
 from silas.gates.output import OutputGateRunner
+from silas.gates.runner import SilasGateRunner
 from silas.models.gates import Gate, GateTrigger
 from silas.models.messages import TaintLevel
 
@@ -15,14 +16,17 @@ def _output_gate(name: str, check: str, config: dict[str, object] | None = None)
     )
 
 
+# ── Tests using the unified SilasGateRunner ────────────────────────
+
+
 def test_taint_ceiling_gate_blocks_high_taint_responses() -> None:
-    runner = OutputGateRunner(
-        [_output_gate("taint_guard", "taint_ceiling", {"threshold": "auth"})]
-    )
-    rewritten, results = runner.evaluate(
+    runner = SilasGateRunner()
+    gates = [_output_gate("taint_guard", "taint_ceiling", {"threshold": "auth"})]
+    rewritten, results = runner.evaluate_output(
         response_text="sensitive response",
         response_taint=TaintLevel.external,
         sender_id="customer-1",
+        gates=gates,
     )
 
     assert rewritten == "sensitive response"
@@ -32,15 +36,15 @@ def test_taint_ceiling_gate_blocks_high_taint_responses() -> None:
 
 
 def test_length_limit_gate_truncates_long_responses() -> None:
-    runner = OutputGateRunner(
-        [_output_gate("length_guard", "length_limit", {"max_tokens": 8, "mode": "truncate"})]
-    )
+    runner = SilasGateRunner()
+    gates = [_output_gate("length_guard", "length_limit", {"max_tokens": 8, "mode": "truncate"})]
     response_text = "A" * 200
 
-    rewritten, results = runner.evaluate(
+    rewritten, results = runner.evaluate_output(
         response_text=response_text,
         response_taint=TaintLevel.owner,
         sender_id="owner",
+        gates=gates,
     )
 
     assert len(results) == 1
@@ -52,13 +56,15 @@ def test_length_limit_gate_truncates_long_responses() -> None:
 
 
 def test_pii_marker_gate_flags_email_and_phone() -> None:
-    runner = OutputGateRunner([_output_gate("pii_guard", "pii_marker")])
+    runner = SilasGateRunner()
+    gates = [_output_gate("pii_guard", "pii_marker")]
     response_text = "Contact me at silas@example.com or +1 (212) 555-0100."
 
-    rewritten, results = runner.evaluate(
+    rewritten, results = runner.evaluate_output(
         response_text=response_text,
         response_taint=TaintLevel.owner,
         sender_id="owner",
+        gates=gates,
     )
 
     assert rewritten == response_text
@@ -71,22 +77,51 @@ def test_pii_marker_gate_flags_email_and_phone() -> None:
 
 
 def test_gate_pipeline_passes_clean_response_unchanged() -> None:
-    runner = OutputGateRunner(
-        [
-            _output_gate("taint_guard", "taint_ceiling", {"threshold": "external"}),
-            _output_gate("length_guard", "length_limit", {"max_tokens": 200, "mode": "truncate"}),
-            _output_gate("pii_guard", "pii_marker"),
-        ]
-    )
+    runner = SilasGateRunner()
+    gates = [
+        _output_gate("taint_guard", "taint_ceiling", {"threshold": "external"}),
+        _output_gate("length_guard", "length_limit", {"max_tokens": 200, "mode": "truncate"}),
+        _output_gate("pii_guard", "pii_marker"),
+    ]
     response_text = "Everything is ready. The build passed and tests are green."
 
-    rewritten, results = runner.evaluate(
+    rewritten, results = runner.evaluate_output(
         response_text=response_text,
         response_taint=TaintLevel.owner,
         sender_id="owner",
+        gates=gates,
     )
 
     assert rewritten == response_text
     assert len(results) == 3
     assert all(result.action == "continue" for result in results)
     assert all("warn" not in result.flags for result in results)
+
+
+def test_set_output_gates_used_when_no_gates_passed() -> None:
+    """evaluate_output uses stored gates when caller omits the gates arg."""
+    runner = SilasGateRunner()
+    runner.set_output_gates([_output_gate("pii_guard", "pii_marker")])
+
+    _, results = runner.evaluate_output(
+        response_text="hello@example.com",
+        response_taint=TaintLevel.owner,
+        sender_id="owner",
+    )
+    assert len(results) == 1
+    assert "pii_email" in results[0].flags
+
+
+# ── Legacy OutputGateRunner still works (backward compat) ──────────
+
+
+def test_legacy_output_gate_runner_still_works() -> None:
+    runner = OutputGateRunner(
+        [_output_gate("taint_guard", "taint_ceiling", {"threshold": "auth"})]
+    )
+    _rewritten, results = runner.evaluate(
+        response_text="sensitive response",
+        response_taint=TaintLevel.external,
+        sender_id="customer-1",
+    )
+    assert results[0].action == "block"

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -83,11 +83,12 @@ class BlockingOutputGateRunner:
     def __init__(self) -> None:
         self.calls: list[tuple[str, TaintLevel, str]] = []
 
-    def evaluate(
+    def evaluate_output(
         self,
         response_text: str,
         response_taint: TaintLevel,
         sender_id: str,
+        gates: list[object] | None = None,
     ) -> tuple[str, list[GateResult]]:
         self.calls.append((response_text, response_taint, sender_id))
         return response_text, [


### PR DESCRIPTION
Merges OutputGateRunner into SilasGateRunner.

- Added evaluate_output() + set_output_gates() to SilasGateRunner
- PII detection, taint ceiling, length limits, escalation pipeline all preserved
- Stream + main.py use single runner for input+output
- OutputGateRunner marked deprecated
- 753 tests pass, ruff clean