### PR TITLE
feat: Group A — queue path security fixes (#219, #229, #230, #218)

### DIFF
--- a/silas/queue/bridge.py
+++ b/silas/queue/bridge.py
@@ -62,6 +62,7 @@ class QueueBridge:
         *,
         scope_id: str | None = None,
         taint: str | None = None,
+        tool_allowlist: list[str] | None = None,
     ) -> None:
         """Enqueue a user message to proxy_queue for agent processing.
 
@@ -80,6 +81,7 @@ class QueueBridge:
             payload=payload,
             scope_id=scope_id,
             taint=TaintLevel(taint) if taint else None,
+            tool_allowlist=list(tool_allowlist or []),
         )
         await self._router.route(msg)
         logger.debug("Dispatched user_message to queue, trace_id=%s", trace_id)

--- a/silas/queue/factory.py
+++ b/silas/queue/factory.py
@@ -32,6 +32,9 @@ async def create_queue_system(
     proxy_agent: ProxyAgentProtocol,
     planner_agent: PlannerAgentProtocol,
     executor_agent: ExecutorAgentProtocol,
+    *,
+    channel: object | None = None,
+    approval_recipient_id: str = "owner",
 ) -> tuple[QueueOrchestrator, QueueBridge]:
     """Create store, router, consumers, orchestrator, and bridge.
 
@@ -65,7 +68,13 @@ async def create_queue_system(
     consult_manager = ConsultPlannerManager(store, router)
     replan_manager = ReplanManager(router)
 
-    proxy_consumer = ProxyConsumer(store, router, proxy_agent)
+    proxy_consumer = ProxyConsumer(
+        store,
+        router,
+        proxy_agent,
+        channel=channel,
+        approval_recipient_id=approval_recipient_id,
+    )
     planner_consumer = PlannerConsumer(store, router, planner_agent)
     executor_consumer = ExecutorConsumer(
         store, router, executor_agent,

--- a/silas/queue/types.py
+++ b/silas/queue/types.py
@@ -255,6 +255,8 @@ class QueueMessage(BaseModel):
     work_item_id: str | None = None
     # Authorization token consumed by the approval engine at execution entry
     approval_token: str | None = None
+    # Per-hop tool exposure contract for queue consumers.
+    tool_allowlist: list[str] = Field(default_factory=list)
     # Priority hint for consumer scheduling decisions
     urgency: Urgency = "informational"
 


### PR DESCRIPTION
## Group A: Queue Path Security

Closes all 4 P0 issues that made the queue path bypass security controls.

### Changes
- **#219 Toolset pipeline**: `tool_allowlist` field on QueueMessage, persisted in SQLite. Stream populates per-role allowlists. All consumers apply FilteredToolset before agent.run().
- **#229 Research mode restriction**: `_handle_research_request()` now uses `build_research_console_toolset()` for structural tool removal (not just prompt prefix).
- **#230 Gate enforcement**: `LiveWorkItemExecutor` checks `on_tool_call` gates before every attempt and `after_step` gates between retries. Gate runner wired via `build_stream()`.
- **#218 Plan/approval flow**: `_handle_plan_result()` parses plan markdown, requests approval via channel, dispatches `execution_request` on approval.

### Files changed (12)
749 insertions, 66 deletions across queue/types, consumers, store, bridge, factory, stream, main, executor + tests.

### Tests
106 tests pass (79 consumer/schema/executor + 27 stream). 10 new tests added.