### PR TITLE
fix: correct broken test_dispatch_through_collect assertion

### DIFF
--- a/tests/test_e2e_queue_loop.py
+++ b/tests/test_e2e_queue_loop.py
@@ -81,7 +81,9 @@ class DirectProxyAgent:
             payload={"text": f"Direct answer to: {prompt}"},
         )
         await self._router.route(response)
-        return _MockResult(output=_MockOutput(route="direct"))
+        return _MockResult(
+            output=_MockOutput(route="direct", message=f"Direct answer to: {prompt}"),
+        )
 
     def set_trace_id(self, trace_id: str) -> None:
         """Inject the trace_id so the mock can tag its response correctly."""


### PR DESCRIPTION
## Problem
`test_dispatch_through_collect` fails on `dev` — pre-existing broken test.

The mock `DirectProxyAgent.run()` returns `_MockOutput(message='Mock response')` but the test asserts `'What is 2+2?' in result.payload['text']`.

## Fix
Set the mock's output message to echo the prompt: `f'Direct answer to: {prompt}'`, consistent with the routed response payload.