### PR TITLE
fix: resolve CI uv sync permission denied error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        run: uv python install 3.12
+        with:
+          python-version: "3.12"
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Problem
CI fails on all PRs with `uv sync` returning `Permission denied (os error 13)`.

## Fix
Consolidate Python installation into `astral-sh/setup-uv@v4` using the `python-version` parameter instead of a separate `uv python install 3.12` step. The standalone install created Python in a path that `uv sync` couldn't write to on GitHub Actions runners.

## Impact
Fixes CI for all open PRs (#244, #245, #254).