### PR TITLE
fix: enforce max_memory_ops_per_turn truncation (#161)

### DIFF
--- a/silas/config.py
+++ b/silas/config.py
@@ -138,6 +138,7 @@ class ExecutionConfig(BaseModel):
 class StreamConfig(BaseModel):
     streaming_enabled: bool = True
     chunk_size: int = Field(default=50, ge=1)
+    max_memory_ops_per_turn: int = Field(default=10, ge=1)
 
 
 class SilasSettings(BaseSettings):


### PR DESCRIPTION
Closes #161

Adds `max_memory_ops_per_turn` to SilasSettings (default: 10). Truncates excess memory ops with warning log + audit event.

Changes:
- `silas/config.py`: new config field
- `silas/core/stream.py`: truncation logic in `_process_memory_ops`
- `tests/test_memory_steps.py`: 3 new tests for truncation behavior