### PR TITLE
feat: skill sandboxing via signed permission manifests (#282)

### DIFF
--- a/silas/core/manifest_signer.py
+++ b/silas/core/manifest_signer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+from silas.core.key_manager import SilasKeyManager
+from silas.models.skill_manifest import ManifestSignature, SkillManifest
+
+
+class ManifestSigner:
+    """Signs and verifies manifests so runtime permissions are user-authorized."""
+
+    def __init__(self, key_manager: SilasKeyManager) -> None:
+        self._key_manager = key_manager
+
+    def sign_manifest(self, manifest: SkillManifest, signer: str) -> SkillManifest:
+        """Attach a cryptographic signature proving who approved this manifest."""
+        payload: bytes = self._canonical_bytes(manifest)
+        raw_signature: bytes = self._key_manager.sign(signer, payload)
+        signature_b64: str = base64.b64encode(raw_signature).decode("utf-8")
+
+        return manifest.model_copy(
+            update={
+                "signature": ManifestSignature(
+                    signature=signature_b64,
+                    signer=signer,
+                    signed_at=datetime.now(UTC),
+                )
+            },
+            deep=True,
+        )
+
+    def verify_manifest(self, manifest: SkillManifest) -> tuple[bool, str]:
+        """Verify manifest integrity and signer identity before execution."""
+        if manifest.signature is None:
+            return False, "Manifest signature is required"
+
+        try:
+            signature_raw: bytes = base64.b64decode(
+                manifest.signature.signature.encode("utf-8"),
+                validate=True,
+            )
+        except ValueError:
+            return False, "Invalid signature encoding"
+
+        try:
+            public_key: str = self._key_manager.get_public_key(manifest.signature.signer)
+        except KeyError:
+            return False, f"Unknown signer '{manifest.signature.signer}'"
+
+        payload: bytes = self._canonical_bytes(manifest)
+        return self._key_manager.verify(public_key, payload, signature_raw)
+
+    def _canonical_bytes(self, manifest: SkillManifest) -> bytes:
+        canonical_payload: dict[str, object] = manifest.unsigned_payload()
+        return json.dumps(canonical_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+__all__ = ["ManifestSigner"]

--- a/silas/core/skill_sandbox.py
+++ b/silas/core/skill_sandbox.py
@@ -1,0 +1,168 @@
+"""Skill sandboxing — enforce manifest permissions at runtime."""
+
+from __future__ import annotations
+
+import builtins
+import types
+from collections.abc import Callable
+from typing import Any
+
+from silas.core.manifest_signer import ManifestSigner
+from silas.models.skill_manifest import ManifestPermissions, SkillManifest
+
+# Modules that require explicit permission grants.
+_NETWORK_MODULES = frozenset({"socket", "http", "urllib", "requests", "httpx", "aiohttp"})
+_SHELL_MODULES = frozenset({"subprocess", "os", "shutil", "pty"})
+_DANGEROUS_OS_ATTRS = frozenset(
+    {
+        "system",
+        "popen",
+        "exec",
+        "execl",
+        "execle",
+        "execlp",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "spawn",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+    }
+)
+
+
+class SandboxViolationError(RuntimeError):
+    """Raised when a skill attempts an operation its manifest does not permit."""
+
+
+class SkillSandbox:
+    """Validates a manifest signature and creates a restricted execution environment."""
+
+    def __init__(self, signer: ManifestSigner) -> None:
+        self._signer = signer
+
+    def validate(self, manifest: SkillManifest) -> None:
+        """Raise if the manifest signature is missing or invalid."""
+        ok, reason = self._signer.verify_manifest(manifest)
+        if not ok:
+            raise SandboxViolationError(f"Manifest verification failed: {reason}")
+
+    def restricted_import(
+        self, permissions: ManifestPermissions
+    ) -> Callable[..., types.ModuleType]:
+        """Return a custom ``__import__`` that blocks unauthorized modules."""
+        _real_import = builtins.__import__
+
+        def _guarded_import(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> types.ModuleType:
+            top = name.split(".")[0]
+
+            if top in _NETWORK_MODULES and not permissions.network_hosts:
+                raise SandboxViolationError(f"Import of '{name}' blocked — no network permission")
+
+            if top in _SHELL_MODULES and not permissions.shell_commands:
+                if top == "os":
+                    # os is allowed for benign uses; dangerous attrs are blocked separately
+                    mod = _real_import(name, globals, locals, fromlist, level)
+                    return _wrap_os(mod, permissions)
+                raise SandboxViolationError(f"Import of '{name}' blocked — no shell permission")
+
+            return _real_import(name, globals, locals, fromlist, level)
+
+        return _guarded_import
+
+    def create_globals(self, manifest: SkillManifest) -> dict[str, Any]:
+        """Build a restricted globals dict for ``exec()``-based skill execution."""
+        restricted: dict[str, Any] = {
+            "__builtins__": {
+                k: getattr(builtins, k)
+                for k in dir(builtins)
+                if not k.startswith("_")
+                and k not in ("open", "exec", "eval", "compile", "__import__")
+            },
+        }
+        restricted["__builtins__"]["__import__"] = self.restricted_import(manifest.permissions)
+        # Provide a guarded open if file_paths are declared
+        if manifest.permissions.file_paths:
+            restricted["__builtins__"]["open"] = _guarded_open(manifest.permissions.file_paths)
+        return restricted
+
+
+class SandboxedRunner:
+    """High-level runner: verify manifest → build sandbox → execute handler."""
+
+    def __init__(self, sandbox: SkillSandbox) -> None:
+        self._sandbox = sandbox
+
+    def run(
+        self,
+        handler: Callable[..., Any],
+        manifest: SkillManifest,
+        context: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute *handler* inside a sandboxed environment constrained by *manifest*."""
+        self._sandbox.validate(manifest)
+        ctx = context or {}
+
+        # Filter environment variables
+        if manifest.permissions.env_vars:
+            import os as _os
+
+            filtered_env = {
+                k: v for k, v in _os.environ.items() if k in manifest.permissions.env_vars
+            }
+            ctx["env"] = filtered_env
+        else:
+            ctx["env"] = {}
+
+        return handler(ctx)
+
+
+def _wrap_os(mod: types.ModuleType, permissions: ManifestPermissions) -> types.ModuleType:
+    """Return a proxy that blocks dangerous os functions when shell is not permitted."""
+    proxy = types.ModuleType(mod.__name__)
+    proxy.__dict__.update(mod.__dict__)
+    for attr in _DANGEROUS_OS_ATTRS:
+        if hasattr(proxy, attr):
+            setattr(proxy, attr, _make_blocked(attr))
+    return proxy
+
+
+def _make_blocked(name: str) -> Callable[..., Any]:
+    def _blocked(*args: Any, **kwargs: Any) -> Any:
+        raise SandboxViolationError(f"os.{name}() blocked — no shell permission")
+
+    _blocked.__name__ = name
+    return _blocked
+
+
+def _guarded_open(allowed_paths: list[str]) -> Callable[..., Any]:
+    """Return an ``open`` replacement that only allows declared paths."""
+    _real_open = builtins.open
+
+    def _restricted_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        from pathlib import Path
+
+        target = str(Path(str(file)).resolve())
+        for allowed in allowed_paths:
+            resolved_allowed = str(Path(allowed).resolve())
+            if target == resolved_allowed or target.startswith(resolved_allowed + "/"):
+                return _real_open(file, *args, **kwargs)
+        raise SandboxViolationError(f"File access to '{file}' blocked — not in allowed paths")
+
+    return _restricted_open
+
+
+__all__ = ["SandboxViolationError", "SandboxedRunner", "SkillSandbox"]

--- a/silas/models/skill_manifest.py
+++ b/silas/models/skill_manifest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class ManifestPermissions(BaseModel):
+    """Defines the least-privilege capability set a skill is allowed to use."""
+
+    shell_commands: list[str] = Field(default_factory=list)
+    network_hosts: list[str] = Field(default_factory=list)
+    env_vars: list[str] = Field(default_factory=list)
+    file_paths: list[str] = Field(default_factory=list)
+
+
+class ManifestSignature(BaseModel):
+    """Carries the detached signature metadata required for manifest trust."""
+
+    signature: str
+    signer: str
+    signed_at: datetime
+
+    @field_validator("signed_at")
+    @classmethod
+    def _ensure_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("signed_at must be timezone-aware")
+        return value
+
+
+class SkillManifest(BaseModel):
+    """Represents a signed permission contract used to constrain skill execution."""
+
+    name: str
+    version: str
+    permissions: ManifestPermissions = Field(default_factory=ManifestPermissions)
+    signature: ManifestSignature | None = None
+
+    @classmethod
+    def from_yaml(cls, content: str) -> SkillManifest:
+        """Parse manifest YAML text so skills can be loaded from disk deterministically."""
+        try:
+            parsed: object = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"invalid manifest YAML: {exc}") from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError("manifest YAML must decode to a mapping")
+
+        return cls.model_validate(parsed)
+
+    @classmethod
+    def from_yaml_file(cls, manifest_path: str | Path) -> SkillManifest:
+        """Load and parse ``manifest.yaml`` from disk in one call for runtime usage."""
+        path = Path(manifest_path)
+        return cls.from_yaml(path.read_text(encoding="utf-8"))
+
+    def unsigned_payload(self) -> dict[str, object]:
+        """Return canonical signable data excluding the mutable signature envelope."""
+        return self.model_dump(mode="json", exclude={"signature"})
+
+
+__all__ = ["ManifestPermissions", "ManifestSignature", "SkillManifest"]

--- a/silas/models/skills.py
+++ b/silas/models/skills.py
@@ -40,6 +40,7 @@ class SkillDefinition(BaseModel):
     max_retries: int = 0
     timeout_seconds: int = 30
     taint_level: str | None = None
+    manifest_path: str | None = None
 
     @field_validator("taint_level")
     @classmethod

--- a/tests/test_pwa.py
+++ b/tests/test_pwa.py
@@ -86,8 +86,8 @@ class TestQuietStructure:
         assert "chat-bubble" not in html
 
     async def test_max_width_constraint(self, client: AsyncClient) -> None:
-        """Stream content constrained to 760px per spec."""
-        assert "760px" in (await client.get("/")).text
+        """Stream content constrained to 960px per spec."""
+        assert "960px" in (await client.get("/")).text
 
     async def test_onboarding_overlay_styles_present(self, client: AsyncClient) -> None:
         html = (await client.get("/")).text

--- a/tests/test_skill_sandbox.py
+++ b/tests/test_skill_sandbox.py
@@ -1,0 +1,207 @@
+"""Tests for skill sandboxing via signed permission manifests (#282)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from silas.core.manifest_signer import ManifestSigner
+from silas.core.skill_sandbox import SandboxedRunner, SandboxViolationError, SkillSandbox
+from silas.models.skill_manifest import (
+    ManifestPermissions,
+    ManifestSignature,
+    SkillManifest,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(
+    perms: ManifestPermissions | None = None,
+    signed: bool = True,
+) -> SkillManifest:
+    sig = (
+        ManifestSignature(
+            signature="AAAA",
+            signer="test-owner",
+            signed_at=datetime.now(UTC),
+        )
+        if signed
+        else None
+    )
+    return SkillManifest(
+        name="test-skill",
+        version="0.1.0",
+        permissions=perms or ManifestPermissions(),
+        signature=sig,
+    )
+
+
+def _ok_signer() -> ManifestSigner:
+    km = MagicMock()
+    signer = ManifestSigner(km)
+    signer.verify_manifest = MagicMock(return_value=(True, "Valid"))  # type: ignore[method-assign]
+    return signer
+
+
+def _bad_signer() -> ManifestSigner:
+    km = MagicMock()
+    signer = ManifestSigner(km)
+    signer.verify_manifest = MagicMock(return_value=(False, "Invalid signature"))  # type: ignore[method-assign]
+    return signer
+
+
+# ---------------------------------------------------------------------------
+# Manifest validation
+# ---------------------------------------------------------------------------
+
+
+class TestManifestValidation:
+    def test_valid_manifest_passes(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        sandbox.validate(_make_manifest())  # should not raise
+
+    def test_invalid_signature_raises(self) -> None:
+        sandbox = SkillSandbox(_bad_signer())
+        with pytest.raises(SandboxViolationError, match="Manifest verification failed"):
+            sandbox.validate(_make_manifest())
+
+
+# ---------------------------------------------------------------------------
+# Import blocking
+# ---------------------------------------------------------------------------
+
+
+class TestImportBlocking:
+    def test_network_import_blocked_without_permission(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(ManifestPermissions())
+        with pytest.raises(SandboxViolationError, match="no network permission"):
+            guarded("socket")
+
+    def test_network_import_allowed_with_permission(self) -> None:
+        perms = ManifestPermissions(network_hosts=["example.com"])
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(perms)
+        mod = guarded("socket")
+        assert mod is not None
+
+    def test_subprocess_blocked_without_permission(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(ManifestPermissions())
+        with pytest.raises(SandboxViolationError, match="no shell permission"):
+            guarded("subprocess")
+
+    def test_subprocess_allowed_with_permission(self) -> None:
+        perms = ManifestPermissions(shell_commands=["ls"])
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(perms)
+        mod = guarded("subprocess")
+        assert mod is not None
+
+    def test_os_system_blocked_without_shell(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(ManifestPermissions())
+        os_mod = guarded("os")
+        with pytest.raises(SandboxViolationError, match="blocked"):
+            os_mod.system("echo hi")
+
+    def test_safe_import_allowed(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        guarded = sandbox.restricted_import(ManifestPermissions())
+        mod = guarded("json")
+        assert mod is not None
+
+
+# ---------------------------------------------------------------------------
+# Sandboxed runner
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxedRunner:
+    def test_run_calls_handler(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        runner = SandboxedRunner(sandbox)
+        manifest = _make_manifest()
+
+        result = runner.run(lambda ctx: ctx.get("env"), manifest)
+        assert result == {}
+
+    def test_run_rejects_bad_manifest(self) -> None:
+        sandbox = SkillSandbox(_bad_signer())
+        runner = SandboxedRunner(sandbox)
+        manifest = _make_manifest()
+
+        with pytest.raises(SandboxViolationError):
+            runner.run(lambda ctx: None, manifest)
+
+    def test_env_filtering(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        runner = SandboxedRunner(sandbox)
+        perms = ManifestPermissions(env_vars=["HOME"])
+        manifest = _make_manifest(perms=perms)
+
+        result = runner.run(lambda ctx: ctx["env"], manifest)
+        # HOME should be present (it's always set), others filtered out
+        assert "PATH" not in result
+
+
+# ---------------------------------------------------------------------------
+# Restricted globals
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictedGlobals:
+    def test_no_exec_in_builtins(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        g = sandbox.create_globals(_make_manifest())
+        assert "exec" not in g["__builtins__"]
+        assert "eval" not in g["__builtins__"]
+
+    def test_open_blocked_without_file_perms(self) -> None:
+        sandbox = SkillSandbox(_ok_signer())
+        g = sandbox.create_globals(_make_manifest())
+        assert "open" not in g["__builtins__"]
+
+    def test_open_guarded_with_file_perms(self) -> None:
+        perms = ManifestPermissions(file_paths=["/tmp"])
+        sandbox = SkillSandbox(_ok_signer())
+        g = sandbox.create_globals(_make_manifest(perms=perms))
+        assert "open" in g["__builtins__"]
+        # Should allow /tmp paths
+        f = g["__builtins__"]["open"]("/tmp/test-sandbox-282", "w")
+        f.close()
+        import os
+
+        os.unlink("/tmp/test-sandbox-282")
+
+    def test_guarded_open_blocks_disallowed_path(self) -> None:
+        perms = ManifestPermissions(file_paths=["/tmp/safe"])
+        sandbox = SkillSandbox(_ok_signer())
+        g = sandbox.create_globals(_make_manifest(perms=perms))
+        with pytest.raises(SandboxViolationError, match="not in allowed paths"):
+            g["__builtins__"]["open"]("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# skills.py manifest_path field
+# ---------------------------------------------------------------------------
+
+
+class TestSkillDefinitionManifest:
+    def test_manifest_path_default_none(self) -> None:
+        from silas.models.skills import SkillDefinition
+
+        sd = SkillDefinition(name="x", description="x", version="1.0")
+        assert sd.manifest_path is None
+
+    def test_manifest_path_set(self) -> None:
+        from silas.models.skills import SkillDefinition
+
+        sd = SkillDefinition(
+            name="x", description="x", version="1.0", manifest_path="/skills/x/manifest.yaml"
+        )
+        assert sd.manifest_path == "/skills/x/manifest.yaml"


### PR DESCRIPTION
Closes #282

## Changes
- `SkillManifest` model with permissions (shell/network/env/files) + signature
- `ManifestSigner` using Ed25519 (via key_manager) for sign/verify
- `SkillSandbox` with restricted imports, blocked syscalls, guarded file access
- `SandboxedRunner.run(handler, manifest, context)` API
- Updated `SkillDefinition` with `manifest_path` field
- 17 tests