### PR TITLE
fix: update manual harness scenarios for accuracy and add --dry-run flag

### DIFF
--- a/silas/main.py
+++ b/silas/main.py
@@ -40,7 +40,7 @@ from silas.core.turn_context import TurnContext
 from silas.core.verification_runner import SilasVerificationRunner
 from silas.execution.sandbox import SubprocessSandboxManager
 from silas.gates import SilasGateRunner
-from silas.manual_harness import run_manual_harness
+from silas.manual_harness import print_scenarios, run_manual_harness
 from silas.memory.sqlite_store import SQLiteMemoryStore
 from silas.models.approval import ApprovalToken
 from silas.models.connections import Connection, HealthCheckResult, SetupStep, SetupStepResponse
@@ -830,9 +830,18 @@ def start_command(config_path: str) -> None:
     default=Path("reports/manual-harness"),
     show_default=True,
 )
-def manual_harness_command(profile: str, base_url: str, output_dir: Path) -> None:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print all scenarios without prompting.",
+)
+def manual_harness_command(profile: str, base_url: str, output_dir: Path, dry_run: bool) -> None:
     """Run the interactive manual acceptance harness and save reports."""
     normalized_profile = profile.lower()
+    if dry_run:
+        print_scenarios(normalized_profile)
+        return
     run_manual_harness(
         profile=normalized_profile,
         base_url=base_url,


### PR DESCRIPTION
## Changes

- **Fixed endpoint references** to match actual routes in web.py: GET /health, POST /secrets/{ref_id}, WS /ws with ?token= and ?session= query params
- **Made steps concrete** with exact curl/websocat commands and specific paths (data/chronicle.db, data/audit.db)
- **Moved 2 scenarios from core to extended**: core-09 (context budget eviction) and core-11 (goal standing approval) — require complex setup not easily testable in a basic manual run
- **Updated preconditions** to reference actual config paths and setup requirements
- **Added --dry-run flag** to silas manual-harness CLI command — prints all scenarios without interactive prompts
- **Added print_scenarios()** to the public API

## Scenario counts
- Total: 18 (unchanged)
- Core: 10 (was 12)
- Extended: 8 (was 6)

## Tests
pytest tests/test_manual_harness.py — 3/3 pass