### PR TITLE
feat: Docker sandbox backend (§9) with factory + fallback

### DIFF
--- a/silas/execution/__init__.py
+++ b/silas/execution/__init__.py
@@ -1,5 +1,15 @@
+from silas.execution.docker_sandbox import DockerSandboxManager, is_docker_available
 from silas.execution.python_exec import PythonExecutor
 from silas.execution.sandbox import SandboxExecResult, SubprocessSandboxManager
+from silas.execution.sandbox_factory import create_sandbox_manager
 from silas.execution.shell import ShellExecutor
 
-__all__ = ["PythonExecutor", "SandboxExecResult", "ShellExecutor", "SubprocessSandboxManager"]
+__all__ = [
+    "DockerSandboxManager",
+    "PythonExecutor",
+    "SandboxExecResult",
+    "ShellExecutor",
+    "SubprocessSandboxManager",
+    "create_sandbox_manager",
+    "is_docker_available",
+]

--- a/silas/execution/docker_sandbox.py
+++ b/silas/execution/docker_sandbox.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+import uuid
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from time import perf_counter
+
+from silas.execution.sandbox import SandboxExecResult
+from silas.models.execution import Sandbox, SandboxConfig
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_IMAGE = "python:3.12-slim"
+
+
+class DockerSandboxManager:
+    """Docker-based sandbox backend for stronger isolation than subprocess.
+
+    Uses the docker CLI directly (no docker-py) so the only hard dependency
+    is a working ``docker`` binary on $PATH.  Falls back to raising clear
+    errors when Docker is unavailable rather than silently degrading.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_image: str = _DEFAULT_IMAGE,
+        docker_bin: str | None = None,
+    ) -> None:
+        self._base_image = base_image
+        # Resolve once so we fail fast if docker is missing
+        self._docker_bin = docker_bin or shutil.which("docker") or "docker"
+        self._containers: dict[str, _ContainerInfo] = {}
+
+    # --- SandboxManager protocol ------------------------------------------------
+
+    async def create(self, config: SandboxConfig) -> Sandbox:
+        if config.max_memory_mb <= 0:
+            raise ValueError("max_memory_mb must be greater than zero")
+        if config.max_cpu_seconds <= 0:
+            raise ValueError("max_cpu_seconds must be greater than zero")
+
+        sandbox_id = uuid.uuid4().hex
+        container_name = f"silas-sandbox-{sandbox_id[:12]}"
+        work_dir = str(Path(config.work_dir).resolve())
+
+        # Build `docker create` once; the container sits idle until exec calls
+        cmd = self._build_create_command(config, container_name, work_dir)
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"docker create failed (rc={proc.returncode}): {detail}")
+
+        container_id = stdout.decode().strip()
+
+        # Start the container so exec works
+        await self._run_docker("start", container_id)
+
+        sandbox = Sandbox(
+            sandbox_id=sandbox_id,
+            config=config.model_copy(deep=True),
+            work_dir=work_dir,
+        )
+        self._containers[sandbox_id] = _ContainerInfo(
+            container_id=container_id,
+            container_name=container_name,
+        )
+        return sandbox
+
+    async def exec(
+        self,
+        sandbox_id: str,
+        command: Sequence[str],
+        *,
+        timeout_seconds: float = 60,
+        env: Mapping[str, str] | None = None,
+        max_output_bytes: int = 100_000,
+    ) -> SandboxExecResult:
+        info = self._containers.get(sandbox_id)
+        if info is None:
+            raise KeyError(f"unknown sandbox_id '{sandbox_id}'")
+
+        exec_cmd: list[str] = [self._docker_bin, "exec"]
+
+        if env:
+            for key, val in env.items():
+                exec_cmd.extend(["-e", f"{key}={val}"])
+
+        exec_cmd.extend([info.container_id, *command])
+
+        started = perf_counter()
+        proc = await asyncio.create_subprocess_exec(
+            *exec_cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        timed_out = False
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=float(timeout_seconds),
+            )
+        except TimeoutError:
+            timed_out = True
+            proc.kill()
+            stdout_bytes, stderr_bytes = await proc.communicate()
+
+        duration = perf_counter() - started
+        return SandboxExecResult(
+            exit_code=proc.returncode,
+            stdout=_decode(stdout_bytes, max_output_bytes),
+            stderr=_decode(stderr_bytes, max_output_bytes),
+            timed_out=timed_out,
+            duration_seconds=duration,
+        )
+
+    async def destroy(self, sandbox_id: str) -> None:
+        info = self._containers.pop(sandbox_id, None)
+        if info is None:
+            return
+
+        # Force-remove stops and deletes in one call
+        await self._run_docker("rm", "-f", info.container_id)
+
+    # --- internals --------------------------------------------------------------
+
+    def _build_create_command(
+        self,
+        config: SandboxConfig,
+        container_name: str,
+        work_dir: str,
+    ) -> list[str]:
+        cmd: list[str] = [
+            self._docker_bin,
+            "create",
+            "--name",
+            container_name,
+            # Security: read-only root prevents writes outside designated dirs
+            "--read-only",
+            # Writable /tmp so programs that need temp files still work
+            "--tmpfs",
+            "/tmp:rw,noexec,size=64m",  # noqa: S108
+            # Mount the host working directory into the container
+            "-v",
+            f"{work_dir}:/workspace",
+            "-w",
+            "/workspace",
+        ]
+
+        # Resource limits — translate our config into docker flags
+        cmd.extend(["--memory", f"{config.max_memory_mb}m"])
+        cmd.extend(["--cpus", str(config.max_cpu_seconds)])
+
+        # Network isolation is the default; only enable networking when asked
+        if not config.network_access:
+            cmd.extend(["--network", "none"])
+
+        # Environment variables from config
+        for key, val in config.env.items():
+            cmd.extend(["-e", f"{key}={val}"])
+
+        # Keep container alive with a blocking entrypoint so `docker exec` works
+        cmd.extend([self._base_image, "sleep", "infinity"])
+        return cmd
+
+    async def _run_docker(self, *args: str) -> bytes:
+        proc = await asyncio.create_subprocess_exec(
+            self._docker_bin,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"docker {args[0]} failed (rc={proc.returncode}): {detail}")
+        return stdout
+
+
+class _ContainerInfo:
+    """Bookkeeping for a live container."""
+
+    __slots__ = ("container_id", "container_name")
+
+    def __init__(self, container_id: str, container_name: str) -> None:
+        self.container_id = container_id
+        self.container_name = container_name
+
+
+def _decode(data: bytes, max_bytes: int) -> str:
+    if max_bytes <= 0:
+        return ""
+    if len(data) > max_bytes:
+        data = data[:max_bytes]
+    return data.decode("utf-8", errors="replace")
+
+
+def is_docker_available(docker_bin: str | None = None) -> bool:
+    """Quick probe: can we talk to the Docker daemon?"""
+    bin_path = docker_bin or shutil.which("docker") or "docker"
+    try:
+        result = subprocess.run(
+            [bin_path, "info", "--format", "{{.ID}}"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+__all__ = ["DockerSandboxManager", "is_docker_available"]

--- a/silas/execution/sandbox_factory.py
+++ b/silas/execution/sandbox_factory.py
@@ -1,0 +1,42 @@
+"""Factory for selecting the sandbox backend based on config.
+
+Keeps the choice centralised so callers don't need to import both backends
+or duplicate the selection logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from silas.execution.docker_sandbox import DockerSandboxManager, is_docker_available
+from silas.execution.sandbox import SubprocessSandboxManager
+
+logger = logging.getLogger(__name__)
+
+SandboxBackend = Union[SubprocessSandboxManager, DockerSandboxManager]
+
+
+def create_sandbox_manager(
+    backend: str = "subprocess",
+    *,
+    docker_image: str = "python:3.12-slim",
+) -> SandboxBackend:
+    """Instantiate the right sandbox manager for *backend*.
+
+    Falls back to subprocess if Docker is requested but unavailable,
+    so the system degrades gracefully in environments without Docker.
+    """
+    if backend == "docker":
+        if is_docker_available():
+            logger.info("Using Docker sandbox backend")
+            return DockerSandboxManager(base_image=docker_image)
+        logger.warning(
+            "Docker sandbox requested but Docker is unavailable — "
+            "falling back to subprocess backend"
+        )
+
+    return SubprocessSandboxManager()
+
+
+__all__ = ["SandboxBackend", "create_sandbox_manager"]

--- a/silas/work/executor.py
+++ b/silas/work/executor.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 
 from silas.execution.python_exec import PythonExecutor
-from silas.execution.sandbox import SubprocessSandboxManager
+from silas.execution.sandbox_factory import create_sandbox_manager
 from silas.execution.shell import ShellExecutor
 from silas.models.execution import (
     ExecutionEnvelope,
@@ -53,7 +53,7 @@ class LiveWorkItemExecutor:
         self._verification_runner = verification_runner
         self._audit = audit
 
-        sandbox_manager = SubprocessSandboxManager()
+        sandbox_manager = create_sandbox_manager()
         self._executor_registry: dict[WorkItemExecutorType, object] = {
             WorkItemExecutorType.skill: skill_executor,
             WorkItemExecutorType.shell: shell_executor or ShellExecutor(sandbox_manager),

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -1,0 +1,269 @@
+"""Tests for the Docker sandbox backend.
+
+All tests mock the docker CLI — no real Docker daemon required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from silas.execution.docker_sandbox import DockerSandboxManager, is_docker_available
+from silas.execution.sandbox import SubprocessSandboxManager
+from silas.execution.sandbox_factory import create_sandbox_manager
+from silas.models.execution import SandboxConfig
+
+
+def _make_config(**overrides: object) -> SandboxConfig:
+    defaults: dict[str, object] = {
+        "work_dir": "/tmp/test-workdir",
+        "max_memory_mb": 256,
+        "max_cpu_seconds": 30,
+    }
+    defaults.update(overrides)
+    return SandboxConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _fake_process(
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    returncode: int = 0,
+) -> AsyncMock:
+    """Build a mock that quacks like asyncio.subprocess.Process."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.returncode = returncode
+    proc.pid = 12345
+    proc.kill = MagicMock()
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Container creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_calls_docker_create() -> None:
+    config = _make_config()
+    container_id = b"abc123containerid\n"
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        # First call: docker create; second call: docker start
+        mock_exec.side_effect = [
+            _fake_process(stdout=container_id),
+            _fake_process(),
+        ]
+        mgr = DockerSandboxManager(docker_bin="/usr/bin/docker")
+        sandbox = await mgr.create(config)
+
+    assert sandbox.sandbox_id
+    assert sandbox.work_dir == "/tmp/test-workdir"
+
+    # Verify docker create was called with expected args
+    create_call = mock_exec.call_args_list[0]
+    args = create_call[0]
+    assert args[0] == "/usr/bin/docker"
+    assert args[1] == "create"
+
+
+@pytest.mark.asyncio
+async def test_create_passes_resource_limits() -> None:
+    config = _make_config(max_memory_mb=1024, max_cpu_seconds=60)
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid\n"),
+            _fake_process(),
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        await mgr.create(config)
+
+    create_args = list(mock_exec.call_args_list[0][0])
+    # Memory limit should appear as --memory 1024m
+    mem_idx = create_args.index("--memory")
+    assert create_args[mem_idx + 1] == "1024m"
+    # CPU limit
+    cpu_idx = create_args.index("--cpus")
+    assert create_args[cpu_idx + 1] == "60"
+
+
+@pytest.mark.asyncio
+async def test_create_sets_network_none_by_default() -> None:
+    config = _make_config(network_access=False)
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid\n"),
+            _fake_process(),
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        await mgr.create(config)
+
+    create_args = list(mock_exec.call_args_list[0][0])
+    net_idx = create_args.index("--network")
+    assert create_args[net_idx + 1] == "none"
+
+
+@pytest.mark.asyncio
+async def test_create_allows_network_when_configured() -> None:
+    config = _make_config(network_access=True)
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid\n"),
+            _fake_process(),
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        await mgr.create(config)
+
+    create_args = list(mock_exec.call_args_list[0][0])
+    assert "--network" not in create_args
+
+
+@pytest.mark.asyncio
+async def test_create_uses_read_only_root() -> None:
+    config = _make_config()
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid\n"),
+            _fake_process(),
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        await mgr.create(config)
+
+    create_args = list(mock_exec.call_args_list[0][0])
+    assert "--read-only" in create_args
+    assert "--tmpfs" in create_args
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_bad_config() -> None:
+    mgr = DockerSandboxManager(docker_bin="docker")
+    with pytest.raises(ValueError, match="max_memory_mb"):
+        await mgr.create(_make_config(max_memory_mb=0))
+    with pytest.raises(ValueError, match="max_cpu_seconds"):
+        await mgr.create(_make_config(max_cpu_seconds=-1))
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_runs_command_in_container() -> None:
+    config = _make_config()
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid\n"),  # create
+            _fake_process(),  # start
+            _fake_process(stdout=b"hello\n", returncode=0),  # exec
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        sandbox = await mgr.create(config)
+        result = await mgr.exec(sandbox.sandbox_id, ["echo", "hello"])
+
+    assert result.stdout == "hello\n"
+    assert result.exit_code == 0
+    assert not result.timed_out
+
+    exec_call = mock_exec.call_args_list[2][0]
+    assert exec_call[0] == "docker"
+    assert exec_call[1] == "exec"
+    assert "cid" in exec_call  # container id
+
+
+@pytest.mark.asyncio
+async def test_exec_unknown_sandbox_raises() -> None:
+    mgr = DockerSandboxManager(docker_bin="docker")
+    with pytest.raises(KeyError, match="unknown sandbox_id"):
+        await mgr.exec("nonexistent", ["true"])
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_destroy_removes_container() -> None:
+    config = _make_config()
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        mock_exec.side_effect = [
+            _fake_process(stdout=b"cid123\n"),  # create
+            _fake_process(),  # start
+            _fake_process(),  # rm -f
+        ]
+        mgr = DockerSandboxManager(docker_bin="docker")
+        sandbox = await mgr.create(config)
+        await mgr.destroy(sandbox.sandbox_id)
+
+    rm_call = mock_exec.call_args_list[2][0]
+    assert rm_call[1] == "rm"
+    assert rm_call[2] == "-f"
+    assert "cid123" in rm_call[3]
+
+
+@pytest.mark.asyncio
+async def test_destroy_idempotent_for_unknown() -> None:
+    """Destroying an unknown sandbox should be a no-op."""
+    mgr = DockerSandboxManager(docker_bin="docker")
+    await mgr.destroy("does-not-exist")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# is_docker_available
+# ---------------------------------------------------------------------------
+
+
+def test_is_docker_available_true() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        assert is_docker_available("/usr/bin/docker") is True
+
+
+def test_is_docker_available_false_on_error() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)
+        assert is_docker_available("/usr/bin/docker") is False
+
+
+def test_is_docker_available_false_on_missing_binary() -> None:
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        assert is_docker_available("/nonexistent/docker") is False
+
+
+# ---------------------------------------------------------------------------
+# Factory / config flag
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_subprocess_by_default() -> None:
+    mgr = create_sandbox_manager("subprocess")
+    assert isinstance(mgr, SubprocessSandboxManager)
+
+
+def test_factory_returns_docker_when_available() -> None:
+    with patch("silas.execution.sandbox_factory.is_docker_available", return_value=True):
+        mgr = create_sandbox_manager("docker")
+    assert isinstance(mgr, DockerSandboxManager)
+
+
+def test_factory_falls_back_when_docker_unavailable() -> None:
+    with patch("silas.execution.sandbox_factory.is_docker_available", return_value=False):
+        mgr = create_sandbox_manager("docker")
+    assert isinstance(mgr, SubprocessSandboxManager)
+
+
+def test_sandbox_config_backend_field() -> None:
+    """SandboxConfig.backend accepts the expected string values."""
+    cfg = SandboxConfig(backend="docker")
+    assert cfg.backend == "docker"
+    cfg2 = SandboxConfig(backend="subprocess")
+    assert cfg2.backend == "subprocess"
+    cfg3 = SandboxConfig()
+    assert cfg3.backend is None


### PR DESCRIPTION
Adds Docker as optional sandbox backend.

- DockerSandboxManager: read-only root, tmpfs /tmp, network=none, resource limits
- sandbox_factory with graceful fallback to subprocess when Docker unavailable
- Config: execution.sandbox_backend = subprocess|docker
- 17 new tests (mocked), 768 total passing, ruff clean