### PR TITLE
fix: add missing taint_tracker kwarg to _process_turn_via_queue

### DIFF
--- a/silas/core/stream.py
+++ b/silas/core/stream.py
@@ -1336,6 +1336,7 @@ class Stream:
         tc: TurnContext,
         connection_id: str,
         message: ChannelMessage,
+        taint_tracker: object | None = None,
     ) -> str:
         """Dispatch a turn through the queue bridge instead of direct agent calls.
 


### PR DESCRIPTION
Regression from #213 — crashed on first real queue-bridged turn in staging. Adds regression test.