### PR TITLE
fix: remove .venv symlink breaking CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 *.egg
 
 # Virtual environments
+.venv
 .venv/
 venv/
 

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/root/silas/.venv


### PR DESCRIPTION
## Problem
A self-referencing `.venv` symlink was accidentally committed in #227 (Codex sandbox artifact). This causes `uv sync` to fail instantly with `Permission denied (os error 13)` on GitHub Actions — **all CI has been broken since.**

## Fix
- Remove `.venv` symlink from git tracking (`git rm --cached`)
- Add `.venv` (without trailing slash) to `.gitignore` to catch symlinks, not just directories

## Impact
Unblocks CI for all open PRs (#244, #245, #257) and future pushes to dev.

Closes the root cause behind #255 (which only changed the uv install step but didn't fix the actual issue).