### PR TITLE
feat: wire toolset wrapper chain into agent construction (#169)

### DIFF
--- a/silas/core/stream.py
+++ b/silas/core/stream.py
@@ -65,8 +65,13 @@ from silas.protocols.connections import ConnectionManager
 from silas.protocols.memory import MemoryStore
 from silas.protocols.proactivity import AutonomyCalibrator, SuggestionEngine
 from silas.protocols.scheduler import TaskScheduler
+from silas.protocols.skills import SkillResolver
 from silas.protocols.work import PlanParser, WorkItemStore
 from silas.security.taint import TaintTracker
+from silas.tools.approval_required import ApprovalRequiredToolset
+from silas.tools.filtered import FilteredToolset
+from silas.tools.prepared import PreparedToolset
+from silas.tools.skill_toolset import SkillToolset, ToolDefinition
 
 if TYPE_CHECKING:
     from silas.queue.bridge import QueueBridge
@@ -79,6 +84,18 @@ _IN_PROGRESS_STATUSES: tuple[WorkItemStatus, ...] = (
     WorkItemStatus.healthy,
     WorkItemStatus.stuck,
     WorkItemStatus.paused,
+)
+_PROXY_BASE_TOOLS: tuple[tuple[str, str], ...] = (
+    ("context_inspect", "Inspect active turn context for routing."),
+    ("memory_search", "Retrieve relevant memories before routing."),
+    ("tell_user", "Send interim status updates to the user."),
+    ("web_search", "Look up current external information."),
+)
+_PLANNER_BASE_TOOLS: tuple[tuple[str, str], ...] = (
+    ("memory_search", "Retrieve historical context before planning."),
+    ("request_research", "Delegate research to executor queue."),
+    ("validate_plan", "Validate markdown plan structure."),
+    ("web_search", "Look up supporting facts for plan quality."),
 )
 
 
@@ -1060,10 +1077,9 @@ class Stream:
                 available_skills=available_skills,
                 has_skills=bool(available_skills),
             )
-            await self._audit(
-                "phase1a_noop",
-                step=6.5,
-                note="skill-aware toolset preparation deferred",
+            proxy_toolset, planner_toolset = await self._prepare_agent_toolsets(
+                connection_id=connection_id,
+                turn_number=turn_number,
             )
 
             # Why queue-first: queue consumers are the primary execution path.
@@ -1083,7 +1099,11 @@ class Stream:
 
             routed = await run_structured_agent(
                 agent=tc.proxy,
-                prompt=self._build_proxy_prompt(processed_message_text, rendered_context),
+                prompt=self._build_proxy_prompt(
+                    processed_message_text,
+                    rendered_context,
+                    toolset=proxy_toolset,
+                ),
                 call_name="proxy",
                 default_context_profile=self.default_context_profile,
             )
@@ -1117,6 +1137,7 @@ class Stream:
                 message.text,
                 rendered_context,
                 interaction_mode,
+                planner_toolset,
             )
             response_text = self._prepend_high_confidence_suggestions(
                 response_text,
@@ -1353,6 +1374,7 @@ class Stream:
         message_text: str,
         rendered_context: str,
         interaction_mode: InteractionMode,
+        planner_toolset: ApprovalRequiredToolset | None,
     ) -> str:
         plan_flow_payload: dict[str, object] = {
             "actions_seen": 0, "skills_executed": 0, "skills_skipped": 0,
@@ -1364,6 +1386,7 @@ class Stream:
                 message_text=message_text,
                 rendered_context=rendered_context,
                 turn_number=turn_number,
+                planner_toolset=planner_toolset,
             )
             plan_flow_payload["actions_seen"] = len(plan_actions)
             if plan_actions:
@@ -1573,6 +1596,7 @@ class Stream:
         message_text: str,
         rendered_context: str,
         turn_number: int,
+        planner_toolset: ApprovalRequiredToolset | None,
     ) -> tuple[list[dict[str, object]], str | None]:
         planner = self._turn_context().planner
         if planner is None:
@@ -1581,7 +1605,11 @@ class Stream:
 
         planner_output = await run_structured_agent(
             agent=planner,
-            prompt=self._build_planner_prompt(message_text, rendered_context),
+            prompt=self._build_planner_prompt(
+                message_text,
+                rendered_context,
+                toolset=planner_toolset,
+            ),
             call_name="planner",
             default_context_profile="planning",
         )
@@ -2262,15 +2290,174 @@ class Stream:
         preface = "\n".join(f"Suggestion: {suggestion.text}" for suggestion in suggestions)
         return f"{preface}\n\n{response_text}" if response_text else preface
 
-    def _build_proxy_prompt(self, message_text: str, rendered_context: str) -> str:
-        if not rendered_context.strip():
-            return message_text
-        return f"[CONTEXT]\n{rendered_context}\n\n[USER MESSAGE]\n{message_text}"
+    async def _prepare_agent_toolsets(
+        self,
+        *,
+        connection_id: str,
+        turn_number: int,
+    ) -> tuple[ApprovalRequiredToolset | None, ApprovalRequiredToolset | None]:
+        tc = self._turn_context()
+        resolver = tc.skill_resolver
+        if resolver is None:
+            await self._audit(
+                "skill_toolsets_prepared",
+                step=6.5,
+                connection_id=connection_id,
+                prepared=False,
+                reason="skill_resolver_missing",
+            )
+            return None, None
 
-    def _build_planner_prompt(self, message_text: str, rendered_context: str) -> str:
-        if not rendered_context.strip():
-            return message_text
-        return f"[CONTEXT]\n{rendered_context}\n\n[USER REQUEST]\n{message_text}"
+        active_work_item = await self._find_active_toolset_work_item()
+        work_item_for_tools = active_work_item or self._build_synthetic_toolset_work_item(turn_number)
+        active_work_item_id = active_work_item.id if active_work_item is not None else None
+
+        proxy_toolset = self._build_role_toolset(
+            resolver=resolver,
+            work_item=work_item_for_tools,
+            agent_role="proxy",
+        )
+        planner_toolset = self._build_role_toolset(
+            resolver=resolver,
+            work_item=work_item_for_tools,
+            agent_role="planner",
+        )
+        await self._audit(
+            "skill_toolsets_prepared",
+            step=6.5,
+            connection_id=connection_id,
+            prepared=True,
+            work_item_id=active_work_item_id,
+            proxy_tools=self._tool_names(proxy_toolset),
+            planner_tools=self._tool_names(planner_toolset),
+        )
+        return proxy_toolset, planner_toolset
+
+    async def _find_active_toolset_work_item(self) -> WorkItem | None:
+        store = self.work_item_store
+        if store is None:
+            return None
+
+        for status in _IN_PROGRESS_STATUSES:
+            try:
+                items = await store.list_by_status(status)
+            except (OSError, RuntimeError, ValueError):
+                return None
+            if not items:
+                continue
+            ordered = sorted(items, key=lambda item: (item.created_at, item.id))
+            return ordered[0].model_copy(deep=True)
+
+        return None
+
+    def _build_role_toolset(
+        self,
+        *,
+        resolver: SkillResolver,
+        work_item: WorkItem,
+        agent_role: str,
+    ) -> ApprovalRequiredToolset:
+        base_tools = self._base_tools_for_role(agent_role)
+        allowed_tools = sorted({
+            *[tool.name for tool in base_tools],
+            *self._available_skill_names(),
+            *work_item.skills,
+        })
+
+        try:
+            prepared = resolver.prepare_toolset(
+                work_item=work_item,
+                agent_role=agent_role,
+                base_toolset=base_tools,
+                allowed_tools=allowed_tools,
+            )
+            if isinstance(prepared, ApprovalRequiredToolset):
+                return prepared
+        except (OSError, RuntimeError, TypeError, ValueError):
+            pass
+
+        return ApprovalRequiredToolset(
+            inner=FilteredToolset(
+                inner=PreparedToolset(
+                    inner=SkillToolset(base_toolset=base_tools, skill_metadata=[]),
+                    agent_role=agent_role,
+                ),
+                allowed_tools=allowed_tools,
+            )
+        )
+
+    def _base_tools_for_role(self, agent_role: str) -> list[ToolDefinition]:
+        catalog = _PLANNER_BASE_TOOLS if agent_role == "planner" else _PROXY_BASE_TOOLS
+        return [
+            ToolDefinition(
+                name=name,
+                description=description,
+                input_schema={"type": "object"},
+            )
+            for name, description in catalog
+        ]
+
+    def _build_synthetic_toolset_work_item(self, turn_number: int) -> WorkItem:
+        scope_id = self._turn_context().scope_id
+        return WorkItem(
+            id=f"toolset:{scope_id}:{turn_number}",
+            type=WorkItemType.task,
+            title="Turn-scoped toolset preparation",
+            body="No active work item available for this turn.",
+            skills=[],
+            needs_approval=False,
+        )
+
+    def _tool_names(self, toolset: ApprovalRequiredToolset | None) -> list[str]:
+        if toolset is None:
+            return []
+        return [tool.name for tool in toolset.list_tools()]
+
+    def _render_toolset_manifest(self, toolset: ApprovalRequiredToolset | None) -> str:
+        if toolset is None:
+            return ""
+        tools = toolset.list_tools()
+        if not tools:
+            return ""
+
+        lines: list[str] = []
+        for tool in tools:
+            description = " ".join(tool.description.split())
+            approval_note = " [approval required]" if tool.requires_approval else ""
+            lines.append(f"- {tool.name}{approval_note}: {description}")
+        return "\n".join(lines)
+
+    def _build_proxy_prompt(
+        self,
+        message_text: str,
+        rendered_context: str,
+        *,
+        toolset: ApprovalRequiredToolset | None = None,
+    ) -> str:
+        sections: list[str] = []
+        if rendered_context.strip():
+            sections.append(f"[CONTEXT]\n{rendered_context}")
+        tool_manifest = self._render_toolset_manifest(toolset)
+        if tool_manifest:
+            sections.append(f"[AVAILABLE TOOLS]\n{tool_manifest}")
+        sections.append(f"[USER MESSAGE]\n{message_text}")
+        return "\n\n".join(sections)
+
+    def _build_planner_prompt(
+        self,
+        message_text: str,
+        rendered_context: str,
+        *,
+        toolset: ApprovalRequiredToolset | None = None,
+    ) -> str:
+        sections: list[str] = []
+        if rendered_context.strip():
+            sections.append(f"[CONTEXT]\n{rendered_context}")
+        tool_manifest = self._render_toolset_manifest(toolset)
+        if tool_manifest:
+            sections.append(f"[AVAILABLE TOOLS]\n{tool_manifest}")
+        sections.append(f"[USER REQUEST]\n{message_text}")
+        return "\n\n".join(sections)
 
     def _route_response_text(self, routed: RouteDecision) -> str:
         if routed.route == "planner":

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -12,6 +12,7 @@ from silas.models.agents import (
     RouteDecision,
 )
 from silas.models.gates import GateTrigger
+from silas.tools.resolver import LiveSkillResolver
 
 from tests.fakes import TestModel
 
@@ -107,3 +108,16 @@ def test_build_stream_injects_signing_key_into_stream(
 
     assert stream._signing_key is signing_key
     assert stream._nonce_store is not None
+
+
+def test_build_stream_wires_skill_loader_and_live_resolver(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SilasSettings.model_validate({"data_dir": str(tmp_path / "data")})
+    monkeypatch.setattr("silas.main.build_proxy_agent", lambda model, default_context_profile: TestModel())
+
+    stream, _ = build_stream(settings)
+
+    assert stream.turn_context.skill_loader is not None
+    assert isinstance(stream.turn_context.skill_resolver, LiveSkillResolver)


### PR DESCRIPTION
## Summary
Closes #169 — Wire toolset wrapper chain into agent construction.

### Changes
**`silas/main.py`:**
- `_CompositeSkillLoader`: chains custom + shipped `SilasSkillLoader` instances (custom takes priority)
- Instantiates `LiveSkillResolver` with composite loader + work_item_lookup closure
- Passes `skill_loader` and `skill_resolver` into `TurnContext`

**`silas/core/stream.py`:**
- Replaces step 6.5 noop (`phase1a_noop`) with `_prepare_agent_toolsets()`
- Full wrapper chain: `SkillToolset → PreparedToolset → FilteredToolset → ApprovalRequiredToolset`
- Per-role base tool definitions (`_PROXY_BASE_TOOLS`, `_PLANNER_BASE_TOOLS`)
- `_render_toolset_manifest()` injects `[AVAILABLE TOOLS]` section into proxy/planner prompts
- `_find_active_toolset_work_item()` looks up in-progress work items for tool resolution
- `_build_synthetic_toolset_work_item()` creates fallback when no active work item exists

**`tests/test_proxy_routing.py`:**
- New test: `test_build_stream_wires_skill_loader_and_live_resolver`

### Testing
- 229 tests passing (excluding known sandbox adversarial deadlock)
- Ruff lint clean