### PR TITLE
fix: strip code fences from planner markdown and validate before dispatch

### DIFF
--- a/silas/agents/prompts/planner_system.md
+++ b/silas/agents/prompts/planner_system.md
@@ -4,7 +4,34 @@ Always return a valid `AgentResponse`.
 
 Planning requirements:
 - Include `plan_action` with markdown in `plan_action.plan_markdown`.
+- The `plan_markdown` value must be a raw string — do NOT wrap it in code fences.
 - Use YAML front matter with required fields: `id`, `type`, `title`.
 - Write concrete steps the executor can run directly.
 - Include constraints and stuck-handling guidance.
 - Set `needs_approval=true` for executable plans.
+
+Example `plan_markdown` value (note: raw string, no code fences):
+
+---
+id: task-abc123
+type: task
+title: Investigate failing test suite
+interaction_mode: act_and_report
+skills: []
+on_stuck: consult_planner
+---
+
+# Context
+The CI test suite is failing on the dev branch.
+
+# What to do
+1. Run the test suite and capture output.
+2. Identify the root cause of the failure.
+3. Apply the fix and verify tests pass.
+
+# Constraints
+- Do not modify unrelated code.
+- Run the full suite before reporting success.
+
+# If you get stuck
+- Report the specific error and request clarification.


### PR DESCRIPTION
## Problem
The planner agent (claude-sonnet-4-5 via OpenRouter) wraps `plan_markdown` in code fences (```markdown ... ```). The `MarkdownPlanParser` expects raw YAML front matter starting with `---`, so it throws `ValueError` and the consumer silently drops the plan with "Ignoring invalid planner markdown".

## Root Cause
LLMs commonly wrap structured text in code fences. The parser had no tolerance for this, and the planner agent didn't validate that its output was actually parseable before sending it downstream.

## Fix (3 changes)

1. **`silas/core/plan_parser.py`** — Added `_strip_code_fences()` that removes a single outermost code fence pair (```markdown, ```md, ```yaml, or bare ```) before parsing. Applied at the top of `parse()`.

2. **`silas/agents/planner.py`** — `_ensure_plan_markdown()` now validates the LLM-produced markdown with `MarkdownPlanParser().parse()`. If validation fails, it falls back to the deterministic plan instead of passing broken markdown to the queue.

3. **`silas/agents/prompts/planner_system.md`** — Added a concrete example of the expected format and an explicit instruction not to wrap in code fences.

## Queue bridge timeout (120s)
Investigated — the planner consumer does send responses back via `plan_result` messages correctly. The 120s timeout is adequate for the planner round-trip. No changes needed there.