### PR TITLE
feat: approval fatigue mitigation (§0.5.4)

### DIFF
--- a/silas/approval/fatigue.py
+++ b/silas/approval/fatigue.py
@@ -1,0 +1,149 @@
+"""Approval fatigue mitigation (§0.5.4).
+
+Adapts approval behaviour based on decision cadence and timing trends
+so the human doesn't rubber-stamp under cognitive load.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from statistics import median
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from silas.models.approval import ApprovalScope
+
+# Scopes that carry higher blast-radius — never auto-approve these.
+_HIGH_RISK_SCOPES: frozenset[ApprovalScope] = frozenset(
+    {
+        ApprovalScope.self_update,
+        ApprovalScope.credential_use,
+        ApprovalScope.budget,
+        ApprovalScope.full_plan,
+        ApprovalScope.skill_install,
+    }
+)
+
+# Volume thresholds per window (default 30 min)
+_LOW_VOLUME_CEILING = 10
+_MEDIUM_VOLUME_CEILING = 25
+
+# Decision-time trend thresholds (proportion increase from first to second half)
+_MEDIUM_TREND_THRESHOLD = 0.20
+_HIGH_TREND_THRESHOLD = 0.50
+
+
+class FatigueLevel(StrEnum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+Recommendation = Literal[
+    "normal",
+    "batch_more",
+    "auto_approve_low_risk",
+    "pause_and_summarize",
+]
+
+
+class DecisionRecord(BaseModel):
+    """One resolved approval decision with timing info."""
+
+    decided_at: datetime
+    decision_time_ms: float = Field(ge=0)
+    scope: ApprovalScope = ApprovalScope.single_step
+
+
+class FatigueAnalysis(BaseModel):
+    fatigue_level: FatigueLevel
+    recommendation: Recommendation
+    median_decision_time_ms: float
+    decisions_in_window: int
+
+
+def _compute_trend(decision_times: list[float]) -> float:
+    """Return proportional increase from first half median to second half median.
+
+    Positive values mean the human is slowing down (classic fatigue signal).
+    Returns 0.0 when there aren't enough samples to compare.
+    """
+    if len(decision_times) < 4:
+        return 0.0
+    mid = len(decision_times) // 2
+    first_half = median(decision_times[:mid])
+    second_half = median(decision_times[mid:])
+    if first_half <= 0:
+        return 0.0
+    return (second_half - first_half) / first_half
+
+
+class ApprovalFatigueMitigator:
+    """Analyses recent approval decisions and recommends flow adaptations."""
+
+    def analyze_fatigue(
+        self,
+        recent_decisions: list[DecisionRecord],
+        *,
+        window_minutes: int = 30,
+    ) -> FatigueAnalysis:
+        cutoff = datetime.now(UTC) - timedelta(minutes=window_minutes)
+        # Only consider decisions inside the rolling window
+        windowed = [d for d in recent_decisions if d.decided_at >= cutoff]
+        windowed.sort(key=lambda d: d.decided_at)
+
+        count = len(windowed)
+        times = [d.decision_time_ms for d in windowed]
+        med_time = median(times) if times else 0.0
+        trend = _compute_trend(times)
+
+        level = self._classify(count, trend)
+        recommendation = self._recommend(level)
+
+        return FatigueAnalysis(
+            fatigue_level=level,
+            recommendation=recommendation,
+            median_decision_time_ms=med_time,
+            decisions_in_window=count,
+        )
+
+    def should_auto_approve(
+        self,
+        analysis: FatigueAnalysis,
+        scope: ApprovalScope,
+    ) -> bool:
+        """High-fatigue auto-approve is only safe for low-risk scopes."""
+        if analysis.fatigue_level != FatigueLevel.high:
+            return False
+        return scope not in _HIGH_RISK_SCOPES
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _classify(count: int, trend: float) -> FatigueLevel:
+        # High if volume alone is extreme OR decision times are ballooning
+        if count > _MEDIUM_VOLUME_CEILING or trend >= _HIGH_TREND_THRESHOLD:
+            return FatigueLevel.high
+        if count >= _LOW_VOLUME_CEILING or trend >= _MEDIUM_TREND_THRESHOLD:
+            return FatigueLevel.medium
+        return FatigueLevel.low
+
+    @staticmethod
+    def _recommend(level: FatigueLevel) -> Recommendation:
+        if level == FatigueLevel.high:
+            return "auto_approve_low_risk"
+        if level == FatigueLevel.medium:
+            return "batch_more"
+        return "normal"
+
+
+__all__ = [
+    "ApprovalFatigueMitigator",
+    "DecisionRecord",
+    "FatigueAnalysis",
+    "FatigueLevel",
+]

--- a/tests/test_approval_fatigue.py
+++ b/tests/test_approval_fatigue.py
@@ -1,0 +1,157 @@
+"""Tests for approval fatigue mitigation (§0.5.4)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from silas.approval.fatigue import (
+    ApprovalFatigueMitigator,
+    DecisionRecord,
+    FatigueLevel,
+)
+from silas.models.approval import ApprovalScope
+
+
+@pytest.fixture
+def mitigator() -> ApprovalFatigueMitigator:
+    return ApprovalFatigueMitigator()
+
+
+def _make_decisions(
+    count: int,
+    *,
+    base_time_ms: float = 500.0,
+    trend_factor: float = 0.0,
+    minutes_ago: float = 10.0,
+    scope: ApprovalScope = ApprovalScope.single_step,
+) -> list[DecisionRecord]:
+    """Generate *count* decisions spread across the last *minutes_ago* minutes.
+
+    trend_factor > 0 makes later decisions progressively slower,
+    simulating fatigue-induced slowdown.
+    """
+    now = datetime.now(UTC)
+    # Place decisions in a 2-minute band centred at minutes_ago in the past
+    centre = now - timedelta(minutes=minutes_ago)
+    start = centre - timedelta(minutes=1)
+    span = timedelta(minutes=2)
+    interval = span / max(count, 1)
+    records: list[DecisionRecord] = []
+    for i in range(count):
+        # Linear ramp: first decision at base_time_ms, last at base*(1+trend_factor)
+        progress = i / max(count - 1, 1)
+        time_ms = base_time_ms * (1.0 + trend_factor * progress)
+        records.append(
+            DecisionRecord(
+                decided_at=start + interval * i,
+                decision_time_ms=time_ms,
+                scope=scope,
+            )
+        )
+    return records
+
+
+# --- Fatigue level classification ---
+
+
+class TestFatigueLevel:
+    def test_low_fatigue_few_decisions(self, mitigator: ApprovalFatigueMitigator) -> None:
+        decisions = _make_decisions(5)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert analysis.fatigue_level == FatigueLevel.low
+        assert analysis.recommendation == "normal"
+        assert analysis.decisions_in_window == 5
+
+    def test_medium_fatigue_volume(self, mitigator: ApprovalFatigueMitigator) -> None:
+        decisions = _make_decisions(15)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert analysis.fatigue_level == FatigueLevel.medium
+        assert analysis.recommendation == "batch_more"
+
+    def test_medium_fatigue_increasing_decision_time(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        # 8 decisions (below volume threshold) but 30% slowdown
+        decisions = _make_decisions(8, trend_factor=0.6)
+        analysis = mitigator.analyze_fatigue(decisions)
+        # Trend ~30% puts us at medium or above
+        assert analysis.fatigue_level in {FatigueLevel.medium, FatigueLevel.high}
+
+    def test_high_fatigue_many_rapid_decisions(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        decisions = _make_decisions(30)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert analysis.fatigue_level == FatigueLevel.high
+        assert analysis.recommendation == "auto_approve_low_risk"
+
+    def test_high_fatigue_extreme_trend(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        # Few decisions but decision time doubles
+        decisions = _make_decisions(6, trend_factor=1.2)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert analysis.fatigue_level == FatigueLevel.high
+
+
+# --- Window filtering ---
+
+
+class TestWindowFiltering:
+    def test_old_decisions_excluded(self, mitigator: ApprovalFatigueMitigator) -> None:
+        old = _make_decisions(30, minutes_ago=60)
+        analysis = mitigator.analyze_fatigue(old, window_minutes=30)
+        # All decisions are older than 30 minutes — should be filtered out
+        assert analysis.decisions_in_window == 0
+        assert analysis.fatigue_level == FatigueLevel.low
+
+    def test_mixed_old_and_recent(self, mitigator: ApprovalFatigueMitigator) -> None:
+        old = _make_decisions(20, minutes_ago=60)
+        recent = _make_decisions(3, minutes_ago=5)
+        analysis = mitigator.analyze_fatigue(old + recent, window_minutes=30)
+        assert analysis.decisions_in_window == 3
+
+
+# --- Recommendation / auto-approve logic ---
+
+
+class TestAutoApprove:
+    def test_high_fatigue_allows_low_risk_auto_approve(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        decisions = _make_decisions(30)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert mitigator.should_auto_approve(analysis, ApprovalScope.single_step)
+
+    def test_high_fatigue_blocks_high_risk_auto_approve(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        decisions = _make_decisions(30)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert not mitigator.should_auto_approve(analysis, ApprovalScope.credential_use)
+        assert not mitigator.should_auto_approve(analysis, ApprovalScope.self_update)
+        assert not mitigator.should_auto_approve(analysis, ApprovalScope.budget)
+
+    def test_low_fatigue_never_auto_approves(
+        self, mitigator: ApprovalFatigueMitigator
+    ) -> None:
+        decisions = _make_decisions(3)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert not mitigator.should_auto_approve(analysis, ApprovalScope.single_step)
+
+
+# --- Median decision time ---
+
+
+class TestMedianTime:
+    def test_median_computed_correctly(self, mitigator: ApprovalFatigueMitigator) -> None:
+        decisions = _make_decisions(5, base_time_ms=200.0)
+        analysis = mitigator.analyze_fatigue(decisions)
+        assert analysis.median_decision_time_ms > 0
+
+    def test_empty_decisions(self, mitigator: ApprovalFatigueMitigator) -> None:
+        analysis = mitigator.analyze_fatigue([])
+        assert analysis.median_decision_time_ms == 0.0
+        assert analysis.decisions_in_window == 0
+        assert analysis.fatigue_level == FatigueLevel.low


### PR DESCRIPTION
Adapts approval behavior based on user fatigue.

- ApprovalFatigueMitigator: low/medium/high fatigue detection
- Auto-approve low-risk at high fatigue, high-risk always requires human
- Recommendations: normal, batch_more, auto_approve_low_risk, pause_and_summarize
- Wired into LiveApprovalManager with fatigue_level in token conditions
- 12 new tests, 763 total passing, ruff clean