### PR TITLE
test: coverage batch 3 — telemetry, loki_handler, metrics (#275)

### DIFF
--- a/tests/test_loki_handler.py
+++ b/tests/test_loki_handler.py
@@ -1,0 +1,190 @@
+"""Tests for silas.core.loki_handler — Loki log shipping."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+from silas.core.loki_handler import LokiHandler, _extract_component
+
+
+class TestExtractComponent:
+    def test_silas_module(self) -> None:
+        assert _extract_component("silas.queue.consumers") == "queue"
+
+    def test_silas_single_submodule(self) -> None:
+        assert _extract_component("silas.core") == "core"
+
+    def test_non_silas_logger(self) -> None:
+        assert _extract_component("uvicorn.error") == "uvicorn"
+
+    def test_simple_name(self) -> None:
+        assert _extract_component("root") == "root"
+
+    def test_empty_string(self) -> None:
+        assert _extract_component("") == ""
+
+
+class TestLokiHandlerEmit:
+    def setup_method(self) -> None:
+        # Patch urlopen globally so no real HTTP happens.
+        self._urlopen_patcher = patch("silas.core.loki_handler.urlopen")
+        self._mock_urlopen = self._urlopen_patcher.start()
+
+    def teardown_method(self) -> None:
+        self._urlopen_patcher.stop()
+
+    def _make_handler(self, **kwargs: object) -> LokiHandler:
+        handler = LokiHandler(
+            url="http://fake:3100/loki/api/v1/push",
+            flush_interval=999,  # don't auto-flush during tests
+            **kwargs,  # type: ignore[arg-type]
+        )
+        return handler
+
+    def test_emit_buffers_record(self) -> None:
+        handler = self._make_handler()
+        try:
+            record = logging.LogRecord(
+                name="silas.queue.router",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="test message",
+                args=None,
+                exc_info=None,
+            )
+            handler.emit(record)
+
+            assert len(handler._buffer) == 1
+            labels, _ts, message = handler._buffer[0]
+            assert labels["component"] == "queue"
+            assert labels["level"] == "info"
+            assert labels["job"] == "silas-runtime"
+            assert message == "test message"
+        finally:
+            handler.close()
+
+    def test_emit_includes_trace_id_when_present(self) -> None:
+        handler = self._make_handler()
+        try:
+            record = logging.LogRecord(
+                name="silas.core",
+                level=logging.WARNING,
+                pathname="",
+                lineno=0,
+                msg="traced",
+                args=None,
+                exc_info=None,
+            )
+            record.trace_id = "abc123"  # type: ignore[attr-defined]
+            handler.emit(record)
+
+            labels, _, _ = handler._buffer[0]
+            assert labels["trace_id"] == "abc123"
+        finally:
+            handler.close()
+
+    def test_flush_sends_payload(self) -> None:
+        handler = self._make_handler()
+        try:
+            record = logging.LogRecord(
+                name="silas.gates",
+                level=logging.ERROR,
+                pathname="",
+                lineno=0,
+                msg="boom",
+                args=None,
+                exc_info=None,
+            )
+            handler.emit(record)
+            handler._flush()
+
+            assert len(handler._buffer) == 0
+            self._mock_urlopen.assert_called_once()
+            req = self._mock_urlopen.call_args[0][0]
+            payload = json.loads(req.data)
+            assert "streams" in payload
+            assert len(payload["streams"]) == 1
+            assert payload["streams"][0]["values"][0][1] == "boom"
+        finally:
+            handler.close()
+
+    def test_flush_empty_buffer_is_noop(self) -> None:
+        handler = self._make_handler()
+        try:
+            handler._flush()
+            self._mock_urlopen.assert_not_called()
+        finally:
+            handler.close()
+
+    def test_flush_groups_by_labels(self) -> None:
+        handler = self._make_handler()
+        try:
+            for name, level in [
+                ("silas.core", logging.INFO),
+                ("silas.queue", logging.INFO),
+                ("silas.core", logging.INFO),
+            ]:
+                record = logging.LogRecord(
+                    name=name,
+                    level=level,
+                    pathname="",
+                    lineno=0,
+                    msg=f"msg-{name}",
+                    args=None,
+                    exc_info=None,
+                )
+                handler.emit(record)
+
+            handler._flush()
+            req = self._mock_urlopen.call_args[0][0]
+            payload = json.loads(req.data)
+            # core x2 and queue x1 → 2 distinct streams
+            assert len(payload["streams"]) == 2
+        finally:
+            handler.close()
+
+    def test_close_stops_thread(self) -> None:
+        handler = self._make_handler()
+        handler.close()
+        assert not handler._thread.is_alive()
+
+    def test_network_error_silently_dropped(self) -> None:
+        from urllib.error import URLError
+
+        self._mock_urlopen.side_effect = URLError("connection refused")
+        handler = self._make_handler()
+        try:
+            record = logging.LogRecord(
+                name="silas.core",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="test",
+                args=None,
+                exc_info=None,
+            )
+            handler.emit(record)
+            handler._flush()  # should not raise
+        finally:
+            handler.close()
+
+    def test_custom_env_label(self) -> None:
+        handler = self._make_handler(env="production")
+        try:
+            record = logging.LogRecord(
+                name="silas.core",
+                level=logging.DEBUG,
+                pathname="",
+                lineno=0,
+                msg="env-test",
+                args=None,
+                exc_info=None,
+            )
+            handler.emit(record)
+            labels, _, _ = handler._buffer[0]
+            assert labels["env"] == "production"
+        finally:
+            handler.close()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,94 @@
+"""Tests for silas.core.metrics — Prometheus metrics and no-op stubs."""
+
+from __future__ import annotations
+
+import time
+
+from silas.core.metrics import (
+    ACTIVE_WEBSOCKETS,
+    LLM_CALLS_TOTAL,
+    LLM_TOKENS_TOTAL,
+    QUEUE_LEASE_TIMEOUTS_TOTAL,
+    QUEUE_MESSAGES_TOTAL,
+    TURN_DURATION_SECONDS,
+    TURNS_TOTAL,
+    _NoOpMetric,
+    metrics_generate_latest,
+    observe_turn_duration,
+)
+
+
+class TestNoOpMetric:
+    def test_labels_returns_self(self) -> None:
+        m = _NoOpMetric()
+        assert m.labels(agent="x") is m
+
+    def test_chained_labels_and_inc(self) -> None:
+        m = _NoOpMetric()
+        m.labels(a="1").labels(b="2").inc()  # should not raise
+
+    def test_inc_default(self) -> None:
+        _NoOpMetric().inc()  # no-op, no raise
+
+    def test_inc_custom(self) -> None:
+        _NoOpMetric().inc(5)
+
+    def test_dec_default(self) -> None:
+        _NoOpMetric().dec()
+
+    def test_dec_custom(self) -> None:
+        _NoOpMetric().dec(3)
+
+    def test_observe(self) -> None:
+        _NoOpMetric().observe(1.5)
+
+
+class TestObserveTurnDuration:
+    def test_context_manager_completes(self) -> None:
+        with observe_turn_duration("test-agent"):
+            pass  # should not raise
+
+    def test_context_manager_records_duration(self) -> None:
+        start = time.monotonic()
+        with observe_turn_duration("timer-agent"):
+            time.sleep(0.01)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.01
+
+    def test_context_manager_on_exception(self) -> None:
+        """Duration is still observed even if body raises."""
+        try:
+            with observe_turn_duration("fail-agent"):
+                raise ValueError("boom")
+        except ValueError:
+            pass  # expected
+
+
+class TestMetricSingletons:
+    """Verify that module-level metric singletons exist and are usable."""
+
+    def test_turns_total(self) -> None:
+        TURNS_TOTAL.labels(agent="test").inc()
+
+    def test_turn_duration(self) -> None:
+        TURN_DURATION_SECONDS.labels(agent="test").observe(0.5)
+
+    def test_llm_calls(self) -> None:
+        LLM_CALLS_TOTAL.labels(model="gpt-4").inc()
+
+    def test_llm_tokens(self) -> None:
+        LLM_TOKENS_TOTAL.labels(model="gpt-4", direction="input").inc(100)
+
+    def test_queue_messages(self) -> None:
+        QUEUE_MESSAGES_TOTAL.labels(queue_name="main", message_kind="task").inc()
+
+    def test_queue_lease_timeouts(self) -> None:
+        QUEUE_LEASE_TIMEOUTS_TOTAL.inc()
+
+    def test_active_websockets(self) -> None:
+        ACTIVE_WEBSOCKETS.inc()
+        ACTIVE_WEBSOCKETS.dec()
+
+    def test_generate_latest(self) -> None:
+        output = metrics_generate_latest()
+        assert isinstance(output, bytes)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,82 @@
+"""Tests for silas.core.telemetry — OpenTelemetry tracing setup."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from opentelemetry.trace import NoOpTracerProvider
+from silas.core import telemetry
+from silas.core.telemetry import get_tracer, init_tracing, shutdown_tracing
+
+
+class TestInitTracing:
+    def setup_method(self) -> None:
+        # Reset module-level state between tests.
+        telemetry._tracer_provider = None
+
+    def test_no_endpoint_returns_noop(self) -> None:
+        provider = init_tracing(endpoint=None)
+        assert isinstance(provider, NoOpTracerProvider)
+
+    def test_empty_endpoint_returns_noop(self) -> None:
+        provider = init_tracing(endpoint="")
+        assert isinstance(provider, NoOpTracerProvider)
+
+    def test_with_endpoint_returns_tracer_provider(self) -> None:
+        # Patch the OTLP exporter so we don't need a real gRPC endpoint.
+        with patch(
+            "silas.core.telemetry.BatchSpanProcessor",
+        ):
+            from opentelemetry.sdk.trace import TracerProvider
+
+            provider = init_tracing(
+                service_name="test-svc",
+                env="test",
+                endpoint="localhost:4317",
+            )
+            assert isinstance(provider, TracerProvider)
+
+    def test_custom_service_name_in_resource(self) -> None:
+        with patch("silas.core.telemetry.BatchSpanProcessor"):
+            from opentelemetry.sdk.trace import TracerProvider
+
+            provider = init_tracing(service_name="custom-svc", endpoint="localhost:4317")
+            assert isinstance(provider, TracerProvider)
+            attrs = dict(provider.resource.attributes)
+            assert attrs["service.name"] == "custom-svc"
+
+    def test_exporter_import_failure_still_returns_provider(self) -> None:
+        """If the OTLP exporter can't be imported, tracing still initialises."""
+        with patch(
+            "silas.core.telemetry.BatchSpanProcessor",
+            side_effect=ImportError("no grpc"),
+        ):
+            from opentelemetry.sdk.trace import TracerProvider
+
+            provider = init_tracing(endpoint="localhost:4317")
+            assert isinstance(provider, TracerProvider)
+
+
+class TestGetTracer:
+    def test_returns_tracer(self) -> None:
+        tracer = get_tracer("test-module")
+        assert tracer is not None
+
+
+class TestShutdownTracing:
+    def setup_method(self) -> None:
+        telemetry._tracer_provider = None
+
+    def test_shutdown_noop_provider(self) -> None:
+        """Shutdown should not raise for NoOpTracerProvider."""
+        init_tracing(endpoint=None)
+        shutdown_tracing()  # should not raise
+
+    def test_shutdown_real_provider(self) -> None:
+        with patch("silas.core.telemetry.BatchSpanProcessor"):
+            init_tracing(endpoint="localhost:4317")
+            shutdown_tracing()  # should not raise
+
+    def test_shutdown_without_init(self) -> None:
+        """Shutdown before init should be a no-op."""
+        shutdown_tracing()  # should not raise


### PR DESCRIPTION
## Test Coverage Batch 3

Adds comprehensive tests for three previously uncovered modules:

### Modules covered
- **`silas/core/telemetry.py`** (9 tests) — `init_tracing` with/without endpoint, custom service names, exporter import failures, `get_tracer`, `shutdown_tracing`
- **`silas/core/loki_handler.py`** (13 tests) — `_extract_component`, emit buffering, trace_id labels, flush payload structure, label grouping, network error resilience, thread lifecycle
- **`silas/core/metrics.py`** (18 tests) — `_NoOpMetric` stub API, `observe_turn_duration` context manager (including exception path), all metric singletons, `metrics_generate_latest`

**40 tests total, all passing.**

Closes part of #275