### PR TITLE
feat: create GitHub skill for executor (#178)

### DIFF
--- a/silas/skills/shipped/github_skill.py
+++ b/silas/skills/shipped/github_skill.py
@@ -1,0 +1,380 @@
+"""GitHub skill — exposes repo operations via the ``gh`` CLI.
+
+Every tool function shells out to ``gh`` / ``git`` so we piggy-back on
+whatever authentication the host already has (``gh auth login``).
+All functions are async-friendly but block on subprocess calls wrapped
+with :func:`asyncio.to_thread`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+from silas.models.skills import SkillDefinition
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    check: bool = True,
+) -> dict[str, object]:
+    """Run *cmd* and return structured result or error."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            check=check,
+            timeout=120,
+        )
+        return {"stdout": proc.stdout, "stderr": proc.stderr, "returncode": proc.returncode}
+    except subprocess.CalledProcessError as exc:
+        return {
+            "error": f"command failed with exit code {exc.returncode}",
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+            "returncode": exc.returncode,
+        }
+    except subprocess.TimeoutExpired:
+        return {"error": "command timed out after 120 seconds", "returncode": -1}
+    except FileNotFoundError:
+        return {"error": f"command not found: {cmd[0]}", "returncode": -1}
+
+
+async def _arun(
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    check: bool = True,
+) -> dict[str, object]:
+    return await asyncio.to_thread(_run, cmd, cwd=cwd, check=check)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+async def read_issue(inputs: dict[str, object]) -> dict[str, object]:
+    """Fetch issue details (title, body, labels, comments)."""
+    repo = _req_str(inputs, "repo")
+    issue_number = _req_int(inputs, "issue_number")
+
+    result = await _arun(
+        [
+            "gh", "issue", "view", str(issue_number),
+            "--repo", repo,
+            "--json", "title,body,labels,comments,state,number",
+        ],
+    )
+    if "error" in result:
+        return result
+
+    data = json.loads(str(result["stdout"]))
+    return {"issue": data}
+
+
+async def create_branch(inputs: dict[str, object]) -> dict[str, object]:
+    """Create a feature branch from *base* (default ``dev``)."""
+    repo_path = _req_str(inputs, "repo_path")
+    branch_name = _req_str(inputs, "branch_name")
+    base = str(inputs.get("base", "dev"))
+
+    # Fetch and create branch
+    fetch = await _arun(["git", "fetch", "origin", base], cwd=repo_path)
+    if "error" in fetch:
+        return fetch
+
+    result = await _arun(
+        ["git", "checkout", "-b", branch_name, f"origin/{base}"],
+        cwd=repo_path,
+    )
+    if "error" in result:
+        return result
+
+    return {"branch": branch_name, "base": base}
+
+
+async def read_file(inputs: dict[str, object]) -> dict[str, object]:
+    """Read a file from the repo working tree."""
+    repo_path = _req_str(inputs, "repo_path")
+    file_path = _req_str(inputs, "file_path")
+
+    target = Path(repo_path) / file_path
+    resolved = target.resolve()
+    repo_resolved = Path(repo_path).resolve()
+    if not str(resolved).startswith(str(repo_resolved)):
+        return {"error": "path traversal detected"}
+
+    try:
+        content = target.read_text()
+    except FileNotFoundError:
+        return {"error": f"file not found: {file_path}"}
+    except OSError as exc:
+        return {"error": str(exc)}
+
+    return {"content": content, "path": file_path}
+
+
+async def write_file(inputs: dict[str, object]) -> dict[str, object]:
+    """Write *content* to a file in the repo working tree."""
+    repo_path = _req_str(inputs, "repo_path")
+    file_path = _req_str(inputs, "file_path")
+    content = _req_str(inputs, "content")
+
+    target = Path(repo_path) / file_path
+    resolved = target.resolve()
+    repo_resolved = Path(repo_path).resolve()
+    if not str(resolved).startswith(str(repo_resolved)):
+        return {"error": "path traversal detected"}
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    return {"written": file_path, "bytes": len(content.encode())}
+
+
+async def commit_and_push(inputs: dict[str, object]) -> dict[str, object]:
+    """Stage all changes, commit, and push to origin."""
+    repo_path = _req_str(inputs, "repo_path")
+    message = _req_str(inputs, "message")
+    branch = str(inputs.get("branch", ""))
+
+    add = await _arun(["git", "add", "-A"], cwd=repo_path)
+    if "error" in add:
+        return add
+
+    commit = await _arun(["git", "commit", "-m", message], cwd=repo_path)
+    if "error" in commit:
+        return commit
+
+    push_cmd = ["git", "push", "origin"]
+    if branch:
+        push_cmd.append(branch)
+    push = await _arun(push_cmd, cwd=repo_path)
+    if "error" in push:
+        return push
+
+    return {"committed": True, "message": message}
+
+
+async def create_pr(inputs: dict[str, object]) -> dict[str, object]:
+    """Open a pull request via ``gh pr create``."""
+    repo = _req_str(inputs, "repo")
+    title = _req_str(inputs, "title")
+    body = _req_str(inputs, "body")
+    base = str(inputs.get("base", "dev"))
+    head = str(inputs.get("head", ""))
+
+    cmd = [
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--base", base,
+        "--title", title,
+        "--body", body,
+    ]
+    if head:
+        cmd += ["--head", head]
+
+    result = await _arun(cmd)
+    if "error" in result:
+        return result
+
+    url = str(result.get("stdout", "")).strip()
+    return {"pr_url": url}
+
+
+# ---------------------------------------------------------------------------
+# Input helpers
+# ---------------------------------------------------------------------------
+
+def _req_str(inputs: dict[str, object], key: str) -> str:
+    val = inputs.get(key)
+    if not isinstance(val, str) or not val.strip():
+        raise ValueError(f"'{key}' must be a non-empty string")
+    return val
+
+
+def _req_int(inputs: dict[str, object], key: str) -> int:
+    val = inputs.get(key)
+    if isinstance(val, int):
+        return val
+    if isinstance(val, str) and val.isdigit():
+        return int(val)
+    raise ValueError(f"'{key}' must be an integer")
+
+
+# ---------------------------------------------------------------------------
+# Skill definitions & registration
+# ---------------------------------------------------------------------------
+
+_TOOLS: dict[str, object] = {
+    "gh_read_issue": read_issue,
+    "gh_create_branch": create_branch,
+    "gh_read_file": read_file,
+    "gh_write_file": write_file,
+    "gh_commit_and_push": commit_and_push,
+    "gh_create_pr": create_pr,
+}
+
+
+def github_skill_definitions() -> list[SkillDefinition]:
+    """Return :class:`SkillDefinition` objects for every GitHub tool."""
+    return [
+        SkillDefinition(
+            name="gh_read_issue",
+            description="Fetch GitHub issue details (title, body, labels, comments) via gh CLI.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo": {"type": "string", "description": "owner/repo"},
+                    "issue_number": {"type": "integer"},
+                },
+                "required": ["repo", "issue_number"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=False,
+            max_retries=1,
+            timeout_seconds=30,
+            taint_level="external",
+        ),
+        SkillDefinition(
+            name="gh_create_branch",
+            description="Create a git feature branch from a base branch.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "branch_name": {"type": "string"},
+                    "base": {"type": "string", "default": "dev"},
+                },
+                "required": ["repo_path", "branch_name"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=True,
+            max_retries=0,
+            timeout_seconds=60,
+            taint_level="owner",
+        ),
+        SkillDefinition(
+            name="gh_read_file",
+            description="Read a file from a local repo working tree.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "file_path": {"type": "string"},
+                },
+                "required": ["repo_path", "file_path"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=False,
+            max_retries=0,
+            timeout_seconds=10,
+            taint_level="external",
+        ),
+        SkillDefinition(
+            name="gh_write_file",
+            description="Write content to a file in a local repo working tree.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "file_path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["repo_path", "file_path", "content"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=True,
+            max_retries=0,
+            timeout_seconds=10,
+            taint_level="owner",
+        ),
+        SkillDefinition(
+            name="gh_commit_and_push",
+            description="Stage all changes, commit with a message, and push to origin.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "message": {"type": "string"},
+                    "branch": {"type": "string"},
+                },
+                "required": ["repo_path", "message"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=True,
+            max_retries=0,
+            timeout_seconds=60,
+            taint_level="owner",
+        ),
+        SkillDefinition(
+            name="gh_create_pr",
+            description="Open a GitHub pull request via gh CLI.",
+            version="1.0.0",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "repo": {"type": "string"},
+                    "title": {"type": "string"},
+                    "body": {"type": "string"},
+                    "base": {"type": "string", "default": "dev"},
+                    "head": {"type": "string"},
+                },
+                "required": ["repo", "title", "body"],
+            },
+            output_schema={"type": "object"},
+            requires_approval=True,
+            max_retries=1,
+            timeout_seconds=30,
+            taint_level="owner",
+        ),
+    ]
+
+
+def register_github_skills(
+    skill_registry: object,
+    executor: object | None = None,
+) -> None:
+    """Register all GitHub skills in *skill_registry*.
+
+    If *executor* is provided (a :class:`SkillExecutor`), handlers are
+    also wired up so the executor can run the tools.
+    """
+    from silas.skills.registry import SkillRegistry
+
+    assert isinstance(skill_registry, SkillRegistry)
+
+    for defn in github_skill_definitions():
+        skill_registry.register(defn)
+
+    if executor is not None:
+        from silas.skills.executor import SkillExecutor
+
+        assert isinstance(executor, SkillExecutor)
+        for name, handler in _TOOLS.items():
+            executor.register_handler(name, handler)  # type: ignore[arg-type]
+
+
+__all__ = [
+    "commit_and_push",
+    "create_branch",
+    "create_pr",
+    "github_skill_definitions",
+    "read_file",
+    "read_issue",
+    "register_github_skills",
+    "write_file",
+]

--- a/tests/test_github_skill.py
+++ b/tests/test_github_skill.py
@@ -1,0 +1,300 @@
+"""Tests for the GitHub skill (silas.skills.shipped.github_skill)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from silas.models.skills import SkillDefinition
+from silas.skills.registry import SkillRegistry
+from silas.skills.shipped.github_skill import (
+    _run,
+    commit_and_push,
+    create_branch,
+    create_pr,
+    github_skill_definitions,
+    read_file,
+    read_issue,
+    register_github_skills,
+    write_file,
+)
+
+# ---------------------------------------------------------------------------
+# _run helper
+# ---------------------------------------------------------------------------
+
+
+class TestRunHelper:
+    def test_success(self) -> None:
+        with patch("subprocess.run") as mock:
+            mock.return_value = subprocess.CompletedProcess(
+                args=["echo", "hi"], returncode=0, stdout="hi\n", stderr=""
+            )
+            result = _run(["echo", "hi"])
+        assert result["returncode"] == 0
+        assert result["stdout"] == "hi\n"
+
+    def test_called_process_error(self) -> None:
+        with patch("subprocess.run") as mock:
+            mock.side_effect = subprocess.CalledProcessError(
+                1, "git", output="", stderr="fatal"
+            )
+            result = _run(["git", "status"])
+        assert "error" in result
+        assert result["returncode"] == 1
+
+    def test_timeout(self) -> None:
+        with patch("subprocess.run") as mock:
+            mock.side_effect = subprocess.TimeoutExpired("cmd", 120)
+            result = _run(["sleep", "999"])
+        assert "timed out" in str(result["error"])
+
+    def test_file_not_found(self) -> None:
+        with patch("subprocess.run") as mock:
+            mock.side_effect = FileNotFoundError()
+            result = _run(["nonexistent"])
+        assert "command not found" in str(result["error"])
+
+
+# ---------------------------------------------------------------------------
+# read_issue
+# ---------------------------------------------------------------------------
+
+
+class TestReadIssue:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        issue_data = {
+            "title": "Bug",
+            "body": "desc",
+            "labels": [],
+            "comments": [],
+            "state": "OPEN",
+            "number": 42,
+        }
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {
+                "stdout": json.dumps(issue_data),
+                "stderr": "",
+                "returncode": 0,
+            }
+            result = await read_issue({"repo": "owner/repo", "issue_number": 42})
+        assert result["issue"]["title"] == "Bug"
+
+    @pytest.mark.asyncio
+    async def test_error(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {"error": "not found", "returncode": 1}
+            result = await read_issue({"repo": "owner/repo", "issue_number": 999})
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_repo(self) -> None:
+        with pytest.raises(ValueError, match="repo"):
+            await read_issue({"issue_number": 1})
+
+
+# ---------------------------------------------------------------------------
+# create_branch
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBranch:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {"stdout": "", "stderr": "", "returncode": 0}
+            result = await create_branch(
+                {"repo_path": "/tmp/repo", "branch_name": "feat/x"}
+            )
+        assert result["branch"] == "feat/x"
+        assert result["base"] == "dev"
+        assert mock.call_count == 2  # fetch + checkout
+
+    @pytest.mark.asyncio
+    async def test_fetch_error(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {"error": "network", "returncode": 1}
+            result = await create_branch(
+                {"repo_path": "/tmp/repo", "branch_name": "feat/x"}
+            )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# read_file / write_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadFile:
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path: Path) -> None:
+        (tmp_path / "hello.txt").write_text("world")
+        result = await read_file(
+            {"repo_path": str(tmp_path), "file_path": "hello.txt"}
+        )
+        assert result["content"] == "world"
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, tmp_path: Path) -> None:
+        result = await read_file(
+            {"repo_path": str(tmp_path), "file_path": "nope.txt"}
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_path_traversal(self, tmp_path: Path) -> None:
+        result = await read_file(
+            {"repo_path": str(tmp_path), "file_path": "../../etc/passwd"}
+        )
+        assert "error" in result
+        assert "traversal" in str(result["error"])
+
+
+class TestWriteFile:
+    @pytest.mark.asyncio
+    async def test_success(self, tmp_path: Path) -> None:
+        result = await write_file(
+            {
+                "repo_path": str(tmp_path),
+                "file_path": "sub/new.txt",
+                "content": "hi",
+            }
+        )
+        assert result["written"] == "sub/new.txt"
+        assert (tmp_path / "sub" / "new.txt").read_text() == "hi"
+
+    @pytest.mark.asyncio
+    async def test_path_traversal(self, tmp_path: Path) -> None:
+        result = await write_file(
+            {
+                "repo_path": str(tmp_path),
+                "file_path": "../../evil.txt",
+                "content": "bad",
+            }
+        )
+        assert "traversal" in str(result["error"])
+
+
+# ---------------------------------------------------------------------------
+# commit_and_push
+# ---------------------------------------------------------------------------
+
+
+class TestCommitAndPush:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {"stdout": "", "stderr": "", "returncode": 0}
+            result = await commit_and_push(
+                {"repo_path": "/tmp/repo", "message": "feat: x"}
+            )
+        assert result["committed"] is True
+        assert mock.call_count == 3  # add, commit, push
+
+    @pytest.mark.asyncio
+    async def test_commit_error(self) -> None:
+        call_count = 0
+
+        def side_effect(cmd: list[str], *, cwd: str | None = None, check: bool = True) -> dict[str, object]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:  # commit step
+                return {"error": "nothing to commit", "returncode": 1}
+            return {"stdout": "", "stderr": "", "returncode": 0}
+
+        with patch("silas.skills.shipped.github_skill._run", side_effect=side_effect):
+            result = await commit_and_push(
+                {"repo_path": "/tmp/repo", "message": "feat: x"}
+            )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# create_pr
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePR:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {
+                "stdout": "https://github.com/owner/repo/pull/1\n",
+                "stderr": "",
+                "returncode": 0,
+            }
+            result = await create_pr(
+                {
+                    "repo": "owner/repo",
+                    "title": "feat: x",
+                    "body": "Closes #1",
+                }
+            )
+        assert result["pr_url"] == "https://github.com/owner/repo/pull/1"
+
+    @pytest.mark.asyncio
+    async def test_with_head(self) -> None:
+        with patch("silas.skills.shipped.github_skill._run") as mock:
+            mock.return_value = {
+                "stdout": "https://github.com/o/r/pull/2\n",
+                "stderr": "",
+                "returncode": 0,
+            }
+            await create_pr(
+                {
+                    "repo": "o/r",
+                    "title": "t",
+                    "body": "b",
+                    "head": "feat/x",
+                }
+            )
+        call_args = mock.call_args[0][0]
+        assert "--head" in call_args
+        assert "feat/x" in call_args
+
+    @pytest.mark.asyncio
+    async def test_missing_title(self) -> None:
+        with pytest.raises(ValueError, match="title"):
+            await create_pr({"repo": "o/r", "body": "b"})
+
+
+# ---------------------------------------------------------------------------
+# Definitions & registration
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitions:
+    def test_all_definitions_valid(self) -> None:
+        defs = github_skill_definitions()
+        assert len(defs) == 6
+        for d in defs:
+            assert isinstance(d, SkillDefinition)
+            assert d.name.startswith("gh_")
+            assert d.taint_level in ("owner", "external")
+
+    def test_register(self) -> None:
+        registry = SkillRegistry()
+        register_github_skills(registry)
+        assert registry.has("gh_read_issue")
+        assert registry.has("gh_create_pr")
+        assert len([s for s in registry.list_all() if s.name.startswith("gh_")]) == 6
+
+    def test_register_with_executor(self) -> None:
+        from silas.skills.executor import SkillExecutor
+
+        registry = SkillRegistry()
+        executor = SkillExecutor(registry)
+        register_github_skills(registry, executor)
+        assert registry.has("gh_commit_and_push")
+        assert "gh_commit_and_push" in executor._handlers
+
+    def test_high_taint_write_ops(self) -> None:
+        """Write operations must be classified as owner (high) taint."""
+        defs = {d.name: d for d in github_skill_definitions()}
+        for name in ("gh_create_branch", "gh_write_file", "gh_commit_and_push", "gh_create_pr"):
+            assert defs[name].taint_level == "owner", f"{name} should be owner taint"
+            assert defs[name].requires_approval is True, f"{name} should require approval"


### PR DESCRIPTION
Closes #178

## Summary
Adds a GitHub skill () with 6 tools:
- `gh_read_issue` — fetch issue details via `gh issue view`
- `gh_create_branch` — create feature branch from base
- `gh_read_file` / `gh_write_file` — read/write repo files (with path traversal protection)
- `gh_commit_and_push` — stage, commit, push
- `gh_create_pr` — open PR via `gh pr create`

All write operations classified as **owner taint** (high) and require approval.
Read operations classified as **external taint**.

Uses `subprocess` → `gh` CLI for GitHub ops (existing auth).
Includes `register_github_skills()` for registry + executor wiring.

## Tests
23 tests covering all tools, error paths, path traversal, and registration.