### PR TITLE
fix: queue path agent_response deserialization crash

### DIFF
--- a/silas/core/stream/_stream.py
+++ b/silas/core/stream/_stream.py
@@ -853,7 +853,13 @@ class Stream(
 
         agent_response = None
         if queue_response is not None:
-            agent_response = queue_response.payload.get("agent_response")
+            raw = queue_response.payload.get("agent_response")
+            if isinstance(raw, dict):
+                from silas.models.agents import AgentResponse
+
+                agent_response = AgentResponse(**raw)
+            else:
+                agent_response = raw
         await self._process_memory_queries(
             agent_response,
             accumulated_taint,


### PR DESCRIPTION
Queue path passed raw dict to `_process_memory_queries` which expected `AgentResponse`. Crashes with `AttributeError: 'dict' object has no attribute 'memory_queries'`.

Fix: deserialize dict → `AgentResponse` on the queue path before passing to memory processing.