### PR TITLE
feat: Topics Phase 1 — Model, Parser, Registry, Matcher

### DIFF
--- a/silas/topics/__init__.py
+++ b/silas/topics/__init__.py
@@ -1,0 +1,8 @@
+"""Topics system for Silas — Phase 1."""
+
+from silas.topics.matcher import TriggerMatcher
+from silas.topics.model import Topic
+from silas.topics.parser import parse_topic
+from silas.topics.registry import TopicRegistry
+
+__all__ = ["Topic", "TopicRegistry", "TriggerMatcher", "parse_topic"]

--- a/silas/topics/matcher.py
+++ b/silas/topics/matcher.py
@@ -1,0 +1,56 @@
+"""Trigger matching logic for topics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from silas.topics.model import SoftTrigger, TriggerSpec
+
+
+class TriggerMatcher:
+    """Match incoming events and text against topic triggers."""
+
+    def match_hard(self, event: dict[str, Any], triggers: list[TriggerSpec]) -> bool:
+        """Return True if the event matches any hard trigger."""
+        for trigger in triggers:
+            if event.get("source") != trigger.source:
+                continue
+            if trigger.event is not None and event.get("event") != trigger.event:
+                continue
+            if not self._filters_match(event, trigger.filter):
+                continue
+            return True
+        return False
+
+    def match_soft(self, text: str, soft_triggers: list[SoftTrigger]) -> float:
+        """Score how well text matches soft triggers. 0.0-1.0."""
+        if not soft_triggers:
+            return 0.0
+
+        text_lower = text.lower()
+        best_score = 0.0
+
+        for st in soft_triggers:
+            score = self._score_soft_trigger(text_lower, st)
+            best_score = max(best_score, score)
+
+        return best_score
+
+    def _filters_match(self, event: dict[str, Any], filters: dict[str, Any]) -> bool:
+        """Check that all filter key-value pairs match the event."""
+        return all(event.get(key) == value for key, value in filters.items())
+
+    def _score_soft_trigger(self, text_lower: str, st: SoftTrigger) -> float:
+        """Score a single soft trigger against lowercased text."""
+        scores: list[float] = []
+
+        if st.keywords:
+            matched = sum(1 for kw in st.keywords if kw.lower() in text_lower)
+            scores.append(matched / len(st.keywords))
+
+        if st.entity is not None:
+            scores.append(1.0 if st.entity.lower() in text_lower else 0.0)
+
+        if not scores:
+            return 0.0
+        return sum(scores) / len(scores)

--- a/silas/topics/model.py
+++ b/silas/topics/model.py
@@ -1,0 +1,47 @@
+"""Topic models for the Silas topics system."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TriggerSpec(BaseModel):
+    """Hard trigger specification for matching incoming events."""
+
+    source: str
+    event: str | None = None
+    filter: dict[str, Any] = Field(default_factory=dict)
+    expr: str | None = None
+
+
+class SoftTrigger(BaseModel):
+    """Soft trigger for keyword/entity-based matching."""
+
+    keywords: list[str] = Field(default_factory=list)
+    entity: str | None = None
+
+
+class ApprovalSpec(BaseModel):
+    """Approval requirement for tool usage within a topic."""
+
+    tool: str
+    constraints: dict[str, Any] = Field(default_factory=dict)
+
+
+class Topic(BaseModel):
+    """A topic represents a unit of work with triggers, scope, and lifecycle."""
+
+    id: str
+    name: str
+    scope: Literal["session", "project", "infinite"]
+    agent: Literal["proxy", "planner", "executor"]
+    status: Literal["active", "paused", "completed", "archived"] = "active"
+    triggers: list[TriggerSpec] = Field(default_factory=list)
+    soft_triggers: list[SoftTrigger] = Field(default_factory=list)
+    approvals: list[ApprovalSpec] = Field(default_factory=list)
+    body: str
+    created_at: datetime
+    updated_at: datetime

--- a/silas/topics/parser.py
+++ b/silas/topics/parser.py
@@ -1,0 +1,65 @@
+"""Parse Markdown files with YAML frontmatter into Topic models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import yaml
+
+from silas.topics.model import Topic
+
+
+class TopicParseError(Exception):
+    """Raised when topic markdown cannot be parsed."""
+
+
+def parse_topic(markdown: str) -> Topic:
+    """Parse a markdown string with YAML frontmatter into a Topic.
+
+    The markdown must start with ``---`` followed by YAML frontmatter
+    and a closing ``---``. Everything after is the body.
+    """
+    stripped = markdown.strip()
+    if not stripped.startswith("---"):
+        raise TopicParseError("Missing frontmatter delimiter")
+
+    # Split on the second ---
+    parts = stripped.split("---", 2)
+    if len(parts) < 3:
+        raise TopicParseError("Incomplete frontmatter: missing closing delimiter")
+
+    frontmatter_raw = parts[1].strip()
+    body = parts[2].strip()
+
+    try:
+        frontmatter: dict = yaml.safe_load(frontmatter_raw) or {}  # type: ignore[assignment]
+    except yaml.YAMLError as exc:
+        raise TopicParseError(f"Invalid YAML in frontmatter: {exc}") from exc
+
+    if not isinstance(frontmatter, dict):
+        raise TopicParseError("Frontmatter must be a YAML mapping")
+
+    now = datetime.now(tz=UTC)
+
+    return Topic(
+        id=frontmatter.get("id", str(uuid4())),
+        name=frontmatter.get("name", "Untitled"),
+        scope=frontmatter.get("scope", "session"),
+        agent=frontmatter.get("agent", "proxy"),
+        status=frontmatter.get("status", "active"),
+        triggers=frontmatter.get("triggers", []),
+        soft_triggers=frontmatter.get("soft_triggers", []),
+        approvals=frontmatter.get("approvals", []),
+        body=body,
+        created_at=frontmatter.get("created_at", now),
+        updated_at=frontmatter.get("updated_at", now),
+    )
+
+
+def topic_to_markdown(topic: Topic) -> str:
+    """Serialize a Topic back to markdown with YAML frontmatter."""
+    data = topic.model_dump(mode="json")
+    body = data.pop("body")
+    frontmatter = yaml.dump(data, default_flow_style=False, sort_keys=False)
+    return f"---\n{frontmatter}---\n\n{body}\n"

--- a/silas/topics/registry.py
+++ b/silas/topics/registry.py
@@ -1,0 +1,97 @@
+"""Filesystem-backed topic registry."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from silas.topics.matcher import TriggerMatcher
+from silas.topics.model import Topic
+from silas.topics.parser import TopicParseError, parse_topic, topic_to_markdown
+
+logger = logging.getLogger(__name__)
+
+
+class TopicRegistry:
+    """CRUD registry for topics stored as markdown files on disk."""
+
+    def __init__(self, topics_dir: Path) -> None:
+        self._dir = topics_dir
+        self._matcher = TriggerMatcher()
+
+    def _path_for(self, topic_id: str) -> Path:
+        return self._dir / f"{topic_id}.md"
+
+    async def create(self, markdown: str) -> Topic:
+        """Parse markdown and persist as a new topic file."""
+        topic = parse_topic(markdown)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(topic.id)
+        path.write_text(topic_to_markdown(topic))
+        return topic
+
+    async def get(self, topic_id: str) -> Topic | None:
+        """Load a topic by ID, or return None if not found."""
+        path = self._path_for(topic_id)
+        if not path.exists():
+            return None
+        try:
+            return parse_topic(path.read_text())
+        except TopicParseError:
+            logger.warning("Failed to parse topic file: %s", path)
+            return None
+
+    async def list(self, status: str | None = None) -> list[Topic]:
+        """List all topics, optionally filtered by status."""
+        if not self._dir.exists():
+            return []
+        topics: list[Topic] = []
+        for path in sorted(self._dir.glob("*.md")):
+            try:
+                topic = parse_topic(path.read_text())
+            except TopicParseError:
+                logger.warning("Skipping unparseable topic: %s", path)
+                continue
+            if status is None or topic.status == status:
+                topics.append(topic)
+        return topics
+
+    async def update(self, topic_id: str, markdown: str) -> Topic:
+        """Update an existing topic with new markdown content."""
+        path = self._path_for(topic_id)
+        if not path.exists():
+            raise FileNotFoundError(f"Topic {topic_id} not found")
+        topic = parse_topic(markdown)
+        if topic.id != topic_id:
+            raise ValueError(f"Topic ID mismatch: expected {topic_id}, got {topic.id}")
+        path.write_text(topic_to_markdown(topic))
+        return topic
+
+    async def delete(self, topic_id: str) -> bool:
+        """Delete a topic file. Returns True if it existed."""
+        path = self._path_for(topic_id)
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+    async def find_by_trigger(self, source: str, event: str, context: dict) -> list[Topic]:
+        """Find all active topics matching a hard trigger."""
+        all_topics = await self.list(status="active")
+        matched: list[Topic] = []
+        full_event = {"source": source, "event": event, **context}
+        for topic in all_topics:
+            if self._matcher.match_hard(full_event, topic.triggers):
+                matched.append(topic)
+        return matched
+
+    async def find_by_keywords(self, text: str) -> list[Topic]:
+        """Find active topics whose soft triggers match the given text."""
+        all_topics = await self.list(status="active")
+        scored: list[tuple[float, Topic]] = []
+        for topic in all_topics:
+            score = self._matcher.match_soft(text, topic.soft_triggers)
+            if score > 0.0:
+                scored.append((score, topic))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [t for _, t in scored]

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,302 @@
+"""Tests for silas.topics — Phase 1: Model, Parser, Registry, Matcher."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from silas.topics.matcher import TriggerMatcher
+from silas.topics.model import SoftTrigger, Topic, TriggerSpec
+from silas.topics.parser import TopicParseError, parse_topic, topic_to_markdown
+from silas.topics.registry import TopicRegistry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_TOPIC_MD = """\
+---
+id: "abc-123"
+name: "CI Failure Handler"
+scope: project
+agent: executor
+status: active
+triggers:
+  - source: github
+    event: check_suite.completed
+    filter:
+      repo: silas
+      conclusion: failure
+soft_triggers:
+  - keywords: ["ci", "build", "failure"]
+    entity: github
+approvals:
+  - tool: codex_exec
+    constraints:
+      max_runtime: 300
+---
+
+# CI Failure Handler
+
+When CI fails, investigate and propose a fix.
+"""
+
+MINIMAL_TOPIC_MD = """\
+---
+name: "Quick Note"
+scope: session
+agent: proxy
+---
+
+Just a simple topic body.
+"""
+
+
+@pytest.fixture
+def tmp_topics_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "topics"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def registry(tmp_topics_dir: Path) -> TopicRegistry:
+    return TopicRegistry(tmp_topics_dir)
+
+
+@pytest.fixture
+def matcher() -> TriggerMatcher:
+    return TriggerMatcher()
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestParser:
+    def test_parse_valid_topic(self) -> None:
+        topic = parse_topic(VALID_TOPIC_MD)
+        assert topic.id == "abc-123"
+        assert topic.name == "CI Failure Handler"
+        assert topic.scope == "project"
+        assert topic.agent == "executor"
+        assert topic.status == "active"
+        assert len(topic.triggers) == 1
+        assert topic.triggers[0].source == "github"
+        assert topic.triggers[0].filter["repo"] == "silas"
+        assert len(topic.soft_triggers) == 1
+        assert "ci" in topic.soft_triggers[0].keywords
+        assert len(topic.approvals) == 1
+        assert topic.approvals[0].tool == "codex_exec"
+        assert "CI Failure Handler" in topic.body
+
+    def test_parse_minimal_defaults(self) -> None:
+        topic = parse_topic(MINIMAL_TOPIC_MD)
+        assert topic.name == "Quick Note"
+        assert topic.status == "active"  # default
+        assert topic.triggers == []
+        assert topic.soft_triggers == []
+        assert topic.approvals == []
+        # ID should be auto-generated UUID
+        assert len(topic.id) > 0
+
+    def test_parse_missing_frontmatter(self) -> None:
+        with pytest.raises(TopicParseError, match="Missing frontmatter"):
+            parse_topic("No frontmatter here")
+
+    def test_parse_incomplete_frontmatter(self) -> None:
+        with pytest.raises(TopicParseError, match="Incomplete frontmatter"):
+            parse_topic("---\nname: test\nno closing delimiter")
+
+    def test_parse_invalid_yaml(self) -> None:
+        with pytest.raises(TopicParseError, match="Invalid YAML"):
+            parse_topic("---\n: :\n  - ][bad\n---\nbody")
+
+    def test_roundtrip(self) -> None:
+        original = parse_topic(VALID_TOPIC_MD)
+        md = topic_to_markdown(original)
+        restored = parse_topic(md)
+        assert original.id == restored.id
+        assert original.name == restored.name
+        assert original.scope == restored.scope
+        assert original.triggers[0].source == restored.triggers[0].source
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestModel:
+    def test_trigger_spec_defaults(self) -> None:
+        t = TriggerSpec(source="manual")
+        assert t.event is None
+        assert t.filter == {}
+        assert t.expr is None
+
+    def test_topic_status_default(self) -> None:
+        now = datetime.now(tz=UTC)
+        topic = Topic(
+            id="x",
+            name="t",
+            scope="session",
+            agent="proxy",
+            body="b",
+            created_at=now,
+            updated_at=now,
+        )
+        assert topic.status == "active"
+
+    def test_invalid_scope_rejected(self) -> None:
+        now = datetime.now(tz=UTC)
+        with pytest.raises(Exception):  # noqa: B017
+            Topic(
+                id="x",
+                name="t",
+                scope="invalid",  # type: ignore[arg-type]
+                agent="proxy",
+                body="b",
+                created_at=now,
+                updated_at=now,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    async def test_create_and_get(self, registry: TopicRegistry) -> None:
+        topic = await registry.create(VALID_TOPIC_MD)
+        assert topic.id == "abc-123"
+        loaded = await registry.get("abc-123")
+        assert loaded is not None
+        assert loaded.name == topic.name
+
+    async def test_get_nonexistent(self, registry: TopicRegistry) -> None:
+        assert await registry.get("nonexistent") is None
+
+    async def test_list_all(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        await registry.create(MINIMAL_TOPIC_MD)
+        topics = await registry.list()
+        assert len(topics) == 2
+
+    async def test_list_by_status(self, registry: TopicRegistry) -> None:
+        paused_md = VALID_TOPIC_MD.replace("status: active", "status: paused").replace(
+            'id: "abc-123"', 'id: "paused-1"'
+        )
+        await registry.create(VALID_TOPIC_MD)
+        await registry.create(paused_md)
+        active = await registry.list(status="active")
+        assert len(active) == 1
+        assert active[0].id == "abc-123"
+
+    async def test_update(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        updated_md = VALID_TOPIC_MD.replace("status: active", "status: paused")
+        topic = await registry.update("abc-123", updated_md)
+        assert topic.status == "paused"
+
+    async def test_update_nonexistent(self, registry: TopicRegistry) -> None:
+        with pytest.raises(FileNotFoundError):
+            await registry.update("nope", VALID_TOPIC_MD)
+
+    async def test_delete(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        assert await registry.delete("abc-123") is True
+        assert await registry.get("abc-123") is None
+
+    async def test_delete_nonexistent(self, registry: TopicRegistry) -> None:
+        assert await registry.delete("nope") is False
+
+    async def test_find_by_trigger(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        matches = await registry.find_by_trigger(
+            "github", "check_suite.completed", {"repo": "silas", "conclusion": "failure"}
+        )
+        assert len(matches) == 1
+        assert matches[0].id == "abc-123"
+
+    async def test_find_by_trigger_no_match(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        matches = await registry.find_by_trigger("gitlab", "push", {})
+        assert len(matches) == 0
+
+    async def test_find_by_keywords(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        matches = await registry.find_by_keywords("the ci build had a failure")
+        assert len(matches) == 1
+        assert matches[0].id == "abc-123"
+
+    async def test_find_by_keywords_no_match(self, registry: TopicRegistry) -> None:
+        await registry.create(VALID_TOPIC_MD)
+        matches = await registry.find_by_keywords("deploy succeeded perfectly")
+        assert len(matches) == 0
+
+    async def test_lifecycle_active_to_paused_to_archived(self, registry: TopicRegistry) -> None:
+        topic = await registry.create(VALID_TOPIC_MD)
+        assert topic.status == "active"
+
+        paused_md = VALID_TOPIC_MD.replace("status: active", "status: paused")
+        topic = await registry.update("abc-123", paused_md)
+        assert topic.status == "paused"
+
+        archived_md = VALID_TOPIC_MD.replace("status: active", "status: archived")
+        topic = await registry.update("abc-123", archived_md)
+        assert topic.status == "archived"
+
+
+# ---------------------------------------------------------------------------
+# Matcher tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatcher:
+    def test_match_hard_exact(self, matcher: TriggerMatcher) -> None:
+        triggers = [TriggerSpec(source="github", event="push")]
+        assert matcher.match_hard({"source": "github", "event": "push"}, triggers) is True
+
+    def test_match_hard_with_filter(self, matcher: TriggerMatcher) -> None:
+        triggers = [TriggerSpec(source="github", event="push", filter={"branch": "main"})]
+        assert (
+            matcher.match_hard({"source": "github", "event": "push", "branch": "main"}, triggers)
+            is True
+        )
+        assert (
+            matcher.match_hard({"source": "github", "event": "push", "branch": "dev"}, triggers)
+            is False
+        )
+
+    def test_match_hard_no_match(self, matcher: TriggerMatcher) -> None:
+        triggers = [TriggerSpec(source="github", event="push")]
+        assert matcher.match_hard({"source": "gitlab", "event": "push"}, triggers) is False
+
+    def test_match_hard_empty_triggers(self, matcher: TriggerMatcher) -> None:
+        assert matcher.match_hard({"source": "github"}, []) is False
+
+    def test_match_soft_full_keywords(self, matcher: TriggerMatcher) -> None:
+        st = [SoftTrigger(keywords=["ci", "failure"], entity="github")]
+        score = matcher.match_soft("CI failure on github actions", st)
+        assert score == 1.0
+
+    def test_match_soft_partial_keywords(self, matcher: TriggerMatcher) -> None:
+        st = [SoftTrigger(keywords=["ci", "failure", "deploy"])]
+        score = matcher.match_soft("ci failure detected", st)
+        assert 0.5 < score < 1.0  # 2/3 keywords
+
+    def test_match_soft_no_match(self, matcher: TriggerMatcher) -> None:
+        st = [SoftTrigger(keywords=["kubernetes", "pod"])]
+        score = matcher.match_soft("the weather is nice", st)
+        assert score == 0.0
+
+    def test_match_soft_entity_only(self, matcher: TriggerMatcher) -> None:
+        st = [SoftTrigger(entity="github")]
+        score = matcher.match_soft("something about GitHub", st)
+        assert score == 1.0
+
+    def test_match_soft_empty(self, matcher: TriggerMatcher) -> None:
+        assert matcher.match_soft("anything", []) == 0.0


### PR DESCRIPTION
## Phase 1: Topic Model + Parser + Registry

Infrastructure for the topics system. No existing functionality is modified.

### What's included

- **`silas/topics/model.py`** — Pydantic models: `Topic`, `TriggerSpec`, `SoftTrigger`, `ApprovalSpec`
- **`silas/topics/parser.py`** — Parse markdown with YAML frontmatter into Topic models, round-trip serialization
- **`silas/topics/registry.py`** — Filesystem-backed CRUD registry with trigger/keyword search
- **`silas/topics/matcher.py`** — Hard event matching and soft keyword scoring
- **`silas/topics/__init__.py`** — Clean public API exports
- **`tests/test_topics.py`** — 31 tests covering parser, model, registry CRUD, trigger matching, keyword search, and lifecycle

### Notes
- No new dependencies (pyyaml already present)
- All tests pass, ruff clean
- Phase 1 infrastructure only — does not close #284