### PR TITLE
test: coverage for 4 untested modules — signing, nonce, subscriptions, interaction mode (#275)

### DIFF
--- a/tests/test_interaction_mode.py
+++ b/tests/test_interaction_mode.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import pytest
+from silas.core.interaction_mode import resolve_interaction_mode
+from silas.models.agents import AgentResponse, InteractionMode, InteractionRegister, RouteDecision
+from silas.models.gates import GateLane, GateResult
+from silas.models.personality import AxisProfile
+
+
+class _Calibrator:
+    def __init__(self, metrics: dict[str, object]) -> None:
+        self.metrics = metrics
+
+    def get_metrics(self, scope_id: str) -> dict[str, object]:
+        del scope_id
+        return self.metrics
+
+
+class _BrokenCalibrator:
+    def get_metrics(self, scope_id: str) -> dict[str, object]:
+        del scope_id
+        raise RuntimeError("boom")
+
+
+class _Personality:
+    def __init__(self, initiative: float) -> None:
+        self.initiative = initiative
+        self.calls: list[tuple[str, str]] = []
+
+    async def get_effective_axes(self, scope_id: str, context_key: str) -> AxisProfile:
+        self.calls.append((scope_id, context_key))
+        return AxisProfile(
+            warmth=0.4,
+            assertiveness=0.4,
+            verbosity=0.4,
+            formality=0.4,
+            humor=0.4,
+            initiative=self.initiative,
+            certainty=0.4,
+        )
+
+
+class _BrokenPersonality:
+    async def get_effective_axes(self, scope_id: str, context_key: str) -> AxisProfile:
+        del scope_id, context_key
+        raise TypeError("invalid")
+
+
+def _route(
+    *,
+    register: InteractionRegister = InteractionRegister.execution,
+    mode: InteractionMode = InteractionMode.default_and_offer,
+    context_profile: str = "conversation",
+) -> RouteDecision:
+    return RouteDecision(
+        route="direct",
+        reason="test",
+        response=AgentResponse(message="ok", needs_approval=False),
+        interaction_register=register,
+        interaction_mode=mode,
+        context_profile=context_profile,
+    )
+
+
+@pytest.mark.asyncio
+async def test_risk_override_from_gate_block_forces_confirmation_mode() -> None:
+    route = _route(mode=InteractionMode.act_and_report)
+    gate_results = [
+        GateResult(
+            gate_name="risk",
+            lane=GateLane.policy,
+            action="block",
+            reason="requires confirmation",
+        )
+    ]
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route,
+        scope_id="owner",
+        autonomy_calibrator=_Calibrator({"initiative_level": 1.0}),
+        gate_results=gate_results,
+        personality_engine=None,
+    )
+
+    assert resolved == InteractionMode.confirm_only_when_required
+
+
+@pytest.mark.asyncio
+async def test_planner_override_takes_precedence_over_work_item_and_proxy() -> None:
+    route = _route(mode=InteractionMode.default_and_offer)
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route,
+        scope_id="owner",
+        autonomy_calibrator=None,
+        gate_results=[],
+        personality_engine=None,
+        planner_override=InteractionMode.confirm_only_when_required,
+        work_item_mode=InteractionMode.act_and_report,
+    )
+
+    assert resolved == InteractionMode.confirm_only_when_required
+
+
+@pytest.mark.asyncio
+async def test_work_item_mode_takes_precedence_when_planner_override_absent() -> None:
+    route = _route(mode=InteractionMode.default_and_offer)
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route,
+        scope_id="owner",
+        autonomy_calibrator=None,
+        gate_results=[],
+        personality_engine=None,
+        work_item_mode=InteractionMode.act_and_report,
+    )
+
+    assert resolved == InteractionMode.act_and_report
+
+
+@pytest.mark.asyncio
+async def test_personality_axes_override_calibrator_initiative_and_use_route_profile() -> None:
+    route = _route(register=InteractionRegister.execution, context_profile="planning")
+    route_without_proxy_mode = route.model_copy(update={"interaction_mode": None})
+    personality = _Personality(initiative=0.95)
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route_without_proxy_mode,
+        scope_id="owner",
+        autonomy_calibrator=_Calibrator({"initiative_level": 0.1, "high_initiative_min": 0.7}),
+        gate_results=[],
+        personality_engine=personality,
+    )
+
+    assert resolved == InteractionMode.act_and_report
+    assert personality.calls == [("owner", "planning")]
+
+
+@pytest.mark.asyncio
+async def test_calibrator_and_personality_failures_fall_back_to_register_default() -> None:
+    route = _route(register=InteractionRegister.review)
+    route_without_proxy_mode = route.model_copy(update={"interaction_mode": None})
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route_without_proxy_mode,
+        scope_id="owner",
+        autonomy_calibrator=_BrokenCalibrator(),
+        gate_results=[],
+        personality_engine=_BrokenPersonality(),
+    )
+
+    assert resolved == InteractionMode.default_and_offer
+
+
+@pytest.mark.asyncio
+async def test_calibrator_risk_flag_forces_confirmation_without_gate_results() -> None:
+    route = _route(mode=InteractionMode.act_and_report)
+
+    resolved = await resolve_interaction_mode(
+        route_decision=route,
+        scope_id="owner",
+        autonomy_calibrator=_Calibrator({"risk_requires_confirmation": True}),
+        gate_results=[],
+        personality_engine=None,
+    )
+
+    assert resolved == InteractionMode.confirm_only_when_required

--- a/tests/test_stream_nonce.py
+++ b/tests/test_stream_nonce.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from silas.core.stream._nonce import _InMemoryNonceStore
+
+
+@pytest.mark.asyncio
+async def test_nonce_replay_detection_in_same_domain() -> None:
+    store = _InMemoryNonceStore()
+    nonce = "nonce-1"
+
+    assert await store.is_used("msg", nonce) is False
+    await store.record("msg", nonce)
+    assert await store.is_used("msg", nonce) is True
+
+
+@pytest.mark.asyncio
+async def test_nonce_uniqueness_for_generated_nonce_values() -> None:
+    store = _InMemoryNonceStore()
+    nonces = [uuid.uuid4().hex for _ in range(10)]
+
+    for nonce in nonces:
+        assert await store.is_used("msg", nonce) is False
+        await store.record("msg", nonce)
+
+    for nonce in nonces:
+        assert await store.is_used("msg", nonce) is True
+
+
+@pytest.mark.asyncio
+async def test_nonce_domain_scoping_prevents_cross_domain_collision() -> None:
+    store = _InMemoryNonceStore()
+    nonce = "shared-value"
+
+    await store.record("msg", nonce)
+
+    assert await store.is_used("msg", nonce) is True
+    assert await store.is_used("exec", nonce) is False
+
+
+@pytest.mark.asyncio
+async def test_prune_expired_is_deterministic_noop() -> None:
+    store = _InMemoryNonceStore()
+    await store.record("msg", "n")
+
+    removed = await store.prune_expired(datetime.now(UTC))
+
+    assert removed == 0
+    assert await store.is_used("msg", "n") is True

--- a/tests/test_stream_signing.py
+++ b/tests/test_stream_signing.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from silas.core.stream._signing import SigningMixin
+from silas.models.messages import ChannelMessage, SignedMessage, TaintLevel
+
+
+class _SigningHarness(SigningMixin):
+    def __init__(self, signing_key: object, owner_id: str = "owner") -> None:
+        self._signing_key = signing_key
+        self.owner_id = owner_id
+        self.audit_events: list[tuple[str, dict[str, Any]]] = []
+
+    async def _audit(self, event: str, **kwargs: Any) -> None:
+        self.audit_events.append((event, kwargs))
+
+
+def _message(*, sender_id: str = "owner", is_authenticated: bool = True) -> ChannelMessage:
+    return ChannelMessage(
+        channel="web",
+        sender_id=sender_id,
+        text="hello",
+        timestamp=datetime.now(UTC),
+        is_authenticated=is_authenticated,
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_inbound_authenticated_message_is_trusted() -> None:
+    harness = _SigningHarness(signing_key=b"secret")
+    signed = SignedMessage(message=_message(is_authenticated=True), signature=b"", nonce="n1")
+
+    verified, reason = await harness.verify_inbound(signed)
+
+    assert verified is True
+    assert reason == "authenticated_session"
+
+
+@pytest.mark.asyncio
+async def test_verify_inbound_unauthenticated_message_is_untrusted() -> None:
+    harness = _SigningHarness(signing_key=b"secret")
+    signed = SignedMessage(message=_message(is_authenticated=False), signature=b"", nonce="n1")
+
+    verified, reason = await harness.verify_inbound(signed)
+
+    assert verified is False
+    assert reason == "no_client_signature"
+
+
+def test_create_inbound_signed_message_keeps_processed_text_without_self_signature() -> None:
+    harness = _SigningHarness(signing_key=b"secret")
+    signed = harness._create_inbound_signed_message(_message(), "processed")
+
+    assert signed.message.text == "processed"
+    assert signed.signature == b""
+    assert len(signed.nonce) == 32
+    assert signed.taint == TaintLevel.external
+
+
+@pytest.mark.asyncio
+async def test_prepare_signed_inbound_message_owner_taint_when_verified_owner() -> None:
+    harness = _SigningHarness(signing_key=b"secret", owner_id="owner")
+    message = _message(sender_id="owner", is_authenticated=True)
+
+    signed = await harness._prepare_signed_inbound_message(
+        message=message,
+        processed_message_text="processed",
+        turn_number=7,
+    )
+
+    assert signed.message.text == "processed"
+    assert signed.taint == TaintLevel.owner
+    assert harness.audit_events == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_signed_inbound_message_external_taint_and_audit_when_untrusted() -> None:
+    harness = _SigningHarness(signing_key=b"secret", owner_id="owner")
+    message = _message(sender_id="owner", is_authenticated=False)
+
+    signed = await harness._prepare_signed_inbound_message(
+        message=message,
+        processed_message_text="processed",
+        turn_number=9,
+    )
+
+    assert signed.taint == TaintLevel.external
+    assert harness.audit_events == [
+        (
+            "inbound_message_untrusted",
+            {"turn_number": 9, "sender_id": "owner", "reason": "no_client_signature"},
+        )
+    ]
+
+
+def test_sign_and_verify_payload_with_ed25519_key() -> None:
+    harness = _SigningHarness(signing_key=Ed25519PrivateKey.generate())
+    payload = b"canonical-payload"
+
+    signature = harness._sign_payload(payload)
+
+    assert harness._is_valid_signature(payload, signature) is True
+
+
+def test_ed25519_invalid_signature_is_rejected() -> None:
+    harness = _SigningHarness(signing_key=Ed25519PrivateKey.generate())
+    payload = b"canonical-payload"
+    invalid_signature = Ed25519PrivateKey.generate().sign(payload)
+
+    assert harness._is_valid_signature(payload, invalid_signature) is False
+
+
+def test_sign_and_verify_payload_with_hmac_key() -> None:
+    harness = _SigningHarness(signing_key=b"shared-secret")
+    payload = b"canonical-payload"
+
+    signature = harness._sign_payload(payload)
+
+    assert harness._is_valid_signature(payload, signature) is True
+    assert harness._is_valid_signature(payload + b"-tampered", signature) is False
+
+
+def test_sign_payload_raises_when_key_missing() -> None:
+    harness = _SigningHarness(signing_key=None)
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        harness._sign_payload(b"payload")
+
+
+def test_verify_signature_returns_false_for_unsupported_key_type() -> None:
+    harness = _SigningHarness(signing_key=object())
+
+    assert harness._is_valid_signature(b"payload", b"signature") is False

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+from silas.core.subscriptions import ContextSubscriptionManager, _is_expired
+from silas.models.context import ContextSubscription, ContextZone
+
+
+def _subscription(
+    sub_id: str,
+    target: str,
+    *,
+    active: bool = True,
+    sub_type: str = "file",
+    token_count: int = 123,
+) -> ContextSubscription:
+    return ContextSubscription(
+        sub_id=sub_id,
+        sub_type=sub_type,
+        target=target,
+        zone=ContextZone.workspace,
+        turn_created=1,
+        content_hash="hash",
+        active=active,
+        token_count=token_count,
+    )
+
+
+def test_register_sets_fresh_created_at_and_preserves_token_budget_data(tmp_path) -> None:
+    manager = ContextSubscriptionManager(subscriptions=[])
+    file_path = tmp_path / "tracked.txt"
+    file_path.write_text("v1", encoding="utf-8")
+    original = _subscription("sub-1", str(file_path), token_count=321)
+    original_created_at = original.created_at
+
+    manager.register(original)
+    active = manager.get_active()
+
+    assert len(active) == 1
+    assert active[0].token_count == 321
+    assert active[0].created_at >= original_created_at
+
+
+def test_get_active_returns_deep_copies() -> None:
+    manager = ContextSubscriptionManager(subscriptions=[_subscription("sub-1", "/tmp/a.txt")])
+
+    first = manager.get_active()
+    first[0].target = "/tmp/changed.txt"
+
+    second = manager.get_active()
+    assert second[0].target == "/tmp/a.txt"
+
+
+def test_check_changes_only_tracks_file_based_active_subscriptions(tmp_path) -> None:
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("v1", encoding="utf-8")
+    manager = ContextSubscriptionManager(
+        subscriptions=[
+            _subscription("tracked", str(tracked), sub_type="file"),
+            _subscription("query", "SELECT 1", sub_type="query"),
+            _subscription("inactive", str(tracked), active=False),
+        ]
+    )
+
+    assert manager.check_changes() == []
+    previous_stat = tracked.stat()
+    tracked.write_text("v2", encoding="utf-8")
+    os.utime(tracked, ns=(previous_stat.st_atime_ns, previous_stat.st_mtime_ns + 1_000_000_000))
+
+    changed = manager.check_changes()
+
+    assert [item["subscription_id"] for item in changed] == ["tracked"]
+    assert changed[0]["target"] == str(tracked)
+
+
+def test_materialize_returns_none_for_non_file_missing_or_inactive(tmp_path) -> None:
+    existing = tmp_path / "existing.txt"
+    existing.write_text("content", encoding="utf-8")
+    manager = ContextSubscriptionManager(
+        subscriptions=[
+            _subscription("file", str(existing), sub_type="file"),
+            _subscription("query", "SELECT 1", sub_type="query"),
+            _subscription("inactive", str(existing), active=False),
+            _subscription("missing", str(tmp_path / "missing.txt"), sub_type="file"),
+        ]
+    )
+
+    assert manager.materialize("file") == "content"
+    assert manager.materialize("query") is None
+    assert manager.materialize("inactive") is None
+    assert manager.materialize("missing") is None
+    assert manager.materialize("unknown") is None
+
+
+def test_prune_expired_removes_inactive_and_time_expired_subscriptions() -> None:
+    now = datetime.now(UTC)
+    active = _subscription("active", "/tmp/active.txt")
+    expired_by_flag = _subscription("inactive", "/tmp/inactive.txt", active=False)
+    expired_by_time = _subscription("time-expired", "/tmp/expired.txt")
+    object.__setattr__(expired_by_time, "expires_at", now - timedelta(seconds=1))
+
+    manager = ContextSubscriptionManager([active, expired_by_flag, expired_by_time])
+
+    removed = manager.prune_expired()
+
+    assert removed == 2
+    assert [sub.sub_id for sub in manager.get_active()] == ["active"]
+
+
+def test_is_expired_accepts_naive_expires_at_as_utc() -> None:
+    now = datetime.now(UTC)
+    subscription = _subscription("naive", "/tmp/naive.txt")
+    naive_expired = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+    object.__setattr__(subscription, "expires_at", naive_expired)
+
+    assert _is_expired(subscription, now) is True


### PR DESCRIPTION
Adds 26 tests across 4 previously untested modules (part of #275):

- **test_stream_signing.py** — message signing/verification, invalid signatures, missing keys
- **test_stream_nonce.py** — nonce generation, uniqueness, replay detection
- **test_subscriptions.py** — subscription CRUD, matching, TTL expiry, token budget
- **test_interaction_mode.py** — mode inference, overrides, profile selection

All pass locally. Partial progress on #275 (4 of 12+ modules covered).