### PR TITLE
fix: unify TaintLevel enum and wire work_item_store (#156, #158)

### DIFF
--- a/silas/main.py
+++ b/silas/main.py
@@ -72,7 +72,7 @@ def build_stream(
 
     memory_store = SQLiteMemoryStore(db)
     chronicle_store = SQLiteChronicleStore(db)
-    work_item_store = SQLiteWorkItemStore(db)  # noqa: F841 — wired in Phase 3
+    work_item_store = SQLiteWorkItemStore(db)
     audit = SQLiteAuditLog(db)
     nonce_store = SQLiteNonceStore(db)
     token_counter = HeuristicTokenCounter()
@@ -114,6 +114,7 @@ def build_stream(
         channel=channel,
         turn_context=turn_context,
         context_manager=context_manager,
+        work_item_store=work_item_store,
         owner_id=settings.owner_id,
         default_context_profile=settings.context.default_profile,
         output_gate_runner=output_gate_runner,

--- a/silas/queue/bridge.py
+++ b/silas/queue/bridge.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from silas.models.messages import TaintLevel
 from silas.queue.orchestrator import QueueOrchestrator
 from silas.queue.router import QueueRouter
 from silas.queue.store import DurableQueueStore
-from silas.queue.types import QueueMessage, TaintLevel
+from silas.queue.types import QueueMessage
 
 logger = logging.getLogger(__name__)
 

--- a/silas/queue/store.py
+++ b/silas/queue/store.py
@@ -23,7 +23,8 @@ from datetime import UTC, datetime
 
 import aiosqlite
 
-from silas.queue.types import QueueMessage, TaintLevel
+from silas.models.messages import TaintLevel
+from silas.queue.types import QueueMessage
 
 # Why ISO format with 'T' separator: SQLite stores datetimes as text,
 # and ISO 8601 sorts lexicographically which matters for ORDER BY created_at.

--- a/silas/queue/types.py
+++ b/silas/queue/types.py
@@ -19,6 +19,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from silas.models.messages import TaintLevel as TaintLevel
+
 # Why Literal over Enum for ErrorCode/MessageKind: these are wire-format
 # strings that appear in JSON payloads and SQLite columns. Literal keeps
 # them as plain strings without .value gymnastics.
@@ -53,19 +55,6 @@ Sender = Literal["user", "proxy", "planner", "executor", "runtime"]
 # Why a dedicated Literal for urgency: the spec (§2.1) defines exactly three
 # levels. A Literal constrains wire values without enum overhead.
 Urgency = Literal["background", "informational", "needs_attention"]
-
-
-class TaintLevel(enum.StrEnum):
-    """Security taint propagated through the message chain.
-
-    Per §2.1: taint tracks the trust level of the originating source.
-    Higher taint restricts which tools/actions are available downstream.
-    Uses StrEnum so values serialize as plain strings in JSON/SQLite.
-    """
-
-    owner = "owner"
-    trusted = "trusted"
-    untrusted = "untrusted"
 
 
 class ExecutionStatus(enum.StrEnum):

--- a/tests/test_queue_schema.py
+++ b/tests/test_queue_schema.py
@@ -44,7 +44,7 @@ class TestQueueMessageTypedFields:
             message_kind="execution_request",
             sender="runtime",
             scope_id="scope-abc",
-            taint=TaintLevel.untrusted,
+            taint=TaintLevel.external,
             task_id="task-1",
             parent_task_id="task-0",
             work_item_id="wi-42",
@@ -52,7 +52,7 @@ class TestQueueMessageTypedFields:
             urgency="needs_attention",
         )
         assert msg.scope_id == "scope-abc"
-        assert msg.taint == TaintLevel.untrusted
+        assert msg.taint == TaintLevel.external
         assert msg.task_id == "task-1"
         assert msg.parent_task_id == "task-0"
         assert msg.work_item_id == "wi-42"
@@ -63,8 +63,8 @@ class TestQueueMessageTypedFields:
         """TaintLevel enum matches the spec's three levels."""
         assert set(TaintLevel) == {
             TaintLevel.owner,
-            TaintLevel.trusted,
-            TaintLevel.untrusted,
+            TaintLevel.auth,
+            TaintLevel.external,
         }
 
     def test_json_roundtrip_preserves_typed_fields(self) -> None:
@@ -73,14 +73,14 @@ class TestQueueMessageTypedFields:
             message_kind="user_message",
             sender="user",
             scope_id="s1",
-            taint=TaintLevel.trusted,
+            taint=TaintLevel.auth,
             task_id="t1",
             urgency="background",
         )
         data = msg.model_dump()
         restored = QueueMessage.model_validate(data)
         assert restored.scope_id == "s1"
-        assert restored.taint == TaintLevel.trusted
+        assert restored.taint == TaintLevel.auth
         assert restored.task_id == "t1"
         assert restored.urgency == "background"
 
@@ -201,7 +201,7 @@ class TestStoreMigration:
             sender="runtime",
             queue_name="executor_queue",
             scope_id="scope-test",
-            taint=TaintLevel.untrusted,
+            taint=TaintLevel.external,
             task_id="task-99",
             parent_task_id="task-0",
             work_item_id="wi-7",
@@ -213,7 +213,7 @@ class TestStoreMigration:
         leased = await store.lease("executor_queue")
         assert leased is not None
         assert leased.scope_id == "scope-test"
-        assert leased.taint == TaintLevel.untrusted
+        assert leased.taint == TaintLevel.external
         assert leased.task_id == "task-99"
         assert leased.parent_task_id == "task-0"
         assert leased.work_item_id == "wi-7"


### PR DESCRIPTION
## Changes

### #156 — TaintLevel enum mismatch (P0-critical, security)
- Removed duplicate `TaintLevel` from `queue/types.py` (had `owner/trusted/untrusted`)
- Re-exported canonical enum from `models/messages.py` (`owner/auth/external` per spec §3.1)
- Updated imports in `queue/store.py` and `queue/bridge.py`
- Fixed test assertions in `test_queue_schema.py`

### #158 — Wire work_item_store into Stream (P0-critical)
- Removed `# noqa: F841` suppression from `work_item_store` in `main.py`
- Passed `work_item_store` to `Stream()` constructor

Closes #156
Closes #158