### PR TITLE
feat: /metrics endpoint + Loki log handler + ObservabilityConfig (#246)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "opentelemetry-sdk>=1.20",
   "opentelemetry-exporter-otlp-proto-grpc>=1.20",
   "opentelemetry-instrumentation-httpx>=0.41b0",
+  "prometheus-client>=0.24.1",
 ]
 
 [project.optional-dependencies]

--- a/silas/channels/web.py
+++ b/silas/channels/web.py
@@ -93,6 +93,15 @@ class WebChannel(ChannelAdapterCore):
         self._setup_routes()
 
     def _setup_routes(self) -> None:
+        @self.app.get("/metrics")
+        async def metrics() -> Response:
+            from silas.core.metrics import metrics_generate_latest
+
+            return Response(
+                content=metrics_generate_latest(),
+                media_type="text/plain; version=0.0.4; charset=utf-8",
+            )
+
         @self.app.get("/health")
         async def health() -> JSONResponse:
             connected = len(self._websockets_by_session)

--- a/silas/config.py
+++ b/silas/config.py
@@ -147,6 +147,14 @@ class TelemetryConfig(BaseModel):
     env: str = "dev"
 
 
+class ObservabilityConfig(BaseModel):
+    """Observability wiring — Loki log shipping + Prometheus metrics."""
+
+    loki_url: str | None = None
+    metrics_enabled: bool = True
+    env: str = "dev"
+
+
 class StreamConfig(BaseModel):
     streaming_enabled: bool = True
     chunk_size: int = Field(default=50, ge=1)
@@ -166,6 +174,7 @@ class SilasSettings(BaseSettings):
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
+    observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     output_gates: list[Gate] = Field(default_factory=list)
     queue_bridge_timeout_s: float = 120.0
     # Backward-compatible alias; prefer queue_bridge_timeout_s.

--- a/silas/main.py
+++ b/silas/main.py
@@ -802,10 +802,16 @@ def start_command(config_path: str) -> None:
     if not settings.channels.web.enabled:
         raise click.ClickException("Phase 1a requires channels.web.enabled=true")
 
-    # Re-initialize logging with observability config (Loki handler)
+    # Wire Loki log handler if configured
     obs = settings.observability
     if obs.loki_url:
-        setup_logging(loki_url=obs.loki_url, loki_env=obs.env)
+        from silas.core.loki_handler import LokiHandler
+
+        loki_handler = LokiHandler(
+            url=f"{obs.loki_url}/loki/api/v1/push",
+            env=obs.env,
+        )
+        logging.getLogger().addHandler(loki_handler)
 
     passphrase = _resolve_signing_passphrase()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2272,6 +2272,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3142,6 +3151,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-ai-backend" },
     { name = "pydantic-ai-slim", extra = ["logfire", "openrouter"] },
@@ -3182,6 +3192,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20" },
+    { name = "prometheus-client", specifier = ">=0.24.1" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pydantic-ai-backend", specifier = ">=0.1.6,<1.0" },
     { name = "pydantic-ai-slim", extras = ["openrouter", "logfire"], specifier = ">=0.0.27" },


### PR DESCRIPTION
Wires the full observability stack into the Silas runtime:

- **`/metrics` endpoint** on FastAPI app (prometheus_client)
- **LokiHandler** in logging pipeline (buffered background HTTP push)
- **ObservabilityConfig** in SilasSettings (loki_url, metrics_enabled, env)
- **prometheus-client** added to dependencies

Prometheus now scrapes Silas directly. Logs flow to Loki in real-time.
Partially closes #246.