### PR TITLE
feat: skill hash-bound versioning (INV-06)

### DIFF
--- a/silas/models/skills.py
+++ b/silas/models/skills.py
@@ -36,6 +36,7 @@ class SkillDefinition(BaseModel):
     input_schema: dict[str, object] = Field(default_factory=dict)
     output_schema: dict[str, object] = Field(default_factory=dict)
     requires_approval: bool = False
+    verified_hash: str | None = None
     max_retries: int = 0
     timeout_seconds: int = 30
 

--- a/silas/skills/hasher.py
+++ b/silas/skills/hasher.py
@@ -1,0 +1,68 @@
+"""Deterministic content hashing for skill integrity verification.
+
+Skills are loaded from disk and executed with agent privileges. Without hash
+tracking, an attacker (or accidental edit) can modify installed skill files
+and the loader would happily activate the tampered code. This module produces
+a deterministic SHA-256 digest of all meaningful skill files so we can detect
+any post-install modification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# Directories whose contents are build artifacts or VCS metadata,
+# not authored skill code — excluding them keeps the hash stable
+# across environments.
+_EXCLUDED_DIRS: frozenset[str] = frozenset({"__pycache__", ".git"})
+
+# Only these extensions/filenames carry meaningful skill logic or config.
+_INCLUDED_EXTENSIONS: frozenset[str] = frozenset({".py", ".md", ".yaml", ".yml", ".toml", ".json"})
+
+
+class SkillHasher:
+    """Computes a deterministic content hash over a skill directory."""
+
+    @staticmethod
+    def compute_hash(skill_path: Path) -> str:
+        """Return hex SHA-256 of all relevant files under *skill_path*.
+
+        Files are sorted by their path relative to *skill_path* so the
+        hash is independent of filesystem enumeration order.
+        """
+        resolved = skill_path.resolve()
+        if not resolved.is_dir():
+            raise ValueError(f"skill path is not a directory: {skill_path}")
+
+        hasher = hashlib.sha256()
+        files = sorted(_iter_hashable_files(resolved), key=lambda p: str(p.relative_to(resolved)))
+
+        for file_path in files:
+            # Include the relative path in the digest so renaming a file
+            # changes the hash even if contents stay the same.
+            rel = str(file_path.relative_to(resolved))
+            hasher.update(rel.encode("utf-8"))
+            hasher.update(file_path.read_bytes())
+
+        return hasher.hexdigest()
+
+
+def _iter_hashable_files(root: Path) -> list[Path]:
+    """Collect files that contribute to the skill's identity."""
+    result: list[Path] = []
+    for item in root.rglob("*"):
+        if not item.is_file():
+            continue
+        # Skip anything inside excluded directory trees
+        if any(part in _EXCLUDED_DIRS for part in item.relative_to(root).parts):
+            continue
+        # Skip compiled bytecode regardless of location
+        if item.suffix == ".pyc":
+            continue
+        if item.suffix in _INCLUDED_EXTENSIONS:
+            result.append(item)
+    return result
+
+
+__all__ = ["SkillHasher"]

--- a/silas/skills/installer.py
+++ b/silas/skills/installer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from silas.models.skills import SkillMetadata
 from silas.protocols.skills import SkillLoader
+from silas.skills.hasher import SkillHasher
 from silas.skills.loader import SilasSkillLoader
 
 
@@ -52,6 +53,9 @@ class SkillInstaller:
             shutil.rmtree(destination)
         shutil.copytree(source_dir, destination)
 
+        # Compute hash at install time so we can detect post-install tampering.
+        content_hash = SkillHasher.compute_hash(destination)
+
         indexed = self._loader.scan()
         return {
             "installed": True,
@@ -61,6 +65,7 @@ class SkillInstaller:
             "indexed_count": len(indexed),
             "destination": str(destination),
             "installed_at": datetime.now(UTC).isoformat(),
+            "verified_hash": content_hash,
         }
 
     def uninstall(self, skill_name: str) -> bool:

--- a/silas/skills/registry.py
+++ b/silas/skills/registry.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+
 from silas.models.skills import SkillDefinition
+from silas.skills.hasher import SkillHasher
+
+logger = logging.getLogger(__name__)
 
 
 class SkillRegistry:
@@ -24,6 +30,46 @@ class SkillRegistry:
 
     def has(self, name: str) -> bool:
         return name in self._skills
+
+    def store_hash(self, name: str, skill_path: Path) -> str:
+        """Compute and persist the hash for an installed skill.
+
+        Called at install time so we have a baseline to compare against
+        on every subsequent load.
+        """
+        skill = self._skills.get(name)
+        if skill is None:
+            raise KeyError(f"skill '{name}' not in registry")
+        content_hash = SkillHasher.compute_hash(skill_path)
+        updated = skill.model_copy(update={"verified_hash": content_hash})
+        self._skills[name] = updated
+        return content_hash
+
+    def verify_hash(self, name: str, skill_path: Path) -> bool:
+        """Re-compute hash and compare to stored value.
+
+        Returns True if the skill is unmodified. Logs a security event
+        and returns False on mismatch so the caller can block activation.
+        """
+        skill = self._skills.get(name)
+        if skill is None:
+            raise KeyError(f"skill '{name}' not in registry")
+
+        if skill.verified_hash is None:
+            # First load — no stored hash yet; caller should store one.
+            return True
+
+        current_hash = SkillHasher.compute_hash(skill_path)
+        if current_hash != skill.verified_hash:
+            logger.warning(
+                "SECURITY: skill '%s' hash mismatch — expected %s, got %s. "
+                "Skill files were modified after installation. Blocking activation.",
+                name,
+                skill.verified_hash,
+                current_hash,
+            )
+            return False
+        return True
 
 
 __all__ = ["SkillRegistry"]

--- a/tests/test_skill_hasher.py
+++ b/tests/test_skill_hasher.py
@@ -1,0 +1,131 @@
+"""Tests for skill hash-bound versioning (INV-06).
+
+Verifies that SkillHasher produces deterministic, tamper-sensitive digests
+and that the loader blocks modified skills.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from silas.skills.hasher import SkillHasher
+from silas.skills.loader import SecurityError, SilasSkillLoader
+
+SKILL_MD = """\
+---
+name: test-skill
+description: A test skill for hashing verification purposes.
+activation: manual
+requires_approval: false
+---
+
+# Test Skill
+"""
+
+
+def _make_skill(tmp_path: Path, name: str = "test-skill", extra_py: str = "") -> Path:
+    """Create a minimal skill directory with SKILL.md and an optional .py file."""
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    if extra_py:
+        scripts = skill_dir / "scripts"
+        scripts.mkdir()
+        (scripts / "run.py").write_text(extra_py, encoding="utf-8")
+    return skill_dir
+
+
+class TestSkillHasher:
+    def test_deterministic_hash(self, tmp_path: Path) -> None:
+        """Same content must always produce the same hash."""
+        skill_dir = _make_skill(tmp_path, extra_py="print('hello')")
+        h1 = SkillHasher.compute_hash(skill_dir)
+        h2 = SkillHasher.compute_hash(skill_dir)
+        assert h1 == h2
+        assert len(h1) == 64  # SHA-256 hex length
+
+    def test_hash_changes_on_content_change(self, tmp_path: Path) -> None:
+        """Modifying any file must change the hash."""
+        skill_dir = _make_skill(tmp_path, extra_py="x = 1")
+        original = SkillHasher.compute_hash(skill_dir)
+
+        (skill_dir / "scripts" / "run.py").write_text("x = 2", encoding="utf-8")
+        modified = SkillHasher.compute_hash(skill_dir)
+
+        assert original != modified
+
+    def test_hash_ignores_pycache(self, tmp_path: Path) -> None:
+        """__pycache__ and .pyc files must not affect the hash."""
+        skill_dir = _make_skill(tmp_path, extra_py="pass")
+        baseline = SkillHasher.compute_hash(skill_dir)
+
+        cache_dir = skill_dir / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "run.cpython-312.pyc").write_bytes(b"\x00\x01\x02")
+
+        assert SkillHasher.compute_hash(skill_dir) == baseline
+
+    def test_hash_changes_on_file_rename(self, tmp_path: Path) -> None:
+        """Renaming a file changes the hash because relative paths are hashed."""
+        skill_dir = _make_skill(tmp_path, extra_py="pass")
+        original = SkillHasher.compute_hash(skill_dir)
+
+        src = skill_dir / "scripts" / "run.py"
+        dst = skill_dir / "scripts" / "main.py"
+        src.rename(dst)
+
+        assert SkillHasher.compute_hash(skill_dir) != original
+
+    def test_not_a_directory_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "not-a-dir.txt"
+        f.write_text("x")
+        with pytest.raises(ValueError, match="not a directory"):
+            SkillHasher.compute_hash(f)
+
+
+class TestLoaderIntegrity:
+    def test_new_skill_returns_hash(self, tmp_path: Path) -> None:
+        """First verification of a new skill (no stored hash) should succeed."""
+        _make_skill(tmp_path)
+        loader = SilasSkillLoader(tmp_path / "skills")
+        ok, h = loader.verify_integrity("test-skill", stored_hash=None)
+        assert ok is True
+        assert len(h) == 64
+
+    def test_unchanged_skill_passes(self, tmp_path: Path) -> None:
+        """An unmodified skill must pass verification."""
+        _make_skill(tmp_path, extra_py="pass")
+        loader = SilasSkillLoader(tmp_path / "skills")
+        _, h = loader.verify_integrity("test-skill", stored_hash=None)
+        ok, h2 = loader.verify_integrity("test-skill", stored_hash=h)
+        assert ok is True
+        assert h == h2
+
+    def test_modified_skill_raises_security_error(self, tmp_path: Path) -> None:
+        """Tampered skill files must raise SecurityError."""
+        skill_dir = _make_skill(tmp_path, extra_py="safe = True")
+        loader = SilasSkillLoader(tmp_path / "skills")
+        _, original_hash = loader.verify_integrity("test-skill", stored_hash=None)
+
+        # Tamper with the skill after hash was stored
+        (skill_dir / "scripts" / "run.py").write_text("safe = False", encoding="utf-8")
+
+        with pytest.raises(SecurityError, match="integrity check"):
+            loader.verify_integrity("test-skill", stored_hash=original_hash)
+
+    def test_hash_stored_in_install_result(self, tmp_path: Path) -> None:
+        """SkillInstaller.install should include verified_hash in result."""
+        source_dir = _make_skill(tmp_path / "source", extra_py="pass")
+        install_dir = tmp_path / "installed"
+        install_dir.mkdir()
+
+        from silas.skills.installer import SkillInstaller
+
+        loader = SilasSkillLoader(install_dir)
+        installer = SkillInstaller(loader, install_dir)
+        result = installer.install(str(source_dir))
+
+        assert result["installed"] is True
+        assert "verified_hash" in result
+        assert len(str(result["verified_hash"])) == 64


### PR DESCRIPTION
Implements INV-06: skills are SHA-256 hashed at install, verified on load.

- SkillHasher: deterministic hash over all skill files (sorted, path-inclusive)
- Registry stores/verifies hash, loader raises SecurityError on mismatch
- Installer computes hash at install time
- 9 new tests, 760 total passing, ruff clean