### PR TITLE
fix: queue consumer context + localStorage chat cache

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -454,6 +454,6 @@
       </section>
     </div>
 
-    <script src="/app.js" defer></script>
+    <script src="/app.js?v=3" defer></script>
   </body>
 </html>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "silas-v3";
+const CACHE_VERSION = "silas-v5";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const API_CACHE = `${CACHE_VERSION}-api`;
 const PRECACHE_ASSETS = ["/", "/index.html", "/style.css", "/app.js", "/manifest.json"];


### PR DESCRIPTION
Staging hotfixes from first live deployment:
- ProxyConsumer includes chronicle context in prompt (fixes goldfish memory)
- ProxyConsumer returns agent_response for direct routes (fixes queue timeout)  
- Frontend localStorage chat cache (survives F5)
- Frontend passes ?token= to WebSocket for auth