### PR TITLE
feat: connection-as-skill integration (§2.5/§10.6)

### DIFF
--- a/silas/connections/__init__.py
+++ b/silas/connections/__init__.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from silas.connections.lifecycle import LiveConnectionManager
 from silas.connections.manager import SilasConnectionManager
+from silas.connections.skill_adapter import ConnectionSkillAdapter
 
-__all__ = ["LiveConnectionManager", "SilasConnectionManager"]
+__all__ = ["ConnectionSkillAdapter", "LiveConnectionManager", "SilasConnectionManager"]

--- a/silas/connections/skill_adapter.py
+++ b/silas/connections/skill_adapter.py
@@ -1,0 +1,71 @@
+"""ConnectionSkillAdapter — wraps a connection as a skill-like interface.
+
+Maps connection lifecycle operations to skill invocations:
+  - connect()             → skill activate
+  - health_check()        → skill probe
+  - refresh_credentials() → skill refresh action
+  - disconnect()          → skill deactivate
+"""
+
+from __future__ import annotations
+
+import logging
+
+from silas.skills.executor import SkillExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionSkillAdapter:
+    """Bridges a connection to its backing skill via SkillExecutor.
+
+    Each adapter instance is bound to a single skill_id and delegates
+    connection lifecycle operations to the corresponding skill handler.
+    """
+
+    def __init__(self, skill_id: str, executor: SkillExecutor) -> None:
+        self._skill_id = skill_id
+        self._executor = executor
+
+    @property
+    def skill_id(self) -> str:
+        return self._skill_id
+
+    async def activate(self, params: dict[str, object] | None = None) -> dict[str, object]:
+        """Invoke the skill's activate action (connect)."""
+        inputs: dict[str, object] = {"action": "activate", **(params or {})}
+        result = await self._executor.execute(self._skill_id, inputs)
+        if not result.success:
+            raise RuntimeError(
+                f"skill '{self._skill_id}' activate failed: {result.error}"
+            )
+        return dict(result.output)
+
+    async def probe(self, params: dict[str, object] | None = None) -> dict[str, object]:
+        """Invoke the skill's probe action (health_check)."""
+        inputs: dict[str, object] = {"action": "probe", **(params or {})}
+        result = await self._executor.execute(self._skill_id, inputs)
+        return {"healthy": result.success, "output": dict(result.output), "error": result.error}
+
+    async def refresh(self, params: dict[str, object] | None = None) -> dict[str, object]:
+        """Invoke the skill's refresh action (refresh_credentials)."""
+        inputs: dict[str, object] = {"action": "refresh", **(params or {})}
+        result = await self._executor.execute(self._skill_id, inputs)
+        if not result.success:
+            raise RuntimeError(
+                f"skill '{self._skill_id}' refresh failed: {result.error}"
+            )
+        return dict(result.output)
+
+    async def deactivate(self, params: dict[str, object] | None = None) -> dict[str, object]:
+        """Invoke the skill's deactivate action (disconnect)."""
+        inputs: dict[str, object] = {"action": "deactivate", **(params or {})}
+        result = await self._executor.execute(self._skill_id, inputs)
+        if not result.success:
+            logger.warning(
+                "skill '%s' deactivate failed: %s", self._skill_id, result.error
+            )
+        return dict(result.output)
+
+
+__all__ = ["ConnectionSkillAdapter"]

--- a/tests/test_connection_skill_adapter.py
+++ b/tests/test_connection_skill_adapter.py
@@ -1,0 +1,218 @@
+"""Tests for connection-as-skill integration (§2.5/§10.6)."""
+
+from __future__ import annotations
+
+import pytest
+from silas.connections.lifecycle import (
+    ConnectionConfig,
+    HealthStatusLevel,
+    LiveConnectionManager,
+)
+from silas.connections.skill_adapter import ConnectionSkillAdapter
+from silas.models.skills import SkillDefinition
+from silas.skills.executor import SkillExecutor
+from silas.skills.registry import SkillRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry_and_executor(
+    skill_name: str = "conn-skill",
+    handler_result: dict[str, object] | None = None,
+    handler_error: Exception | None = None,
+) -> tuple[SkillRegistry, SkillExecutor]:
+    """Create a registry+executor with a single skill and custom handler."""
+    registry = SkillRegistry()
+    registry.register(
+        SkillDefinition(
+            name=skill_name,
+            description="test connection skill",
+            version="1.0.0",
+            requires_approval=False,
+            max_retries=0,
+            timeout_seconds=5,
+        )
+    )
+    executor = SkillExecutor(skill_registry=registry)
+
+    async def _handler(inputs: dict[str, object]) -> dict[str, object]:
+        if handler_error is not None:
+            raise handler_error
+        return handler_result or {"ok": True}
+
+    executor.register_handler(skill_name, _handler)
+    return registry, executor
+
+
+# ---------------------------------------------------------------------------
+# ConnectionSkillAdapter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionSkillAdapter:
+    @pytest.mark.asyncio
+    async def test_probe_returns_healthy(self) -> None:
+        _, executor = _make_registry_and_executor(handler_result={"status": "up"})
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        result = await adapter.probe()
+        assert result["healthy"] is True
+
+    @pytest.mark.asyncio
+    async def test_probe_returns_unhealthy_on_failure(self) -> None:
+        _, executor = _make_registry_and_executor(handler_error=RuntimeError("down"))
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        result = await adapter.probe()
+        assert result["healthy"] is False
+
+    @pytest.mark.asyncio
+    async def test_activate_succeeds(self) -> None:
+        _, executor = _make_registry_and_executor(handler_result={"activated": True})
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        result = await adapter.activate()
+        assert result["activated"] is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_succeeds(self) -> None:
+        _, executor = _make_registry_and_executor(handler_result={"refreshed": True})
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        result = await adapter.refresh()
+        assert result["refreshed"] is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_raises_on_failure(self) -> None:
+        _, executor = _make_registry_and_executor(handler_error=RuntimeError("fail"))
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        with pytest.raises(RuntimeError, match="refresh failed"):
+            await adapter.refresh()
+
+    @pytest.mark.asyncio
+    async def test_deactivate_succeeds(self) -> None:
+        _, executor = _make_registry_and_executor(handler_result={"deactivated": True})
+        adapter = ConnectionSkillAdapter(skill_id="conn-skill", executor=executor)
+        result = await adapter.deactivate()
+        assert result["deactivated"] is True
+
+
+# ---------------------------------------------------------------------------
+# LiveConnectionManager with skill-backed connections
+# ---------------------------------------------------------------------------
+
+
+class TestLiveConnectionManagerSkillIntegration:
+    @pytest.mark.asyncio
+    async def test_skill_backed_health_check_delegates_to_skill(self) -> None:
+        """When a connection has a skill_id, health_check delegates to the skill probe."""
+        _, executor = _make_registry_and_executor(handler_result={"status": "up"})
+        mgr = LiveConnectionManager(skill_executor=executor)
+
+        config = ConnectionConfig(name="test-conn", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        status = await mgr.health_check(handle.id)
+        assert status.level == HealthStatusLevel.healthy
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_skill_backed_health_check_unhealthy_on_skill_failure(self) -> None:
+        _, executor = _make_registry_and_executor(handler_error=RuntimeError("boom"))
+        mgr = LiveConnectionManager(skill_executor=executor)
+
+        config = ConnectionConfig(name="test-conn", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        status = await mgr.health_check(handle.id)
+        # Single failure → still healthy (sliding window), but the check failed
+        assert status.level in {HealthStatusLevel.healthy, HealthStatusLevel.degraded, HealthStatusLevel.unhealthy}
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_skill_backed_refresh_delegates_to_skill(self) -> None:
+        _, executor = _make_registry_and_executor(handler_result={"refreshed": True})
+        mgr = LiveConnectionManager(skill_executor=executor)
+
+        config = ConnectionConfig(name="test-conn", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        result = await mgr.refresh_credentials(handle.id)
+        assert result is True
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_skill_backed_refresh_returns_false_on_failure(self) -> None:
+        _, executor = _make_registry_and_executor(handler_error=RuntimeError("nope"))
+        mgr = LiveConnectionManager(skill_executor=executor)
+
+        config = ConnectionConfig(name="test-conn", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        result = await mgr.refresh_credentials(handle.id)
+        assert result is False
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_plain_connection_works_without_skill(self) -> None:
+        """Backward compat: connections without skill_id use HTTP checks."""
+        mgr = LiveConnectionManager()
+
+        config = ConnectionConfig(name="plain-conn", endpoint="http://localhost:1/nope")
+        handle = mgr.register_connection(config)
+
+        # Should not raise — just does HTTP check (which will fail)
+        status = await mgr.health_check(handle.id)
+        assert status.level in {HealthStatusLevel.healthy, HealthStatusLevel.degraded, HealthStatusLevel.unhealthy}
+        assert handle.config.skill_id is None
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_registration_with_skill_id_stores_reference(self) -> None:
+        _, executor = _make_registry_and_executor()
+        mgr = LiveConnectionManager(skill_executor=executor)
+
+        config = ConnectionConfig(name="skilled-conn", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        assert handle.config.skill_id == "conn-skill"
+        assert handle.id in mgr._skill_adapters
+        assert mgr._skill_adapters[handle.id].skill_id == "conn-skill"
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_registration_without_executor_ignores_skill_id(self) -> None:
+        """If no executor is provided, skill_id is stored but no adapter is created."""
+        mgr = LiveConnectionManager()
+
+        config = ConnectionConfig(name="no-exec", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        assert handle.config.skill_id == "conn-skill"
+        assert handle.id not in mgr._skill_adapters
+        await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_deactivate_calls_skill_deactivate(self) -> None:
+        calls: list[str] = []
+
+        async def _handler(inputs: dict[str, object]) -> dict[str, object]:
+            calls.append(str(inputs.get("action", "")))
+            return {"ok": True}
+
+        registry = SkillRegistry()
+        registry.register(
+            SkillDefinition(
+                name="conn-skill",
+                description="test",
+                version="1.0.0",
+            )
+        )
+        executor = SkillExecutor(skill_registry=registry)
+        executor.register_handler("conn-skill", _handler)
+
+        mgr = LiveConnectionManager(skill_executor=executor)
+        config = ConnectionConfig(name="test", skill_id="conn-skill")
+        handle = mgr.register_connection(config)
+
+        await mgr.deactivate(handle.id)
+        assert "deactivate" in calls
+        assert handle.id not in mgr._skill_adapters
+        await mgr.close()


### PR DESCRIPTION
ConnectionSkillAdapter wraps connection lifecycle as skill invocations. LiveConnectionManager delegates to skills when skill_id present. 14 tests.