### PR TITLE
feat: memory portability — export/import bundles (§4.2.3)

### DIFF
--- a/silas/memory/portability.py
+++ b/silas/memory/portability.py
@@ -1,0 +1,155 @@
+"""MemoryPortability implementation — export/import memory bundles across instances."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from silas.models.memory import MemoryItem
+from silas.models.messages import TaintLevel
+from silas.models.portability import (
+    SCHEMA_VERSION,
+    BundleMetadata,
+    ImportResult,
+    MemoryBundle,
+)
+from silas.protocols.memory import MemoryStore
+
+
+class MemoryPortabilityManager:
+    """Standalone service wrapping any MemoryStore with export/import capabilities.
+
+    Satisfies the MemoryPortability protocol (bytes in/out) while using typed
+    Pydantic models internally for safety.
+    """
+
+    def __init__(self, store: MemoryStore, instance_id: str = "") -> None:
+        self._store = store
+        self._instance_id = instance_id
+
+    # -- Protocol surface (bytes-oriented) ------------------------------------
+
+    async def export_bundle(
+        self,
+        since: datetime | None = None,
+        include_raw: bool = True,
+        filters: dict[str, object] | None = None,
+    ) -> bytes:
+        """Serialize matching memories into a portable JSON blob."""
+        bundle = await self._build_bundle(since=since, include_raw=include_raw, filters=filters)
+        return bundle.model_dump_json(indent=2).encode()
+
+    async def import_bundle(
+        self,
+        bundle: bytes,
+        mode: str = "merge",
+    ) -> dict[str, object]:
+        """Deserialize a bundle and upsert into the backing store."""
+        parsed = MemoryBundle.model_validate_json(bundle)
+        result = await self._apply_bundle(parsed, conflict_strategy=mode)
+        return result.model_dump()
+
+    # -- Typed helpers (usable directly in-process) ---------------------------
+
+    async def _build_bundle(
+        self,
+        *,
+        since: datetime | None = None,
+        include_raw: bool = True,
+        filters: dict[str, object] | None = None,
+    ) -> MemoryBundle:
+        # Grab a broad set; real vector/FTS filtering isn't needed for export
+        items = await self._store.list_recent(limit=10_000)
+
+        if since is not None:
+            items = [i for i in items if i.updated_at >= since]
+
+        if filters:
+            items = _apply_filters(items, filters)
+
+        if not include_raw:
+            # Strip embeddings to shrink bundle size
+            for item in items:
+                item.embedding = None
+
+        metadata = BundleMetadata(
+            source_instance_id=self._instance_id,
+            schema_version=SCHEMA_VERSION,
+            item_count=len(items),
+        )
+        return MemoryBundle(metadata=metadata, items=items)
+
+    async def _apply_bundle(
+        self,
+        bundle: MemoryBundle,
+        conflict_strategy: str = "skip",
+    ) -> ImportResult:
+        _validate_schema_version(bundle.metadata.schema_version)
+
+        result = ImportResult()
+        for item in bundle.items:
+            existing = await self._store.get(item.memory_id)
+
+            if existing is None:
+                await self._store.store(item)
+                result.imported_count += 1
+                continue
+
+            # Conflict detected — apply chosen strategy
+            result.conflict_count += 1
+            if conflict_strategy == "skip":
+                result.skipped_count += 1
+            elif conflict_strategy == "overwrite":
+                await self._store.store(item)
+                result.imported_count += 1
+            elif conflict_strategy == "merge":
+                # "merge" keeps whichever was updated more recently
+                winner = item if item.updated_at > existing.updated_at else existing
+                if winner is item:
+                    await self._store.store(item)
+                    result.imported_count += 1
+                else:
+                    result.skipped_count += 1
+            else:
+                result.errors.append(f"Unknown conflict strategy: {conflict_strategy}")
+
+        return result
+
+
+# -- Private helpers ----------------------------------------------------------
+
+
+def _apply_filters(items: list[MemoryItem], filters: dict[str, object]) -> list[MemoryItem]:
+    """Narrow items by optional taint, date_from, date_until, tags."""
+    out = items
+
+    if "taint" in filters:
+        level = TaintLevel(str(filters["taint"]))
+        out = [i for i in out if i.taint == level]
+
+    if "date_from" in filters:
+        dt = filters["date_from"]
+        if isinstance(dt, datetime):
+            out = [i for i in out if i.created_at >= dt]
+
+    if "date_until" in filters:
+        dt = filters["date_until"]
+        if isinstance(dt, datetime):
+            out = [i for i in out if i.created_at <= dt]
+
+    if "tags" in filters:
+        required = set(filters["tags"]) if isinstance(filters["tags"], list) else {filters["tags"]}
+        out = [i for i in out if required & set(i.semantic_tags)]
+
+    return out
+
+
+def _validate_schema_version(version: str) -> None:
+    """Reject bundles from incompatible major versions."""
+    major = version.split(".")[0]
+    current_major = SCHEMA_VERSION.split(".")[0]
+    if major != current_major:
+        msg = f"Incompatible schema version {version} (current: {SCHEMA_VERSION})"
+        raise ValueError(msg)
+
+
+__all__ = ["MemoryPortabilityManager"]

--- a/silas/models/portability.py
+++ b/silas/models/portability.py
@@ -1,0 +1,35 @@
+"""Portable bundle models for memory migration between Silas instances."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from silas.models.memory import MemoryItem
+from silas.models.messages import utc_now
+
+# Bump when MemoryItem schema changes — import rejects incompatible majors
+SCHEMA_VERSION = "1.0"
+
+
+class BundleMetadata(BaseModel):
+    exported_at: datetime = Field(default_factory=utc_now)
+    source_instance_id: str = ""
+    schema_version: str = SCHEMA_VERSION
+    item_count: int = 0
+
+
+class MemoryBundle(BaseModel):
+    metadata: BundleMetadata
+    items: list[MemoryItem]
+
+
+class ImportResult(BaseModel):
+    imported_count: int = 0
+    skipped_count: int = 0
+    conflict_count: int = 0
+    errors: list[str] = Field(default_factory=list)
+
+
+__all__ = ["BundleMetadata", "ImportResult", "MemoryBundle", "SCHEMA_VERSION"]  # noqa: RUF022

--- a/tests/test_portability.py
+++ b/tests/test_portability.py
@@ -1,0 +1,231 @@
+"""Tests for memory portability — export, import, round-trip."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from silas.memory.portability import MemoryPortabilityManager
+from silas.models.memory import MemoryItem, MemoryType
+from silas.models.messages import TaintLevel, utc_now
+from silas.models.portability import SCHEMA_VERSION, MemoryBundle
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_item(
+    memory_id: str = "m1",
+    content: str = "hello",
+    taint: TaintLevel = TaintLevel.owner,
+    tags: list[str] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> MemoryItem:
+    now = utc_now()
+    return MemoryItem(
+        memory_id=memory_id,
+        content=content,
+        memory_type=MemoryType.fact,
+        taint=taint,
+        semantic_tags=tags or [],
+        created_at=created_at or now,
+        updated_at=updated_at or now,
+        source_kind="test",
+    )
+
+
+class InMemoryStore:
+    """Minimal MemoryStore fake for testing portability in isolation."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, MemoryItem] = {}
+
+    async def store(self, item: MemoryItem) -> str:
+        self._items[item.memory_id] = item
+        return item.memory_id
+
+    async def get(self, memory_id: str) -> MemoryItem | None:
+        return self._items.get(memory_id)
+
+    async def list_recent(self, limit: int) -> list[MemoryItem]:
+        items = sorted(self._items.values(), key=lambda i: i.updated_at, reverse=True)
+        return items[:limit]
+
+    # Unused but required by protocol
+    async def update(self, memory_id: str, **kwargs: object) -> None: ...
+    async def delete(self, memory_id: str) -> None: ...
+    async def search_keyword(self, query: str, limit: int) -> list[MemoryItem]: return []
+    async def search_by_type(self, memory_type: object, limit: int) -> list[MemoryItem]: return []
+    async def increment_access(self, memory_id: str) -> None: ...
+    async def search_session(self, session_id: str) -> list[MemoryItem]: return []
+    async def store_raw(self, item: MemoryItem) -> str: return await self.store(item)
+    async def search_raw(self, query: str, limit: int) -> list[MemoryItem]: return []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store() -> InMemoryStore:
+    return InMemoryStore()
+
+
+@pytest.fixture
+def mgr(store: InMemoryStore) -> MemoryPortabilityManager:
+    return MemoryPortabilityManager(store, instance_id="test-instance")
+
+
+@pytest.mark.asyncio
+async def test_export_produces_valid_bundle(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    await store.store(_make_item("m1", "first"))
+    raw = await mgr.export_bundle()
+    bundle = MemoryBundle.model_validate_json(raw)
+    assert bundle.metadata.schema_version == SCHEMA_VERSION
+    assert bundle.metadata.source_instance_id == "test-instance"
+    assert bundle.metadata.item_count == 1
+    assert len(bundle.items) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_skip_keeps_existing(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    existing = _make_item("m1", "original")
+    await store.store(existing)
+
+    bundle = await mgr.export_bundle()
+    # Overwrite store content with different value so we can verify skip
+    await store.store(_make_item("m1", "local-version"))
+
+    result = await mgr.import_bundle(bundle, mode="skip")
+    assert result["skipped_count"] == 1
+    assert result["imported_count"] == 0
+    item = await store.get("m1")
+    assert item is not None
+    assert item.content == "local-version"
+
+
+@pytest.mark.asyncio
+async def test_import_overwrite_replaces_existing(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    await store.store(_make_item("m1", "old"))
+    bundle = await mgr.export_bundle()
+
+    await store.store(_make_item("m1", "local"))
+    result = await mgr.import_bundle(bundle, mode="overwrite")
+    assert result["imported_count"] == 1
+    item = await store.get("m1")
+    assert item is not None
+    assert item.content == "old"
+
+
+@pytest.mark.asyncio
+async def test_import_merge_keeps_newer(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    old_time = datetime(2025, 1, 1, tzinfo=UTC)
+    new_time = datetime(2026, 1, 1, tzinfo=UTC)
+
+    await store.store(_make_item("m1", "older", updated_at=old_time, created_at=old_time))
+    # Build a bundle with the older item
+    bundle_bytes = await mgr.export_bundle()
+
+    # Now put a newer item in store
+    await store.store(_make_item("m1", "newer", updated_at=new_time, created_at=new_time))
+
+    result = await mgr.import_bundle(bundle_bytes, mode="merge")
+    # Merge should keep the newer local version
+    assert result["skipped_count"] == 1
+    item = await store.get("m1")
+    assert item is not None
+    assert item.content == "newer"
+
+
+@pytest.mark.asyncio
+async def test_import_merge_replaces_with_newer_incoming(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    old_time = datetime(2025, 1, 1, tzinfo=UTC)
+    new_time = datetime(2026, 1, 1, tzinfo=UTC)
+
+    await store.store(_make_item("m1", "newer-incoming", updated_at=new_time, created_at=new_time))
+    bundle_bytes = await mgr.export_bundle()
+
+    # Downgrade local to older
+    await store.store(_make_item("m1", "older-local", updated_at=old_time, created_at=old_time))
+
+    result = await mgr.import_bundle(bundle_bytes, mode="merge")
+    assert result["imported_count"] == 1
+    item = await store.get("m1")
+    assert item is not None
+    assert item.content == "newer-incoming"
+
+
+@pytest.mark.asyncio
+async def test_schema_version_validation(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    await store.store(_make_item("m1"))
+    raw = await mgr.export_bundle()
+    # Tamper with schema version to simulate incompatible bundle
+    data = json.loads(raw)
+    data["metadata"]["schema_version"] = "99.0"
+    tampered = json.dumps(data).encode()
+
+    with pytest.raises(ValueError, match="Incompatible schema version"):
+        await mgr.import_bundle(tampered)
+
+
+@pytest.mark.asyncio
+async def test_filtered_export_by_taint(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    await store.store(_make_item("m1", taint=TaintLevel.owner))
+    await store.store(_make_item("m2", taint=TaintLevel.external))
+
+    raw = await mgr.export_bundle(filters={"taint": "owner"})
+    bundle = MemoryBundle.model_validate_json(raw)
+    assert len(bundle.items) == 1
+    assert bundle.items[0].memory_id == "m1"
+
+
+@pytest.mark.asyncio
+async def test_filtered_export_by_date_range(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    early = datetime(2025, 1, 1, tzinfo=UTC)
+    late = datetime(2026, 6, 1, tzinfo=UTC)
+    await store.store(_make_item("m1", created_at=early, updated_at=early))
+    await store.store(_make_item("m2", created_at=late, updated_at=late))
+
+    raw = await mgr.export_bundle(filters={
+        "date_from": datetime(2026, 1, 1, tzinfo=UTC),
+    })
+    bundle = MemoryBundle.model_validate_json(raw)
+    assert len(bundle.items) == 1
+    assert bundle.items[0].memory_id == "m2"
+
+
+@pytest.mark.asyncio
+async def test_filtered_export_by_tags(mgr: MemoryPortabilityManager, store: InMemoryStore) -> None:
+    await store.store(_make_item("m1", tags=["important", "work"]))
+    await store.store(_make_item("m2", tags=["personal"]))
+
+    raw = await mgr.export_bundle(filters={"tags": ["important"]})
+    bundle = MemoryBundle.model_validate_json(raw)
+    assert len(bundle.items) == 1
+    assert bundle.items[0].memory_id == "m1"
+
+
+@pytest.mark.asyncio
+async def test_round_trip(store: InMemoryStore) -> None:
+    """Export from one store, import into another — data survives intact."""
+    source_mgr = MemoryPortabilityManager(store, instance_id="source")
+    items = [_make_item(f"m{i}", f"content-{i}") for i in range(5)]
+    for item in items:
+        await store.store(item)
+
+    bundle_bytes = await source_mgr.export_bundle()
+
+    # Import into a fresh store
+    dest_store = InMemoryStore()
+    dest_mgr = MemoryPortabilityManager(dest_store, instance_id="dest")
+    result = await dest_mgr.import_bundle(bundle_bytes)
+
+    assert result["imported_count"] == 5
+    for item in items:
+        got = await dest_store.get(item.memory_id)
+        assert got is not None
+        assert got.content == item.content
+        assert got.memory_type == item.memory_type


### PR DESCRIPTION
Implements MemoryPortability protocol.

- MemoryPortabilityManager: export_bundle with filters (taint, date, tags), import_bundle with conflict strategies (skip/overwrite/merge)
- Schema version validation, round-trip integrity
- 10 new tests, ruff clean