### PR TITLE
test: coverage batch 2 — access_controller, predicate_checker, skill_validator (#275)

### DIFF
--- a/tests/test_access_controller.py
+++ b/tests/test_access_controller.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from silas.gates.access import SilasAccessController
+from silas.models.gates import AccessLevel
+from silas.models.messages import TaintLevel
+
+
+class TestAccessControllerInit:
+    def test_default_levels_created(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.get_access_level("stranger") == "anonymous"
+
+    def test_owner_gets_owner_level(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.get_access_level("owner1") == "owner"
+
+    def test_custom_default_level(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1", default_level="authenticated")
+        assert ctrl.get_access_level("stranger") == "authenticated"
+
+    def test_invalid_default_level_raises(self) -> None:
+        with pytest.raises(ValueError, match="default level must exist"):
+            SilasAccessController(owner_id="owner1", default_level="nonexistent")
+
+    def test_custom_access_levels_merged(self) -> None:
+        custom = {
+            "vip": AccessLevel(description="VIP", tools=["search"], requires=["vip_gate"]),
+        }
+        ctrl = SilasAccessController(owner_id="owner1", access_levels=custom)
+        # default levels still present
+        assert ctrl.get_access_level("stranger") == "anonymous"
+
+
+class TestOwnerAccess:
+    def test_owner_by_id(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.get_access_level("owner1") == "owner"
+        assert ctrl.get_allowed_tools("owner1") == ["*"]
+
+    def test_owner_by_taint(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.get_access_level("stranger", taint=TaintLevel.owner) == "owner"
+
+    def test_owner_filter_tools_returns_all(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        tools = ctrl.filter_tools("owner1", ["a", "b", "c"])
+        assert tools == ["a", "b", "c"]
+
+
+class TestGatePassed:
+    def test_gate_promotes_level(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        level = ctrl.gate_passed("user1", "authenticated")
+        assert level == "authenticated"
+
+    def test_gate_promotes_to_trusted(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated")
+        level = ctrl.gate_passed("user1", "trusted")
+        assert level == "trusted"
+
+    def test_gate_does_not_demote(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "trusted")
+        # passing only authenticated gate doesn't demote
+        level = ctrl.gate_passed("user1", "some_other_gate")
+        assert level == "trusted"
+
+    def test_gate_passed_for_owner(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        level = ctrl.gate_passed("owner1", "anything")
+        assert level == "owner"
+
+    def test_customer_context_stored(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated", customer_context={"plan": "pro"})
+        ctx = ctrl.get_customer_context("user1")
+        assert ctx == {"plan": "pro"}
+
+    def test_customer_context_none_for_owner(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.get_customer_context("owner1") is None
+
+
+class TestFilterTools:
+    def test_anonymous_gets_nothing(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        assert ctrl.filter_tools("stranger", ["a", "b"]) == []
+
+    def test_custom_level_filters(self) -> None:
+        custom = {
+            "authenticated": AccessLevel(
+                description="Auth", tools=["search", "read"], requires=["authenticated"]
+            ),
+        }
+        ctrl = SilasAccessController(owner_id="owner1", access_levels=custom)
+        ctrl.gate_passed("user1", "authenticated")
+        result = ctrl.filter_tools("user1", ["search", "write", "read"])
+        assert result == ["search", "read"]
+
+
+class TestExpiration:
+    def test_level_expires(self) -> None:
+        custom = {
+            "authenticated": AccessLevel(
+                description="Auth",
+                tools=["search"],
+                requires=["authenticated"],
+                expires_after=60,
+            ),
+        }
+        ctrl = SilasAccessController(owner_id="owner1", access_levels=custom)
+        ctrl.gate_passed("user1", "authenticated")
+        assert ctrl.get_access_level("user1") == "authenticated"
+
+        # simulate time passing
+        past = datetime.now(UTC) - timedelta(seconds=120)
+        state = ctrl._state_by_connection["user1"]
+        state.granted_at = past
+
+        assert ctrl.get_access_level("user1") == "anonymous"
+
+    def test_no_expiry_means_permanent(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated")
+        # default levels have no expires_after
+        past = datetime.now(UTC) - timedelta(days=365)
+        state = ctrl._state_by_connection["user1"]
+        state.granted_at = past
+        assert ctrl.get_access_level("user1") == "authenticated"
+
+
+class TestStateSnapshot:
+    def test_snapshot_content(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated")
+        snap = ctrl.state_snapshot("user1")
+        assert snap["level_name"] == "authenticated"
+        assert "authenticated" in snap["verified_gates"]
+        assert snap["customer_context"] is None
+
+    def test_snapshot_new_connection(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        snap = ctrl.state_snapshot("new_user")
+        assert snap["level_name"] == "anonymous"
+        assert snap["verified_gates"] == []
+
+
+class TestUpdateAccessLevels:
+    def test_update_levels(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated")
+        assert ctrl.get_access_level("user1") == "authenticated"
+
+        new_levels = {
+            "authenticated": AccessLevel(
+                description="New auth", tools=["new_tool"], requires=["authenticated"]
+            ),
+        }
+        ctrl.update_access_levels(new_levels)
+        # user still has authenticated level
+        assert ctrl.get_allowed_tools("user1") == ["new_tool"]
+
+    def test_update_with_reset(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.gate_passed("user1", "authenticated")
+        ctrl.update_access_levels({}, reset_non_owner_state=True)
+        assert ctrl.get_access_level("user1") == "anonymous"
+
+    def test_update_preserves_owner(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1")
+        ctrl.get_access_level("owner1")  # ensure owner state exists
+        ctrl.update_access_levels({}, reset_non_owner_state=True)
+        assert ctrl.get_access_level("owner1") == "owner"
+
+    def test_update_keeps_merged_defaults(self) -> None:
+        ctrl = SilasAccessController(owner_id="owner1", default_level="authenticated")
+        # updating with custom levels still keeps defaults merged
+        ctrl.update_access_levels({"vip": AccessLevel(description="VIP", tools=["x"], requires=[])})
+        # authenticated still exists from defaults
+        assert ctrl.get_access_level("owner1") == "owner"

--- a/tests/test_predicate_checker.py
+++ b/tests/test_predicate_checker.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import pytest
+from silas.gates.predicates import PredicateChecker
+from silas.models.gates import Gate, GateTrigger, GateType
+
+
+def _gate(
+    name: str = "g",
+    *,
+    gate_type: GateType = GateType.string_match,
+    check: str | None = None,
+    config: dict | None = None,
+    extract: str | None = None,
+    auto_approve: dict | None = None,
+    require_approval: dict | None = None,
+    block: dict | None = None,
+    allowed_values: list[str] | None = None,
+    approval_values: list[str] | None = None,
+) -> Gate:
+    return Gate(
+        name=name,
+        on=GateTrigger.every_user_message,
+        type=gate_type,
+        check=check,
+        config=config or {},
+        extract=extract,
+        auto_approve=auto_approve,
+        require_approval=require_approval,
+        block=block,
+        allowed_values=allowed_values,
+        approval_values=approval_values,
+    )
+
+
+class TestStringMatch:
+    def test_allowed_value(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(allowed_values=["yes", "no"])
+        result = checker.evaluate(gate, {"value": "yes"})
+        assert result.action == "continue"
+
+    def test_blocked_value(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(allowed_values=["yes"], approval_values=["maybe"])
+        result = checker.evaluate(gate, {"value": "nope"})
+        assert result.action == "block"
+
+    def test_approval_value(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(approval_values=["maybe"])
+        result = checker.evaluate(gate, {"value": "maybe"})
+        assert result.action == "require_approval"
+
+    def test_case_insensitive(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={"case_sensitive": False},
+            allowed_values=["yes"],
+        )
+        result = checker.evaluate(gate, {"value": "YES"})
+        assert result.action == "continue"
+
+
+class TestRegex:
+    def test_matching_regex(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.regex, config={"pattern": r"\d{3}"})
+        result = checker.evaluate(gate, {"value": "code 123 here"})
+        assert result.action == "continue"
+
+    def test_non_matching_regex(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.regex, config={"pattern": r"^\d+$"})
+        result = checker.evaluate(gate, {"value": "no digits"})
+        assert result.action == "block"
+
+    def test_invalid_regex_blocks(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.regex, config={"pattern": r"[invalid"})
+        result = checker.evaluate(gate, {"value": "test"})
+        assert result.action == "block"
+        assert "invalid regex" in result.reason
+
+    def test_ignore_case_flag(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            gate_type=GateType.regex,
+            config={"pattern": r"hello", "ignore_case": True},
+        )
+        result = checker.evaluate(gate, {"value": "HELLO world"})
+        assert result.action == "continue"
+
+    def test_no_pattern_blocks(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.regex, config={})
+        result = checker.evaluate(gate, {"value": "test"})
+        assert result.action == "block"
+
+    def test_check_as_pattern(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.regex, check=r"\w+@\w+")
+        result = checker.evaluate(gate, {"value": "user@host"})
+        assert result.action == "continue"
+
+
+class TestNumericRange:
+    def test_auto_approve_in_range(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            gate_type=GateType.numeric_range,
+            auto_approve={"min": 0, "max": 100},
+        )
+        result = checker.evaluate(gate, {"value": 50})
+        assert result.action == "continue"
+
+    def test_require_approval_in_range(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            gate_type=GateType.numeric_range,
+            auto_approve={"min": 0, "max": 100},
+            require_approval={"min": 100, "max": 500},
+        )
+        result = checker.evaluate(gate, {"value": 200})
+        assert result.action == "require_approval"
+
+    def test_blocked_outside(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            gate_type=GateType.numeric_range,
+            block={"outside": [0, 1000]},
+        )
+        result = checker.evaluate(gate, {"value": 2000})
+        assert result.action == "block"
+
+    def test_non_numeric_blocks(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.numeric_range)
+        result = checker.evaluate(gate, {"value": "not a number"})
+        assert result.action == "block"
+
+    def test_no_matching_range_blocks(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            gate_type=GateType.numeric_range,
+            auto_approve={"min": 0, "max": 10},
+        )
+        result = checker.evaluate(gate, {"value": 50})
+        assert result.action == "block"
+
+
+class TestLength:
+    def test_within_limits(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"min_chars": 1, "max_chars": 100}, check="length")
+        result = checker.evaluate(gate, {"value": "hello"})
+        assert result.action == "continue"
+
+    def test_too_short(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"min_chars": 10}, check="length")
+        result = checker.evaluate(gate, {"value": "hi"})
+        assert result.action == "block"
+
+    def test_too_long(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"max_chars": 5}, check="length")
+        result = checker.evaluate(gate, {"value": "this is too long"})
+        assert result.action == "block"
+
+    def test_token_limits(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"max_tokens": 2}, check="length")
+        result = checker.evaluate(gate, {"value": "one two three four five six"})
+        assert result.action == "block"
+
+
+class TestKeyword:
+    def test_blocked_keyword(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"blocked_keywords": ["bad", "evil"]}, check="keyword")
+        result = checker.evaluate(gate, {"value": "this is bad"})
+        assert result.action == "block"
+
+    def test_required_keyword_missing(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"required_keywords": ["agree"]}, check="keyword")
+        result = checker.evaluate(gate, {"value": "I do not"})
+        assert result.action == "require_approval"
+
+    def test_keyword_passes(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={"blocked_keywords": ["bad"], "required_keywords": ["agree"]},
+            check="keyword",
+        )
+        result = checker.evaluate(gate, {"value": "I agree"})
+        assert result.action == "continue"
+
+    def test_case_insensitive_keywords(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={"blocked_keywords": ["BAD"], "case_sensitive": False},
+            check="keyword",
+        )
+        result = checker.evaluate(gate, {"value": "this is bad"})
+        assert result.action == "block"
+
+
+class TestApprovalAlways:
+    def test_approval_always(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.approval_always)
+        result = checker.evaluate(gate, {})
+        assert result.action == "require_approval"
+
+
+class TestLogicComposition:
+    def test_and_logic_all_pass(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={
+                "logic": "and",
+                "predicates": [
+                    {"type": "length", "min_chars": 1},
+                    {"type": "keyword", "blocked_keywords": ["evil"]},
+                ],
+            }
+        )
+        result = checker.evaluate(gate, {"value": "hello world"})
+        assert result.action == "continue"
+
+    def test_and_logic_one_fails(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={
+                "logic": "and",
+                "predicates": [
+                    {"type": "length", "min_chars": 1},
+                    {"type": "keyword", "blocked_keywords": ["world"]},
+                ],
+            }
+        )
+        result = checker.evaluate(gate, {"value": "hello world"})
+        assert result.action == "block"
+
+    def test_or_logic_one_passes(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={
+                "logic": "or",
+                "predicates": [
+                    {"type": "regex", "pattern": r"^\d+$"},
+                    {"type": "keyword", "required_keywords": ["hello"]},
+                ],
+            }
+        )
+        result = checker.evaluate(gate, {"value": "hello"})
+        assert result.action == "continue"
+
+    def test_or_logic_all_fail(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            config={
+                "logic": "or",
+                "predicates": [
+                    {"type": "regex", "pattern": r"^\d+$"},
+                    {"type": "length", "max_chars": 2},
+                ],
+            }
+        )
+        result = checker.evaluate(gate, {"value": "hello"})
+        assert result.action == "block"
+
+    def test_invalid_logic_operator(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"logic": "xor", "predicates": [{"type": "length"}]})
+        result = checker.evaluate(gate, {"value": "test"})
+        assert result.action == "block"
+
+    def test_invalid_predicates_list(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(config={"predicates": "not_a_list"})
+        # string predicates -> _has_logic_predicates returns False, falls through
+        result = checker.evaluate(gate, {"value": "test"})
+        # should fall through to string_match default handling
+        assert result.action == "block"
+
+
+class TestExtractValue:
+    def test_extract_from_context_key(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(
+            extract="custom_field",
+            allowed_values=["hello"],
+        )
+        result = checker.evaluate(gate, {"custom_field": "hello"})
+        assert result.action == "continue"
+
+    def test_extract_fallback_to_message(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(allowed_values=["hi"])
+        result = checker.evaluate(gate, {"message": "hi"})
+        assert result.action == "continue"
+
+
+class TestAsyncCheck:
+    @pytest.mark.asyncio
+    async def test_async_check_delegates(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(allowed_values=["ok"])
+        result = await checker.check(gate, {"value": "ok"})
+        assert result.action == "continue"
+
+
+class TestUnknownPredicate:
+    def test_unknown_type_blocks(self) -> None:
+        checker = PredicateChecker()
+        gate = _gate(gate_type=GateType.string_match, check="totally_unknown_check")
+        # Falls through to string_match evaluation
+        result = checker.evaluate(gate, {"value": "test"})
+        assert result.action == "block"

--- a/tests/test_skill_validator.py
+++ b/tests/test_skill_validator.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from silas.models.skills import SkillMetadata
+from silas.skills.validator import (
+    SkillValidator,
+    check_forbidden_patterns,
+    validate_frontmatter,
+    validate_references,
+    validate_scripts,
+)
+
+
+def _metadata(
+    name: str = "test-skill",
+    description: str = "A valid test skill description",
+    script_args: dict | None = None,
+) -> SkillMetadata:
+    return SkillMetadata(
+        name=name,
+        description=description,
+        script_args=script_args or {},
+    )
+
+
+class TestValidateFrontmatter:
+    def test_valid_metadata(self) -> None:
+        errors = validate_frontmatter(_metadata())
+        assert errors == []
+
+    def test_empty_name(self) -> None:
+        errors = validate_frontmatter(_metadata(name=""))
+        assert any("name is required" in e for e in errors)
+
+    def test_whitespace_name(self) -> None:
+        errors = validate_frontmatter(_metadata(name="   "))
+        assert any("name is required" in e for e in errors)
+
+    def test_empty_description(self) -> None:
+        errors = validate_frontmatter(_metadata(description=""))
+        assert any("description is required" in e for e in errors)
+
+    def test_short_description(self) -> None:
+        errors = validate_frontmatter(_metadata(description="short"))
+        assert any("between 10 and 500" in e for e in errors)
+
+    def test_long_description(self) -> None:
+        errors = validate_frontmatter(_metadata(description="x" * 501))
+        assert any("between 10 and 500" in e for e in errors)
+
+    def test_boundary_description_10_chars(self) -> None:
+        errors = validate_frontmatter(_metadata(description="a" * 10))
+        assert errors == []
+
+    def test_boundary_description_500_chars(self) -> None:
+        errors = validate_frontmatter(_metadata(description="a" * 500))
+        assert errors == []
+
+    def test_multiple_errors(self) -> None:
+        errors = validate_frontmatter(_metadata(name="", description=""))
+        assert len(errors) == 2
+
+
+class TestValidateScripts:
+    def test_valid_python_file(self, tmp_path: Path) -> None:
+        (tmp_path / "main.py").write_text("x = 1\n")
+        errors = validate_scripts(tmp_path)
+        assert errors == []
+
+    def test_syntax_error(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("def f(\n")
+        errors = validate_scripts(tmp_path)
+        assert len(errors) == 1
+        assert "syntax error" in errors[0]
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        errors = validate_scripts(tmp_path)
+        assert errors == []
+
+    def test_nonexistent_dir(self, tmp_path: Path) -> None:
+        errors = validate_scripts(tmp_path / "nonexistent")
+        assert errors == []
+
+    def test_nested_python_files(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "a.py").write_text("x = 1\n")
+        (tmp_path / "b.py").write_text("y = 2\n")
+        errors = validate_scripts(tmp_path)
+        assert errors == []
+
+    def test_non_python_files_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "data.txt").write_text("not python {{{\n")
+        errors = validate_scripts(tmp_path)
+        assert errors == []
+
+
+class TestCheckForbiddenPatterns:
+    def test_clean_code(self, tmp_path: Path) -> None:
+        (tmp_path / "clean.py").write_text("x = 1 + 2\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert errors == []
+
+    def test_eval_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("result = eval('1+1')\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert len(errors) == 1
+        assert "eval(" in errors[0]
+
+    def test_exec_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("exec('import os')\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert len(errors) == 1
+        assert "exec(" in errors[0]
+
+    def test_dunder_import_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("mod = __import__('os')\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert len(errors) == 1
+        assert "__import__" in errors[0]
+
+    def test_multiple_violations(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("eval('x')\nexec('y')\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert len(errors) == 2
+
+    def test_line_numbers_reported(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.py").write_text("ok = 1\nresult = eval('2')\n")
+        errors = check_forbidden_patterns(tmp_path)
+        assert ":2" in errors[0]
+
+
+class TestValidateReferences:
+    def test_valid_reference(self, tmp_path: Path) -> None:
+        (tmp_path / "run.py").write_text("x = 1\n")
+        meta = _metadata(script_args={"run.py": {}})
+        errors = validate_references(tmp_path, meta)
+        assert errors == []
+
+    def test_missing_reference(self, tmp_path: Path) -> None:
+        meta = _metadata(script_args={"missing.py": {}})
+        errors = validate_references(tmp_path, meta)
+        assert len(errors) == 1
+        assert "does not exist" in errors[0]
+
+    def test_directory_traversal_blocked(self, tmp_path: Path) -> None:
+        meta = _metadata(script_args={"../../etc/passwd": {}})
+        errors = validate_references(tmp_path, meta)
+        assert len(errors) == 1
+        assert "escapes skill directory" in errors[0]
+
+    def test_multiple_references(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("x = 1\n")
+        (tmp_path / "b.py").write_text("y = 2\n")
+        meta = _metadata(script_args={"a.py": {}, "b.py": {}})
+        errors = validate_references(tmp_path, meta)
+        assert errors == []
+
+    def test_reference_to_directory_fails(self, tmp_path: Path) -> None:
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        meta = _metadata(script_args={"subdir": {}})
+        errors = validate_references(tmp_path, meta)
+        assert len(errors) == 1
+        assert "does not exist" in errors[0]
+
+
+class TestSkillValidatorClass:
+    """Ensure SkillValidator static methods delegate correctly."""
+
+    def test_validate_frontmatter(self) -> None:
+        errors = SkillValidator.validate_frontmatter(_metadata())
+        assert errors == []
+
+    def test_validate_scripts(self, tmp_path: Path) -> None:
+        (tmp_path / "ok.py").write_text("x = 1\n")
+        errors = SkillValidator.validate_scripts(tmp_path)
+        assert errors == []
+
+    def test_check_forbidden_patterns(self, tmp_path: Path) -> None:
+        (tmp_path / "clean.py").write_text("x = 1\n")
+        errors = SkillValidator.check_forbidden_patterns(tmp_path)
+        assert errors == []
+
+    def test_validate_references(self, tmp_path: Path) -> None:
+        (tmp_path / "run.py").write_text("x = 1\n")
+        meta = _metadata(script_args={"run.py": {}})
+        errors = SkillValidator.validate_references(tmp_path, meta)
+        assert errors == []


### PR DESCRIPTION
## Summary

Adds 88 tests across 3 previously uncovered modules as part of issue #275 test coverage effort.

### Modules covered:
- **`gates/access`** (`SilasAccessController`) — 24 tests covering init, owner access, gate promotion, tool filtering, expiration, state snapshots, and level updates
- **`gates/predicates`** (`PredicateChecker`) — 34 tests covering string match, regex, numeric range, length, keyword, approval_always, logic composition (and/or), value extraction, async check, and unknown predicates
- **`skills/validator`** (`SkillValidator`) — 30 tests covering frontmatter validation, script syntax checking, forbidden pattern detection, reference validation (including directory traversal), and the SkillValidator class delegation

### Previous batch (PR #293):
_signing, _nonce, subscriptions, interaction_mode (26 tests)

### Checklist:
- [x] All 88 tests pass
- [x] ruff check clean
- [x] ruff format clean

Closes partially #275