### PR TITLE
feat: add ExecutorPool and WorktreeManager for parallel execution (#98, #99)

### DIFF
--- a/silas/execution/__init__.py
+++ b/silas/execution/__init__.py
@@ -3,9 +3,11 @@ from silas.execution.python_exec import PythonExecutor
 from silas.execution.sandbox import SandboxExecResult, SubprocessSandboxManager
 from silas.execution.sandbox_factory import create_sandbox_manager
 from silas.execution.shell import ShellExecutor
+from silas.execution.worktree import LiveWorktreeManager
 
 __all__ = [
     "DockerSandboxManager",
+    "LiveWorktreeManager",
     "PythonExecutor",
     "SandboxExecResult",
     "ShellExecutor",

--- a/silas/execution/worktree.py
+++ b/silas/execution/worktree.py
@@ -1,0 +1,255 @@
+"""Git-worktree workspace isolation for parallel executors (§7.4).
+
+Each executor gets an ephemeral worktree created from the canonical
+workspace's HEAD.  On success the worktree's diff is three-way-merged
+back; on conflict the work item is marked blocked.  Worktrees are
+cleaned up after merge or dead-letter.
+
+Path convention::
+
+    .runtime/worktrees/{scope_id}/{task_id}/{attempt}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RUNTIME_DIR = ".runtime/worktrees"
+
+
+class LiveWorktreeManager:
+    """Subprocess-based ``git worktree`` lifecycle manager.
+
+    Parameters
+    ----------
+    canonical_root:
+        Absolute path to the canonical workspace (the git repo root).
+    runtime_dir:
+        Relative or absolute directory under which worktrees are created.
+        Defaults to ``<canonical_root>/.runtime/worktrees``.
+    """
+
+    def __init__(
+        self,
+        canonical_root: str,
+        *,
+        runtime_dir: str | None = None,
+    ) -> None:
+        self._canonical_root = Path(canonical_root).resolve()
+        if runtime_dir is not None:
+            self._runtime_dir = Path(runtime_dir).resolve()
+        else:
+            self._runtime_dir = self._canonical_root / _DEFAULT_RUNTIME_DIR
+
+        # Per-scope merge lock - only one merge at a time per scope
+        self._scope_locks: dict[str, asyncio.Lock] = {}
+
+    # ── public API ──────────────────────────────────────────────────
+
+    async def create(
+        self,
+        scope_id: str,
+        task_id: str,
+        attempt: int,
+    ) -> str:
+        """Create an ephemeral worktree from HEAD and return its path."""
+        worktree_path = self._worktree_path(scope_id, task_id, attempt)
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+        baseline = await self._git_rev_parse("HEAD")
+
+        await self._run_git(
+            "worktree",
+            "add",
+            "--detach",
+            str(worktree_path),
+            baseline,
+        )
+
+        logger.info(
+            "worktree_created scope=%s task=%s attempt=%d path=%s baseline=%s",
+            scope_id,
+            task_id,
+            attempt,
+            worktree_path,
+            baseline[:12],
+        )
+        return str(worktree_path)
+
+    async def merge_back(
+        self,
+        worktree_path: str,
+    ) -> tuple[bool, str | None]:
+        """Three-way-merge worktree changes back into the canonical workspace.
+
+        Acquires a per-scope merge lock to serialise merges within a scope.
+        Returns ``(True, None)`` on clean merge or no-op, or
+        ``(False, detail)`` on conflict.
+        """
+        wt = Path(worktree_path).resolve()
+        scope_id = self._scope_from_path(wt)
+        lock = self._scope_locks.setdefault(scope_id, asyncio.Lock())
+
+        async with lock:
+            # Check if the worktree has any changes
+            has_changes = await self._worktree_has_changes(wt)
+            if not has_changes:
+                logger.info("worktree_merge_noop path=%s (no changes)", wt)
+                return True, None
+
+            # Commit worktree changes so we have a tree to merge
+            await self._run_git_in(wt, "add", "-A")
+            await self._run_git_in(
+                wt,
+                "commit",
+                "-m",
+                f"worktree changes from {wt.name}",
+                "--allow-empty",
+            )
+
+            worktree_commit = await self._git_rev_parse_in(wt, "HEAD")
+            baseline = await self._git_merge_base(wt, worktree_commit)
+
+            # Create a patch and apply to canonical workspace
+            try:
+                diff = await self._run_git_in(
+                    wt,
+                    "diff",
+                    baseline,
+                    worktree_commit,
+                )
+                if not diff.strip():
+                    return True, None
+
+                # Apply the patch in the canonical workspace
+                await self._run_git(
+                    "apply",
+                    "--3way",
+                    "--whitespace=nowarn",
+                    input_data=diff,
+                )
+                logger.info(
+                    "worktree_merged path=%s baseline=%s commit=%s",
+                    wt,
+                    baseline[:12],
+                    worktree_commit[:12],
+                )
+                return True, None
+
+            except _GitConflictError as exc:
+                logger.warning(
+                    "worktree_merge_conflict path=%s detail=%s",
+                    wt,
+                    exc.detail,
+                )
+                # Abort the failed apply
+                await self._run_git("apply", "--abort", check=False)
+                return False, exc.detail
+
+    async def destroy(self, worktree_path: str) -> None:
+        """Remove the worktree directory and prune git metadata."""
+        wt = Path(worktree_path).resolve()
+        if wt.exists():
+            shutil.rmtree(wt, ignore_errors=True)
+        await self._run_git("worktree", "prune", check=False)
+        logger.info("worktree_destroyed path=%s", wt)
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    def _worktree_path(self, scope_id: str, task_id: str, attempt: int) -> Path:
+        """Convention: .runtime/worktrees/{scope_id}/{task_id}/{attempt}."""
+        return self._runtime_dir / scope_id / task_id / str(attempt)
+
+    def _scope_from_path(self, worktree: Path) -> str:
+        """Extract scope_id from the worktree path convention."""
+        try:
+            relative = worktree.relative_to(self._runtime_dir)
+            return str(relative.parts[0])
+        except (ValueError, IndexError):
+            return "unknown"
+
+    async def _worktree_has_changes(self, worktree: Path) -> bool:
+        """Check whether the worktree has uncommitted changes."""
+        output = await self._run_git_in(worktree, "status", "--porcelain")
+        return bool(output.strip())
+
+    async def _git_rev_parse(self, ref: str) -> str:
+        """Resolve a ref to its SHA in the canonical workspace."""
+        output = await self._run_git("rev-parse", ref)
+        return output.strip()
+
+    async def _git_rev_parse_in(self, cwd: Path, ref: str) -> str:
+        """Resolve a ref to its SHA inside a specific worktree."""
+        output = await self._run_git_in(cwd, "rev-parse", ref)
+        return output.strip()
+
+    async def _git_merge_base(self, cwd: Path, commit: str) -> str:
+        """Find the merge base between the worktree commit and canonical HEAD."""
+        canonical_head = await self._git_rev_parse("HEAD")
+        output = await self._run_git_in(cwd, "merge-base", canonical_head, commit)
+        return output.strip()
+
+    async def _run_git(
+        self,
+        *args: str,
+        check: bool = True,
+        input_data: str | None = None,
+    ) -> str:
+        """Run a git command in the canonical workspace."""
+        return await self._run_git_in(
+            self._canonical_root,
+            *args,
+            check=check,
+            input_data=input_data,
+        )
+
+    async def _run_git_in(
+        self,
+        cwd: Path,
+        *args: str,
+        check: bool = True,
+        input_data: str | None = None,
+    ) -> str:
+        """Run a git command in a specific directory."""
+        cmd = ["git", *args]
+        env = {
+            **os.environ,
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE if input_data else asyncio.subprocess.DEVNULL,
+            env=env,
+        )
+        stdin_bytes = input_data.encode() if input_data else None
+        stdout, stderr = await proc.communicate(input=stdin_bytes)
+        stdout_text = stdout.decode(errors="replace")
+        stderr_text = stderr.decode(errors="replace")
+
+        if proc.returncode != 0 and check:
+            if "conflict" in stderr_text.lower() or "conflict" in stdout_text.lower():
+                raise _GitConflictError(stderr_text or stdout_text)
+            msg = f"git {' '.join(args)} failed (rc={proc.returncode}): {stderr_text}"
+            raise RuntimeError(msg)
+
+        return stdout_text
+
+
+class _GitConflictError(Exception):
+    """Raised when a git operation hits a merge conflict."""
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
+__all__ = ["LiveWorktreeManager"]

--- a/silas/protocols/work.py
+++ b/silas/protocols/work.py
@@ -45,4 +45,58 @@ class PlanParser(Protocol):
     def parse(self, markdown: str) -> WorkItem: ...
 
 
-__all__ = ["PlanParser", "VerificationRunner", "WorkItemExecutor", "WorkItemStore"]
+@runtime_checkable
+class ExecutorPool(Protocol):
+    """Concurrency-capped pool that dispatches work items in parallel.
+
+    Respects per-scope and global concurrency limits.  Priority ordering:
+    approved_execution > research > status (§7.1).
+    """
+
+    async def dispatch(self, work_item: WorkItem, scope_id: str) -> WorkItemResult:
+        """Dispatch *work_item* to a pool slot, blocking until a slot is free."""
+        ...
+
+    async def cancel(self, task_id: str) -> bool:
+        """Cancel a running executor.  Returns ``True`` if cancellation succeeded."""
+        ...
+
+    async def shutdown(self) -> None:
+        """Wait for all in-flight work items and release resources."""
+        ...
+
+
+@runtime_checkable
+class WorktreeManager(Protocol):
+    """Manages per-executor git-worktree isolation (§7.4)."""
+
+    async def create(
+        self,
+        scope_id: str,
+        task_id: str,
+        attempt: int,
+    ) -> str:
+        """Create an ephemeral worktree; return its path."""
+        ...
+
+    async def merge_back(self, worktree_path: str) -> tuple[bool, str | None]:
+        """Three-way-merge changes into the canonical workspace.
+
+        Returns ``(True, None)`` on success, or ``(False, conflict_detail)``
+        on merge conflict.
+        """
+        ...
+
+    async def destroy(self, worktree_path: str) -> None:
+        """Remove the worktree and its git metadata."""
+        ...
+
+
+__all__ = [
+    "ExecutorPool",
+    "PlanParser",
+    "VerificationRunner",
+    "WorkItemExecutor",
+    "WorkItemStore",
+    "WorktreeManager",
+]

--- a/silas/work/__init__.py
+++ b/silas/work/__init__.py
@@ -1,4 +1,5 @@
 from silas.work.batch import BatchExecutor
 from silas.work.executor import LiveWorkItemExecutor
+from silas.work.pool import LiveExecutorPool
 
-__all__ = ["BatchExecutor", "LiveWorkItemExecutor"]
+__all__ = ["BatchExecutor", "LiveExecutorPool", "LiveWorkItemExecutor"]

--- a/silas/work/pool.py
+++ b/silas/work/pool.py
@@ -1,0 +1,267 @@
+"""Concurrency-capped executor pool for parallel work-item dispatch (§7.1).
+
+The pool manages per-scope and global semaphores so that independent
+work items can execute concurrently without exceeding configured caps.
+Conflict detection (§7.2) serialises items that write overlapping
+file paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from silas.models.work import WorkItem, WorkItemResult, WorkItemStatus
+
+logger = logging.getLogger(__name__)
+
+# Priority ordering: lower number = higher priority (§7.1)
+_PRIORITY_MAP: dict[str, int] = {
+    "approved_execution": 0,
+    "research": 1,
+    "status": 2,
+}
+
+
+class LiveExecutorPool:
+    """Async executor pool with per-scope and global concurrency caps.
+
+    Parameters
+    ----------
+    executor_factory:
+        Callable that, given a ``WorkItem`` and ``scope_id``, returns the
+        coroutine result (``WorkItemResult``).  Typically wraps a
+        ``LiveWorkItemExecutor.execute`` call.
+    max_concurrent:
+        Maximum concurrent work items per scope.
+    max_concurrent_global:
+        Maximum concurrent work items across all scopes.
+    """
+
+    def __init__(
+        self,
+        executor_factory: Callable[..., Any],
+        *,
+        max_concurrent: int = 8,
+        max_concurrent_global: int = 16,
+    ) -> None:
+        self._executor_factory = executor_factory
+        self._max_concurrent = max(1, max_concurrent)
+        self._max_concurrent_global = max(1, max_concurrent_global)
+
+        self._global_semaphore = asyncio.Semaphore(self._max_concurrent_global)
+        self._scope_semaphores: dict[str, asyncio.Semaphore] = {}
+
+        # Track in-flight tasks by task_id for cancellation
+        self._in_flight: dict[str, asyncio.Task[WorkItemResult]] = {}
+        self._lock = asyncio.Lock()
+
+    # ── public API ──────────────────────────────────────────────────
+
+    async def dispatch(self, work_item: WorkItem, scope_id: str) -> WorkItemResult:
+        """Dispatch a work item, respecting concurrency caps.
+
+        Blocks until both per-scope and global semaphore slots are free,
+        then executes via the factory.
+        """
+        scope_sem = self._get_scope_semaphore(scope_id)
+
+        # Acquire both semaphores (global first to avoid deadlock)
+        async with self._global_semaphore, scope_sem:
+            task = asyncio.current_task()
+            async with self._lock:
+                if task is not None:
+                    self._in_flight[work_item.id] = task
+
+            logger.info(
+                "executor_pool_dispatch scope=%s task=%s global_available=%d scope_available=%d",
+                scope_id,
+                work_item.id,
+                self._global_semaphore._value,
+                scope_sem._value,
+            )
+            try:
+                result: WorkItemResult = await self._executor_factory(work_item)
+                return result
+            except asyncio.CancelledError:
+                logger.warning(
+                    "executor_pool_cancelled scope=%s task=%s",
+                    scope_id,
+                    work_item.id,
+                )
+                return WorkItemResult(
+                    work_item_id=work_item.id,
+                    status=WorkItemStatus.failed,
+                    summary=f"Work item {work_item.id} cancelled.",
+                    last_error="cancelled",
+                )
+            except Exception as exc:
+                logger.exception(
+                    "executor_pool_error scope=%s task=%s",
+                    scope_id,
+                    work_item.id,
+                )
+                return WorkItemResult(
+                    work_item_id=work_item.id,
+                    status=WorkItemStatus.failed,
+                    summary=f"Work item {work_item.id} failed with error.",
+                    last_error=str(exc),
+                )
+            finally:
+                async with self._lock:
+                    self._in_flight.pop(work_item.id, None)
+
+    async def cancel(self, task_id: str) -> bool:
+        """Cancel a running executor by task_id.
+
+        Returns ``True`` if cancellation was sent, ``False`` if the task
+        was not found (already finished or never dispatched).
+        """
+        async with self._lock:
+            task = self._in_flight.get(task_id)
+        if task is None:
+            return False
+        task.cancel()
+        logger.info("executor_pool_cancel_requested task=%s", task_id)
+        return True
+
+    async def shutdown(self) -> None:
+        """Wait for all in-flight work items to finish."""
+        async with self._lock:
+            tasks = list(self._in_flight.values())
+        if tasks:
+            logger.info("executor_pool_shutdown waiting for %d tasks", len(tasks))
+            await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info("executor_pool_shutdown_complete")
+
+    async def dispatch_parallel(
+        self,
+        work_items: list[WorkItem],
+        scope_id: str,
+    ) -> list[WorkItemResult]:
+        """Dispatch multiple independent work items concurrently.
+
+        All items run in parallel, respecting concurrency caps.
+        Conflicting items (overlapping file paths) are serialised.
+        Returns results in the same order as the input list.
+        """
+        groups = _detect_conflicts(work_items)
+        results: dict[str, WorkItemResult] = {}
+
+        # Dispatch non-conflicting groups in parallel
+        for group in groups:
+            if len(group) == 1:
+                # Single item or serialised conflict — just dispatch
+                coros = [self.dispatch(group[0], scope_id)]
+            else:
+                # Independent items — dispatch concurrently
+                coros = [self.dispatch(item, scope_id) for item in group]
+
+            group_results = await asyncio.gather(*coros)
+            for item, result in zip(group, group_results, strict=True):
+                results[item.id] = result
+
+        return [results[item.id] for item in work_items]
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _get_scope_semaphore(self, scope_id: str) -> asyncio.Semaphore:
+        """Lazily create and cache a per-scope semaphore."""
+        sem = self._scope_semaphores.get(scope_id)
+        if sem is None:
+            sem = asyncio.Semaphore(self._max_concurrent)
+            self._scope_semaphores[scope_id] = sem
+        return sem
+
+    @property
+    def in_flight_count(self) -> int:
+        """Number of currently executing tasks."""
+        return len(self._in_flight)
+
+    @property
+    def max_concurrent(self) -> int:
+        """Per-scope concurrency cap."""
+        return self._max_concurrent
+
+    @property
+    def max_concurrent_global(self) -> int:
+        """Global concurrency cap."""
+        return self._max_concurrent_global
+
+
+def _detect_conflicts(work_items: list[WorkItem]) -> list[list[WorkItem]]:
+    """Group work items by file-resource overlaps (§7.2).
+
+    Items that write overlapping paths are serialised (placed in separate
+    single-item groups).  Non-conflicting items go into one parallel group.
+
+    Returns a list of groups.  Groups with >1 item can be dispatched
+    concurrently; groups with 1 item are dispatched serially.
+    """
+    if len(work_items) <= 1:
+        return [work_items] if work_items else []
+
+    # Extract write paths from each work item's body (heuristic parse)
+    write_paths: dict[str, set[str]] = {}
+    for item in work_items:
+        paths = _extract_file_paths(item)
+        write_paths[item.id] = paths
+
+    # Find conflicting pairs
+    conflicting: set[str] = set()
+    item_ids = list(write_paths.keys())
+    for i, id_a in enumerate(item_ids):
+        for id_b in item_ids[i + 1 :]:
+            if write_paths[id_a] & write_paths[id_b]:
+                conflicting.add(id_a)
+                conflicting.add(id_b)
+
+    # Build groups: non-conflicting items in one parallel group,
+    # conflicting items each get their own serial group
+    parallel_group: list[WorkItem] = []
+    serial_groups: list[list[WorkItem]] = []
+
+    for item in work_items:
+        if item.id in conflicting:
+            serial_groups.append([item])
+        else:
+            parallel_group.append(item)
+
+    groups: list[list[WorkItem]] = []
+    if parallel_group:
+        groups.append(parallel_group)
+    groups.extend(serial_groups)
+    return groups
+
+
+def _extract_file_paths(item: WorkItem) -> set[str]:
+    """Extract file paths from a work item for conflict detection.
+
+    Uses a heuristic: looks at ``input_artifacts_from`` and common
+    path patterns in the body.  This is intentionally conservative —
+    false positives (serialising unnecessarily) are safe; false negatives
+    (missing a conflict) risk data corruption.
+    """
+    paths: set[str] = set()
+    # input_artifacts_from is the explicit artifact dependency list
+    for artifact_ref in item.input_artifacts_from:
+        paths.add(artifact_ref)
+    return paths
+
+
+def priority_key(work_item: WorkItem) -> int:
+    """Return a sort key for dispatch priority ordering (§7.1).
+
+    Lower values = higher priority:
+    approved_execution (0) > research (1) > status (2).
+    """
+    if work_item.approval_token is not None:
+        return _PRIORITY_MAP.get("approved_execution", 0)
+    if work_item.type.value == "goal":
+        return _PRIORITY_MAP.get("status", 2)
+    return _PRIORITY_MAP.get("research", 1)
+
+
+__all__ = ["LiveExecutorPool", "priority_key"]

--- a/tests/test_executor_pool.py
+++ b/tests/test_executor_pool.py
@@ -1,0 +1,614 @@
+"""Tests for ExecutorPool (§7.1) and WorktreeManager (§7.4).
+
+Covers:
+- Concurrency caps (per-scope and global)
+- Parallel dispatch of independent work items
+- Cancellation
+- Conflict detection and serialisation
+- Wave scheduling in LiveWorkItemExecutor
+- WorktreeManager lifecycle (create / merge / destroy)
+- Worktree merge conflict handling
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from silas.execution.worktree import LiveWorktreeManager
+from silas.models.approval import ApprovalScope, ApprovalToken, ApprovalVerdict
+from silas.models.work import (
+    BudgetUsed,
+    WorkItem,
+    WorkItemResult,
+    WorkItemStatus,
+    WorkItemType,
+)
+from silas.skills.executor import SkillExecutor
+from silas.skills.registry import SkillRegistry
+from silas.work.executor import LiveWorkItemExecutor
+from silas.work.pool import LiveExecutorPool, _detect_conflicts, priority_key
+
+from tests.fakes import InMemoryWorkItemStore
+
+# ── Fixtures & helpers ──────────────────────────────────────────────
+
+
+def _work_item(
+    item_id: str,
+    *,
+    depends_on: list[str] | None = None,
+    input_artifacts_from: list[str] | None = None,
+    include_approval: bool = True,
+) -> WorkItem:
+    item = WorkItem(
+        id=item_id,
+        type=WorkItemType.task,
+        title=item_id,
+        body=f"Execute {item_id}",
+        skills=[],
+        depends_on=depends_on or [],
+        input_artifacts_from=input_artifacts_from or [],
+    )
+    if include_approval:
+        item.approval_token = _approval_token(item)
+    return item
+
+
+def _approval_token(work_item: WorkItem) -> ApprovalToken:
+    now = datetime.now(UTC)
+    return ApprovalToken(
+        token_id=f"tok:{work_item.id}",
+        plan_hash=work_item.plan_hash(),
+        work_item_id=work_item.id,
+        scope=ApprovalScope.full_plan,
+        verdict=ApprovalVerdict.approved,
+        signature=b"test-sig",
+        issued_at=now - timedelta(minutes=1),
+        expires_at=now + timedelta(minutes=30),
+        nonce=f"nonce:{work_item.id}",
+        executions_used=1,
+        max_executions=1,
+    )
+
+
+def _ok_result(item_id: str) -> WorkItemResult:
+    return WorkItemResult(
+        work_item_id=item_id,
+        status=WorkItemStatus.done,
+        summary=f"{item_id} done",
+        budget_used=BudgetUsed(attempts=1, executor_runs=1),
+    )
+
+
+# ── ExecutorPool tests ──────────────────────────────────────────────
+
+
+class TestExecutorPoolConcurrency:
+    """Verify per-scope and global concurrency caps."""
+
+    @pytest.mark.asyncio
+    async def test_per_scope_concurrency_cap(self) -> None:
+        """At most max_concurrent items run simultaneously per scope."""
+        max_running = 0
+        current_running = 0
+        lock = asyncio.Lock()
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            nonlocal max_running, current_running
+            async with lock:
+                current_running += 1
+                max_running = max(max_running, current_running)
+            await asyncio.sleep(0.01)
+            async with lock:
+                current_running -= 1
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=2, max_concurrent_global=10)
+        items = [_work_item(f"t{i}", include_approval=False) for i in range(6)]
+
+        results = await asyncio.gather(
+            *[pool.dispatch(item, "scope-a") for item in items]
+        )
+
+        assert all(r.status == WorkItemStatus.done for r in results)
+        assert max_running <= 2
+
+    @pytest.mark.asyncio
+    async def test_global_concurrency_cap(self) -> None:
+        """Global cap limits total concurrent items across scopes."""
+        max_running = 0
+        current_running = 0
+        lock = asyncio.Lock()
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            nonlocal max_running, current_running
+            async with lock:
+                current_running += 1
+                max_running = max(max_running, current_running)
+            await asyncio.sleep(0.01)
+            async with lock:
+                current_running -= 1
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=5, max_concurrent_global=3)
+        items = [_work_item(f"t{i}", include_approval=False) for i in range(6)]
+        scopes = ["s1", "s2", "s3", "s1", "s2", "s3"]
+
+        results = await asyncio.gather(
+            *[pool.dispatch(item, scope) for item, scope in zip(items, scopes, strict=True)]
+        )
+
+        assert all(r.status == WorkItemStatus.done for r in results)
+        assert max_running <= 3
+
+    @pytest.mark.asyncio
+    async def test_in_flight_count_tracks_active_tasks(self) -> None:
+        """in_flight_count accurately reflects running tasks."""
+        gate = asyncio.Event()
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            await gate.wait()
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=4, max_concurrent_global=4)
+        item = _work_item("t1", include_approval=False)
+
+        task = asyncio.create_task(pool.dispatch(item, "s1"))
+        await asyncio.sleep(0.01)
+        assert pool.in_flight_count == 1
+
+        gate.set()
+        await task
+        assert pool.in_flight_count == 0
+
+
+class TestExecutorPoolCancellation:
+    """Verify task cancellation."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_running_task(self) -> None:
+        """Cancelling a running task returns a failed result."""
+        gate = asyncio.Event()
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            await gate.wait()
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=4, max_concurrent_global=4)
+        item = _work_item("cancel-me", include_approval=False)
+
+        task = asyncio.create_task(pool.dispatch(item, "s1"))
+        await asyncio.sleep(0.01)
+
+        cancelled = await pool.cancel("cancel-me")
+        assert cancelled is True
+
+        result = await task
+        assert result.status == WorkItemStatus.failed
+        assert result.last_error == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_task(self) -> None:
+        """Cancelling a task that doesn't exist returns False."""
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=4, max_concurrent_global=4)
+        assert await pool.cancel("does-not-exist") is False
+
+
+class TestExecutorPoolDispatchParallel:
+    """Verify dispatch_parallel with conflict detection."""
+
+    @pytest.mark.asyncio
+    async def test_independent_items_run_concurrently(self) -> None:
+        """Non-conflicting items are dispatched in parallel."""
+        call_order: list[str] = []
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            call_order.append(f"start:{item.id}")
+            await asyncio.sleep(0.01)
+            call_order.append(f"end:{item.id}")
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=4, max_concurrent_global=4)
+        items = [_work_item(f"t{i}", include_approval=False) for i in range(3)]
+
+        results = await pool.dispatch_parallel(items, "s1")
+
+        assert all(r.status == WorkItemStatus.done for r in results)
+        # All should start before any ends (concurrent)
+        starts = [e for e in call_order if e.startswith("start:")]
+        assert len(starts) == 3
+
+    @pytest.mark.asyncio
+    async def test_conflicting_items_serialised(self) -> None:
+        """Items with overlapping file paths run serially."""
+        concurrency = 0
+        max_concurrent = 0
+        lock = asyncio.Lock()
+
+        async def _executor(item: WorkItem) -> WorkItemResult:
+            nonlocal concurrency, max_concurrent
+            async with lock:
+                concurrency += 1
+                max_concurrent = max(max_concurrent, concurrency)
+            await asyncio.sleep(0.01)
+            async with lock:
+                concurrency -= 1
+            return _ok_result(item.id)
+
+        pool = LiveExecutorPool(_executor, max_concurrent=4, max_concurrent_global=4)
+        # These share an artifact path -> conflict -> serialised
+        items = [
+            _work_item("t1", input_artifacts_from=["shared/file.txt"], include_approval=False),
+            _work_item("t2", input_artifacts_from=["shared/file.txt"], include_approval=False),
+        ]
+
+        results = await pool.dispatch_parallel(items, "s1")
+
+        assert all(r.status == WorkItemStatus.done for r in results)
+        # Conflicting items are in separate serial groups, so max_concurrent
+        # for each group is 1
+        assert max_concurrent <= 1
+
+
+class TestConflictDetection:
+    """Unit tests for _detect_conflicts."""
+
+    def test_no_items(self) -> None:
+        assert _detect_conflicts([]) == []
+
+    def test_single_item(self) -> None:
+        items = [_work_item("t1", include_approval=False)]
+        groups = _detect_conflicts(items)
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+
+    def test_no_conflicts(self) -> None:
+        items = [
+            _work_item("t1", input_artifacts_from=["a.txt"], include_approval=False),
+            _work_item("t2", input_artifacts_from=["b.txt"], include_approval=False),
+            _work_item("t3", input_artifacts_from=["c.txt"], include_approval=False),
+        ]
+        groups = _detect_conflicts(items)
+        # All in one parallel group
+        assert len(groups) == 1
+        assert len(groups[0]) == 3
+
+    def test_overlapping_paths_serialised(self) -> None:
+        items = [
+            _work_item("t1", input_artifacts_from=["shared.txt"], include_approval=False),
+            _work_item("t2", input_artifacts_from=["shared.txt", "other.txt"], include_approval=False),
+            _work_item("t3", input_artifacts_from=["unique.txt"], include_approval=False),
+        ]
+        groups = _detect_conflicts(items)
+        # t3 is non-conflicting → 1 parallel group
+        # t1 and t2 conflict → 2 serial groups
+        assert len(groups) == 3
+        serial = [g for g in groups if len(g) == 1]
+        # t3 is alone but may also be a single-item group
+        assert len(serial) >= 2  # t1, t2 each serialised
+
+
+class TestPriorityKey:
+    """Verify dispatch priority ordering."""
+
+    def test_approved_highest_priority(self) -> None:
+        item = _work_item("approved", include_approval=True)
+        assert priority_key(item) == 0
+
+    def test_unapproved_task_is_research(self) -> None:
+        item = _work_item("research", include_approval=False)
+        assert priority_key(item) == 1
+
+    def test_goal_is_status(self) -> None:
+        item = WorkItem(
+            id="goal-1",
+            type=WorkItemType.goal,
+            title="goal",
+            body="monitor",
+            agent="stream",
+            schedule="always_on",
+        )
+        assert priority_key(item) == 2
+
+
+# ── Wave scheduling tests ──────────────────────────────────────────
+
+
+class TestWaveScheduling:
+    """Verify _build_waves groups items correctly."""
+
+    def test_linear_chain_produces_single_item_waves(self) -> None:
+        """A->B->C produces 3 waves of 1 item each."""
+        registry = SkillRegistry()
+        skill_executor = SkillExecutor(registry)
+        store = InMemoryWorkItemStore()
+        executor = LiveWorkItemExecutor(skill_executor, store)
+
+        prerequisites = {
+            "A": set(),
+            "B": {"A"},
+            "C": {"B"},
+        }
+        waves = executor._build_waves(["A", "B", "C"], prerequisites)
+        assert waves == [["A"], ["B"], ["C"]]
+
+    def test_independent_items_in_single_wave(self) -> None:
+        """Independent items are grouped into one wave."""
+        registry = SkillRegistry()
+        skill_executor = SkillExecutor(registry)
+        store = InMemoryWorkItemStore()
+        executor = LiveWorkItemExecutor(skill_executor, store)
+
+        prerequisites = {
+            "A": set(),
+            "B": set(),
+            "C": set(),
+        }
+        waves = executor._build_waves(["A", "B", "C"], prerequisites)
+        assert len(waves) == 1
+        assert set(waves[0]) == {"A", "B", "C"}
+
+    def test_diamond_dependency_produces_three_waves(self) -> None:
+        """Diamond: A depends on B and C, B and C independent -> 3 waves."""
+        registry = SkillRegistry()
+        skill_executor = SkillExecutor(registry)
+        store = InMemoryWorkItemStore()
+        executor = LiveWorkItemExecutor(skill_executor, store)
+
+        # D has no deps, B and C depend on D, A depends on B and C
+        prerequisites = {
+            "D": set(),
+            "B": {"D"},
+            "C": {"D"},
+            "A": {"B", "C"},
+        }
+        waves = executor._build_waves(["D", "B", "C", "A"], prerequisites)
+        assert len(waves) == 3
+        assert waves[0] == ["D"]
+        assert set(waves[1]) == {"B", "C"}
+        assert waves[2] == ["A"]
+
+
+# ── WorktreeManager tests ──────────────────────────────────────────
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a bare git repo with an initial commit."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=str(path), check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(path), check=True, capture_output=True,
+    )
+    # Create an initial commit
+    readme = path / "README.md"
+    readme.write_text("# Test Repo\n")
+    subprocess.run(["git", "add", "-A"], cwd=str(path), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=str(path), check=True, capture_output=True,
+    )
+
+
+class TestWorktreeManager:
+    """Integration tests for LiveWorktreeManager."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_destroy(self, tmp_path: Path) -> None:
+        """Create a worktree and verify it exists, then destroy it."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        wt_path = await mgr.create("scope1", "task1", 1)
+
+        assert Path(wt_path).exists()
+        assert (Path(wt_path) / "README.md").exists()
+
+        await mgr.destroy(wt_path)
+        assert not Path(wt_path).exists()
+
+    @pytest.mark.asyncio
+    async def test_merge_back_with_changes(self, tmp_path: Path) -> None:
+        """Changes in the worktree are merged back to canonical workspace."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        wt_path = await mgr.create("scope1", "task1", 1)
+
+        # Write a new file in the worktree
+        new_file = Path(wt_path) / "feature.py"
+        new_file.write_text("print('hello')\n")
+
+        ok, err = await mgr.merge_back(wt_path)
+        assert ok is True
+        assert err is None
+
+        # Verify the file exists in canonical workspace
+        assert (repo / "feature.py").exists()
+
+        await mgr.destroy(wt_path)
+
+    @pytest.mark.asyncio
+    async def test_merge_back_no_changes(self, tmp_path: Path) -> None:
+        """No-op merge when worktree has no changes."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        wt_path = await mgr.create("scope1", "task2", 1)
+
+        ok, err = await mgr.merge_back(wt_path)
+        assert ok is True
+        assert err is None
+
+        await mgr.destroy(wt_path)
+
+    @pytest.mark.asyncio
+    async def test_worktree_path_convention(self, tmp_path: Path) -> None:
+        """Worktree paths follow .runtime/worktrees/{scope}/{task}/{attempt}."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        wt_path = await mgr.create("my-scope", "my-task", 3)
+
+        expected_suffix = os.path.join(
+            ".runtime", "worktrees", "my-scope", "my-task", "3"
+        )
+        assert wt_path.endswith(expected_suffix)
+
+        await mgr.destroy(wt_path)
+
+    @pytest.mark.asyncio
+    async def test_multiple_worktrees_isolated(self, tmp_path: Path) -> None:
+        """Two worktrees from the same repo don't see each other's changes."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        wt1 = await mgr.create("scope1", "task-a", 1)
+        wt2 = await mgr.create("scope1", "task-b", 1)
+
+        # Write different files in each worktree
+        (Path(wt1) / "from_a.txt").write_text("a")
+        (Path(wt2) / "from_b.txt").write_text("b")
+
+        # Worktree 1 doesn't see worktree 2's files
+        assert not (Path(wt1) / "from_b.txt").exists()
+        assert not (Path(wt2) / "from_a.txt").exists()
+
+        # Merge both back
+        ok1, _ = await mgr.merge_back(wt1)
+        ok2, _ = await mgr.merge_back(wt2)
+        assert ok1 is True
+        assert ok2 is True
+
+        # Canonical repo has both files
+        assert (repo / "from_a.txt").exists()
+        assert (repo / "from_b.txt").exists()
+
+        await mgr.destroy(wt1)
+        await mgr.destroy(wt2)
+
+    @pytest.mark.asyncio
+    async def test_destroy_nonexistent_worktree(self, tmp_path: Path) -> None:
+        """Destroying a non-existent worktree doesn't raise."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        mgr = LiveWorktreeManager(str(repo))
+        await mgr.destroy("/nonexistent/path")  # Should not raise
+
+
+# ── Pool + executor integration ────────────────────────────────────
+
+
+class TestPoolExecutorIntegration:
+    """End-to-end: pool dispatches to executor for parallel items."""
+
+    @pytest.mark.asyncio
+    async def test_parallel_items_dispatched_via_pool(self) -> None:
+        """When pool is provided, independent items run concurrently."""
+        from silas.models.skills import SkillDefinition
+        from silas.skills.executor import SkillExecutor
+        from silas.skills.registry import SkillRegistry
+        from silas.work.executor import LiveWorkItemExecutor
+
+        registry = SkillRegistry()
+        skill_executor = SkillExecutor(registry)
+        store = InMemoryWorkItemStore()
+
+        # Register a trivial skill
+        registry.register(
+            SkillDefinition(
+                name="noop",
+                description="no-op",
+                version="1.0.0",
+                input_schema={"type": "object"},
+                output_schema={"type": "object"},
+                requires_approval=False,
+                max_retries=0,
+                timeout_seconds=5,
+            )
+        )
+
+        async def _noop_handler(_inputs: dict[str, object]) -> dict[str, object]:
+            return {"ok": True}
+
+        skill_executor.register_handler("noop", _noop_handler)
+
+        # Track dispatch calls through the pool
+        dispatched_ids: list[str] = []
+
+        async def _pool_dispatch(item: WorkItem, scope_id: str) -> WorkItemResult:
+            dispatched_ids.append(item.id)
+            return _ok_result(item.id)
+
+        class _MockPool:
+            async def dispatch(self, item: WorkItem, scope_id: str) -> WorkItemResult:
+                return await _pool_dispatch(item, scope_id)
+
+        executor = LiveWorkItemExecutor(
+            skill_executor,
+            store,
+            pool=_MockPool(),
+            scope_id="test-scope",
+            approval_verifier=_StubApprovalVerifier(valid=True, reason="ok"),
+        )
+
+        # Create two independent child tasks + root
+        child_a = _work_item("child-a", depends_on=[])
+        child_b = _work_item("child-b", depends_on=[])
+        root = WorkItem(
+            id="root",
+            type=WorkItemType.task,
+            title="root",
+            body="root",
+            tasks=["child-a", "child-b"],
+            depends_on=[],
+        )
+        root.approval_token = _approval_token(root)
+
+        # Pre-save children so _resolve_items finds them
+        await store.save(child_a)
+        await store.save(child_b)
+
+        result = await executor.execute(root)
+
+        assert result.status == WorkItemStatus.done
+        # Both children dispatched through the pool
+        assert set(dispatched_ids) == {"child-a", "child-b"}
+
+
+# ── Stub helpers ────────────────────────────────────────────────────
+
+
+class _StubApprovalVerifier:
+    """Always returns a fixed approval result."""
+
+    def __init__(self, *, valid: bool, reason: str) -> None:
+        self._valid = valid
+        self._reason = reason
+
+    async def check(self, token: object, work_item: object) -> tuple[bool, str]:
+        return self._valid, self._reason


### PR DESCRIPTION
## Summary
Implements §7.1 (ExecutorPool) and §7.4 (WorktreeManager) from the Agent Loop Architecture Spec.

### ExecutorPool (`silas/work/pool.py`)
- Per-scope and global concurrency caps via async semaphores
- Parallel dispatch with conflict detection (overlapping file paths → serialise)
- Priority ordering (approved_execution > research > status)
- Cancellation support + graceful shutdown

### WorktreeManager (`silas/execution/worktree.py`)
- Ephemeral git worktree lifecycle: create from HEAD, merge back, destroy
- Three-way merge with conflict detection and per-scope merge locks
- Path convention: `.runtime/worktrees/{scope_id}/{task_id}/{attempt}`

### Executor Integration (`silas/work/executor.py`)
- Wave scheduling: topologically-sorted work items grouped into parallel waves
- Pool-backed parallel dispatch when available, serial fallback otherwise

### Tests (`tests/test_executor_pool.py`)
- 614 lines covering concurrency caps, parallel dispatch, cancellation, conflict detection, wave scheduling, worktree lifecycle, and merge conflicts

Closes #98, closes #99