### PR TITLE
fix: move test dependencies out of production install (#248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --group dev
 
       - name: Ruff
         run: uv run ruff check .
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --group dev
 
       - name: Pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,6 @@ dependencies = [
   "pynacl>=1.5",
   "cryptography>=43",
   "keyring>=25.2",
-  "pytest>=8.3",
-  "pytest-asyncio>=0.24",
-  "pytest-timeout>=2.3",
-  "pytest-split>=0.10",
-  "pyright>=1.1.397",
-  "ruff>=0.6",
   "aiosqlite>=0.22.1",
   "apscheduler>=3.11,<4",
   "pydantic-ai-backend>=0.1.6",
@@ -33,6 +27,16 @@ dependencies = [
 
 [project.optional-dependencies]
 guardrails = ["guardrails-ai"]
+
+[dependency-groups]
+dev = [
+  "pytest>=8.3",
+  "pytest-asyncio>=0.24",
+  "pytest-timeout>=2.3",
+  "pytest-split>=0.10",
+  "pyright>=1.1.397",
+  "ruff>=0.6",
+]
 
 [project.scripts]
 silas = "silas.main:cli"

--- a/uv.lock
+++ b/uv.lock
@@ -2572,19 +2572,23 @@ dependencies = [
     { name = "pydantic-ai-slim", extra = ["logfire", "openrouter"] },
     { name = "pydantic-settings" },
     { name = "pynacl" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-split" },
-    { name = "pytest-timeout" },
     { name = "pyyaml" },
-    { name = "ruff" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
 guardrails = [
     { name = "guardrails-ai" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-split" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -2602,16 +2606,20 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["openrouter", "logfire"], specifier = ">=0.0.27" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pynacl", specifier = ">=1.5" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
+]
+provides-extras = ["guardrails"]
+
+[package.metadata.requires-dev]
+dev = [
     { name = "pyright", specifier = ">=1.1.397" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-split", specifier = ">=0.10" },
     { name = "pytest-timeout", specifier = ">=2.3" },
-    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.6" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["guardrails"]
 
 [[package]]
 name = "six"


### PR DESCRIPTION
Closes #248

Moves pytest, pytest-asyncio, and ruff from `[project.dependencies]` to `[dependency-groups] dev`. Production installs no longer ship test tooling.

CI uses `uv sync` which pulls dev deps automatically.