### PR TITLE
chore: add community files — LICENSE, CONTRIBUTING, SECURITY, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug in Silas
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What should happen.
+
+## Actual Behavior
+
+What actually happens.
+
+## Environment
+
+- OS: 
+- Python version: 
+- Silas version/commit: 
+
+## Additional Context
+
+Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a feature or improvement
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this solve?
+
+## Proposed Solution
+
+How should it work?
+
+## Spec Reference
+
+If this relates to a section in `specs.md`, reference it here (e.g., §5.2.1).
+
+## Alternatives Considered
+
+Any other approaches you considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What
+
+Brief description of the change.
+
+## Why
+
+What problem does this solve? Link to issue if applicable.
+
+## Spec Reference
+
+Section(s) of `specs.md` this implements (e.g., §5.2.1, §10.4).
+
+## Changes
+
+- ...
+- ...
+
+## Testing
+
+- [ ] Tests added/updated
+- [ ] `uv run ruff check silas/ tests/` passes
+- [ ] `uv run pyright silas/` passes
+- [ ] `uv run pytest tests/ -v` passes
+
+## Notes
+
+Anything reviewers should know.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at [david@feldhofer.cc](mailto:david@feldhofer.cc).
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to Silas
+
+Thanks for your interest in contributing! Silas is an AI agent runtime with structured execution, approval gates, and persistent memory.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/) for package management
+
+### Setup
+
+```bash
+git clone https://github.com/DavSimFel/silas.git
+cd silas
+git checkout dev
+uv sync --dev
+```
+
+### Run Tests
+
+```bash
+uv run pytest tests/ -v --tb=short
+```
+
+### Lint & Type Check
+
+```bash
+uv run ruff check silas/ tests/
+uv run pyright silas/
+```
+
+All three must pass before submitting a PR.
+
+## Development Workflow
+
+### Branch Strategy
+
+- **`main`** — stable releases only. Requires 1 approving review.
+- **`dev`** — integration branch. All feature work targets `dev`.
+- **Feature branches** — `feat/*`, `fix/*`, `chore/*`, `refactor/*` off `dev`.
+
+### Pull Requests
+
+1. Fork the repo and create a feature branch from `dev`
+2. Make your changes with tests
+3. Ensure CI is green (lint + types + tests)
+4. Open a PR targeting `dev`
+5. PRs to `main` are opened by maintainers only
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add Telegram channel adapter
+fix: timezone collision detection in slot allocator
+chore: update dependencies
+refactor: split stream.py into focused modules
+test: add concurrent turn isolation tests
+docs: update architecture overview
+```
+
+## Code Standards
+
+- **Type hints on everything** — all function signatures, all variables where not obvious
+- **Docstrings on all public methods** — explain *why*, not just *what*
+- **Inline comments for non-obvious logic** — if you had to think about it, comment it
+- **No bare `except:`** — always catch specific exceptions
+- **No `print()`** — use `logging.getLogger(__name__)`
+- **Timezone-aware datetimes** — `datetime.now(datetime.UTC)`, never naive
+- **Cyclomatic complexity < 12** — extract helpers if needed
+
+Enforced rules: `E, F, I, B, N, C901, UP, SIM, RUF, PT, S, DTZ, PIE, T20`
+
+## Architecture
+
+Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for an overview of how the system fits together. The full specification lives in [`specs.md`](specs.md).
+
+Key directories:
+
+| Directory | Purpose |
+|-----------|---------|
+| `silas/agents/` | Proxy, planner, executor agents (PydanticAI) |
+| `silas/approval/` | Ed25519 approval token system |
+| `silas/core/` | Stream (main loop), context manager, plan parser |
+| `silas/execution/` | Sandbox backends, shell/Python executors |
+| `silas/gates/` | Policy + quality gate providers |
+| `silas/memory/` | SQLite memory store + FTS5 retrieval |
+| `silas/models/` | All Pydantic domain models |
+| `silas/protocols/` | Typed Protocol interfaces |
+| `silas/skills/` | Skill loader, resolver, validator |
+| `tests/` | Unit + integration tests |
+
+## What to Work On
+
+Check the [issues](https://github.com/DavSimFel/silas/issues) for open tasks. Issues labeled `good first issue` are a good starting point.
+
+If you want to work on something not yet filed, open an issue first to discuss the approach.
+
+## Spec Compliance
+
+Silas is built against a detailed specification (`specs.md`). When implementing features:
+
+1. Read the relevant spec section first
+2. Check `STATUS.md` for current implementation state
+3. Follow the spec's contracts — don't improvise interfaces
+4. If the spec is wrong or ambiguous, open an issue to discuss before diverging
+
+## Security
+
+If you find a security vulnerability, **do not open a public issue**. Email [david@feldhofer.cc](mailto:david@feldhofer.cc) instead.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 David Feldhofer
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Silas, **please do not open a public issue**.
+
+Instead, report it privately via email to [david@feldhofer.cc](mailto:david@feldhofer.cc).
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You'll receive acknowledgment within 48 hours. We'll work with you on a fix before any public disclosure.
+
+## Scope
+
+Security-relevant areas of Silas include:
+
+- **Approval system** — Ed25519 token signing, plan hash binding, nonce replay protection
+- **Sandbox execution** — process isolation, network access controls
+- **Gate system** — policy enforcement, input/output filtering
+- **Credential handling** — OS keyring isolation, secret non-exposure
+- **Access control** — per-connection scope isolation, tool filtering
+- **Taint tracking** — trust classification propagation
+
+## Supported Versions
+
+Only the latest version on the `dev` branch receives security updates. There are no stable releases yet.


### PR DESCRIPTION
## What
Adds standard open-source community files for the Silas repo.

## Changes
- **LICENSE** — Apache 2.0
- **CONTRIBUTING.md** — dev setup, workflow, code standards, spec compliance guidance
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **SECURITY.md** — vulnerability reporting policy
- **Issue templates** — bug report + feature request
- **PR template** — checklist with spec reference field

Also updated repo metadata (description + topics) via GitHub API.