### PR TITLE
feat: Telegram channel adapter

### DIFF
--- a/silas/channels/telegram.py
+++ b/silas/channels/telegram.py
@@ -1,0 +1,206 @@
+"""Telegram Bot API channel adapter.
+
+Uses raw HTTP (httpx) instead of python-telegram-bot to keep the dependency
+footprint minimal — we only need sendMessage + webhook ingestion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+import httpx
+
+from silas.models.messages import ChannelMessage, utc_now
+
+logger = logging.getLogger(__name__)
+
+# Telegram enforces a hard 4096 UTF-8 character limit per message.
+_TG_MAX_LEN = 4096
+
+_API_BASE = "https://api.telegram.org"
+
+
+@dataclass
+class TelegramConfig:
+    bot_token: str
+    owner_chat_ids: list[str] = field(default_factory=list)
+    webhook_path: str = "/telegram/webhook"
+
+
+def _split_text(text: str, limit: int = _TG_MAX_LEN) -> list[str]:
+    """Split long text into chunks that fit Telegram's message limit.
+
+    Tries to break on newlines to preserve readability; falls back to
+    hard splits when a single line exceeds the limit.
+    """
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining)
+            break
+
+        # Prefer splitting at the last newline within the limit
+        split_at = remaining.rfind("\n", 0, limit)
+        if split_at <= 0:
+            split_at = limit
+
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip("\n")
+
+    return chunks
+
+
+class TelegramChannel:
+    """Telegram channel adapter implementing ChannelAdapterCore.
+
+    Receives updates via webhook (FastAPI route) and sends responses
+    via the Bot API HTTP endpoint.
+    """
+
+    channel_name = "telegram"
+
+    def __init__(
+        self,
+        config: TelegramConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        # Allow injection for testing — avoids real HTTP in tests
+        self._http = http_client or httpx.AsyncClient(timeout=httpx.Timeout(15.0))
+        self._incoming: asyncio.Queue[tuple[ChannelMessage, str]] = asyncio.Queue()
+        self._owner_ids = set(config.owner_chat_ids)
+
+    @property
+    def api_url(self) -> str:
+        return f"{_API_BASE}/bot{self._config.bot_token}"
+
+    # ── Inbound (webhook) ────────────────────────────────────────────
+
+    async def handle_update(self, update: dict[str, object]) -> None:
+        """Parse a raw Telegram Update dict and enqueue as ChannelMessage.
+
+        Called by the webhook route handler. Silently drops updates that
+        don't contain a text message (edits, media, etc.) — those can be
+        added later without changing the interface.
+        """
+        message = update.get("message")
+        if not isinstance(message, dict):
+            return
+
+        text = message.get("text")
+        if not isinstance(text, str):
+            return
+
+        chat = message.get("chat", {})
+        if not isinstance(chat, dict):
+            return
+        chat_id = str(chat.get("id", ""))
+        if not chat_id:
+            return
+
+        reply_to_message_id: str | None = None
+        reply = message.get("reply_to_message")
+        if isinstance(reply, dict):
+            mid = reply.get("message_id")
+            if mid is not None:
+                reply_to_message_id = str(mid)
+
+        is_owner = chat_id in self._owner_ids
+
+        channel_msg = ChannelMessage(
+            channel=self.channel_name,
+            sender_id=chat_id,
+            text=text,
+            timestamp=utc_now(),
+            reply_to=reply_to_message_id,
+        )
+
+        # Session key doubles as taint signal — owner chat_ids get "owner"
+        # scope so the trust pipeline can elevate their messages.
+        session_id = "owner" if is_owner else f"tg:{chat_id}"
+        await self._incoming.put((channel_msg, session_id))
+
+    # ── ChannelAdapterCore ───────────────────────────────────────────
+
+    async def listen(self) -> AsyncIterator[tuple[ChannelMessage, str]]:
+        while True:
+            yield await self._incoming.get()
+
+    async def send(
+        self,
+        recipient_id: str,
+        text: str,
+        reply_to: str | None = None,
+    ) -> None:
+        """Send a message (possibly multi-part) to a Telegram chat."""
+        chunks = _split_text(text)
+        for chunk in chunks:
+            await self._send_message(recipient_id, chunk, reply_to=reply_to)
+            # Only thread the first chunk; subsequent chunks flow naturally
+            reply_to = None
+
+    async def send_stream_start(self, connection_id: str) -> None:
+        # Telegram has no streaming primitive — no-op by design.
+        pass
+
+    async def send_stream_chunk(self, connection_id: str, text: str) -> None:
+        # Could buffer and edit-in-place later; for now, no-op.
+        pass
+
+    async def send_stream_end(self, connection_id: str) -> None:
+        pass
+
+    # ── Bot API calls ────────────────────────────────────────────────
+
+    async def _send_message(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to: str | None = None,
+    ) -> dict[str, object]:
+        """POST sendMessage to the Telegram Bot API."""
+        payload: dict[str, object] = {
+            "chat_id": chat_id,
+            "text": text,
+            "parse_mode": "Markdown",
+        }
+        if reply_to is not None:
+            payload["reply_parameters"] = {"message_id": int(reply_to)}
+
+        url = f"{self.api_url}/sendMessage"
+        resp = await self._http.post(url, json=payload)
+        resp.raise_for_status()
+        result = resp.json()
+        if not isinstance(result, dict):
+            return {}
+        return result
+
+    # ── FastAPI route factory ────────────────────────────────────────
+
+    def register_routes(self, app: object) -> None:
+        """Attach the webhook POST route to a FastAPI app.
+
+        Kept as explicit registration rather than owning the app so Telegram
+        can coexist with WebChannel on the same server.
+        """
+        from fastapi import FastAPI, Request
+        from fastapi.responses import JSONResponse
+
+        assert isinstance(app, FastAPI)
+
+        @app.post(self._config.webhook_path)
+        async def telegram_webhook(request: Request) -> JSONResponse:
+            body = await request.json()
+            await self.handle_update(body)
+            # Telegram expects 200 OK quickly; async processing happens via queue
+            return JSONResponse({"ok": True})
+
+
+__all__ = ["TelegramChannel", "TelegramConfig"]

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,0 +1,174 @@
+"""Tests for the Telegram channel adapter."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from silas.channels.telegram import TelegramChannel, TelegramConfig, _split_text
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+def _make_channel(
+    owner_ids: list[str] | None = None,
+    transport: httpx.MockTransport | None = None,
+) -> TelegramChannel:
+    config = TelegramConfig(
+        bot_token="123:FAKE",
+        owner_chat_ids=owner_ids or ["111"],
+    )
+    client = httpx.AsyncClient(transport=transport or httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})))
+    return TelegramChannel(config=config, http_client=client)
+
+
+def _update(chat_id: int = 111, text: str = "hello", reply_to_msg_id: int | None = None) -> dict:
+    msg: dict = {
+        "message_id": 42,
+        "chat": {"id": chat_id, "type": "private"},
+        "from": {"id": chat_id, "is_bot": False, "first_name": "Test"},
+        "text": text,
+        "date": 1700000000,
+    }
+    if reply_to_msg_id is not None:
+        msg["reply_to_message"] = {"message_id": reply_to_msg_id}
+    return {"update_id": 1, "message": msg}
+
+
+# ── Webhook → ChannelMessage ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_update_to_channel_message() -> None:
+    ch = _make_channel()
+    await ch.handle_update(_update(chat_id=111, text="ping"))
+
+    msg, session = ch._incoming.get_nowait()
+    assert msg.channel == "telegram"
+    assert msg.sender_id == "111"
+    assert msg.text == "ping"
+    assert session == "owner"
+
+
+@pytest.mark.asyncio
+async def test_unknown_chat_id_not_owner() -> None:
+    ch = _make_channel(owner_ids=["111"])
+    await ch.handle_update(_update(chat_id=999, text="hi"))
+
+    msg, session = ch._incoming.get_nowait()
+    assert msg.sender_id == "999"
+    assert session == "tg:999"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_threading() -> None:
+    ch = _make_channel()
+    await ch.handle_update(_update(reply_to_msg_id=7))
+
+    msg, _ = ch._incoming.get_nowait()
+    assert msg.reply_to == "7"
+
+
+@pytest.mark.asyncio
+async def test_non_text_update_ignored() -> None:
+    ch = _make_channel()
+    # Photo message with no text field
+    await ch.handle_update({"update_id": 1, "message": {"message_id": 1, "chat": {"id": 111}, "photo": []}})
+    assert ch._incoming.empty()
+
+
+@pytest.mark.asyncio
+async def test_no_message_key_ignored() -> None:
+    ch = _make_channel()
+    await ch.handle_update({"update_id": 1, "edited_message": {"text": "edited"}})
+    assert ch._incoming.empty()
+
+
+# ── Message splitting ────────────────────────────────────────────────
+
+
+def test_short_message_no_split() -> None:
+    assert _split_text("hello") == ["hello"]
+
+
+def test_long_message_split_on_newline() -> None:
+    line = "x" * 2000
+    text = f"{line}\n{line}\n{line}"
+    chunks = _split_text(text, limit=4096)
+    assert all(len(c) <= 4096 for c in chunks)
+    # Reassembled content should match (modulo stripped newlines at boundaries)
+    assert "".join(chunks).replace("\n", "") == text.replace("\n", "")
+
+
+def test_long_message_hard_split() -> None:
+    # Single line longer than limit — must hard-split
+    text = "a" * 10000
+    chunks = _split_text(text, limit=4096)
+    assert len(chunks) == 3
+    assert chunks[0] == "a" * 4096
+    assert chunks[1] == "a" * 4096
+    assert chunks[2] == "a" * 1808
+
+
+# ── send_message ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_message_calls_api() -> None:
+    requests_made: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_made.append(request)
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+
+    ch = _make_channel(transport=httpx.MockTransport(handler))
+    await ch.send("111", "hello world", reply_to="5")
+
+    assert len(requests_made) == 1
+    import json
+    body = json.loads(requests_made[0].content)
+    assert body["chat_id"] == "111"
+    assert body["text"] == "hello world"
+    assert body["parse_mode"] == "Markdown"
+    assert body["reply_parameters"] == {"message_id": 5}
+
+
+@pytest.mark.asyncio
+async def test_send_long_message_splits() -> None:
+    requests_made: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_made.append(request)
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+
+    ch = _make_channel(transport=httpx.MockTransport(handler))
+    await ch.send("111", "a" * 5000)
+
+    # Should split into 2 chunks
+    assert len(requests_made) == 2
+
+
+@pytest.mark.asyncio
+async def test_send_reply_to_only_first_chunk() -> None:
+    """Only the first chunk should carry reply_to; rest flow naturally."""
+    import json
+    requests_made: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_made.append(request)
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+
+    ch = _make_channel(transport=httpx.MockTransport(handler))
+    await ch.send("111", "a" * 5000, reply_to="10")
+
+    body_0 = json.loads(requests_made[0].content)
+    body_1 = json.loads(requests_made[1].content)
+    assert "reply_parameters" in body_0
+    assert "reply_parameters" not in body_1
+
+
+# ── channel_name property ───────────────────────────────────────────
+
+
+def test_channel_name() -> None:
+    ch = _make_channel()
+    assert ch.channel_name == "telegram"


### PR DESCRIPTION
Adds TelegramChannel implementing ChannelAdapterCore.

- Webhook → ChannelMessage conversion with owner detection
- Outbound via sendMessage with Markdown, >4096 char splitting (newline-aware)
- reply_to threading, FastAPI route registration
- 12 new tests (mocked httpx), ruff clean