### PR TITLE
feat: topics as universal context containers (#284)

### DIFF
--- a/silas/core/topic_manager.py
+++ b/silas/core/topic_manager.py
@@ -1,0 +1,113 @@
+"""TopicManager — load, match, and render topics as context."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from silas.topics.matcher import TriggerMatcher
+from silas.topics.model import Topic
+from silas.topics.parser import TopicParseError, parse_topic
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TopicMatch:
+    """A matched topic with its relevance score."""
+
+    topic: Topic
+    score: float
+    match_type: str  # "hard" | "soft"
+
+
+class TopicManager:
+    """Load topics from a directory, match against events/messages, render context.
+
+    This is the high-level orchestrator that combines parsing, matching, and
+    context rendering. The TopicRegistry handles CRUD; TopicManager handles
+    the read-path used during message processing.
+    """
+
+    def __init__(self, topics_dir: Path) -> None:
+        self._dir = topics_dir
+        self._matcher = TriggerMatcher()
+        self._topics: list[Topic] = []
+
+    @property
+    def topics(self) -> list[Topic]:
+        return list(self._topics)
+
+    def load(self) -> int:
+        """Load all topic files from disk. Returns count of loaded topics."""
+        self._topics.clear()
+        if not self._dir.exists():
+            return 0
+
+        for path in sorted(self._dir.glob("*.md")):
+            try:
+                topic = parse_topic(path.read_text())
+                self._topics.append(topic)
+            except TopicParseError:
+                logger.warning("Skipping unparseable topic: %s", path)
+        return len(self._topics)
+
+    def match_event(self, event: dict[str, Any]) -> list[TopicMatch]:
+        """Match an event dict against hard triggers of all active topics.
+
+        Returns matches sorted by specificity (more filters = higher score).
+        """
+        matches: list[TopicMatch] = []
+        for topic in self._active_topics():
+            if self._matcher.match_hard(event, topic.triggers):
+                # Score by number of filter constraints — more specific = better.
+                best_specificity = max(
+                    (len(t.filter) + (1 if t.event else 0) for t in topic.triggers),
+                    default=1,
+                )
+                matches.append(
+                    TopicMatch(topic=topic, score=float(best_specificity), match_type="hard")
+                )
+        matches.sort(key=lambda m: m.score, reverse=True)
+        return matches
+
+    def match_message(self, text: str) -> list[TopicMatch]:
+        """Match message text against soft triggers of all active topics.
+
+        Returns matches sorted by score descending.
+        """
+        matches: list[TopicMatch] = []
+        for topic in self._active_topics():
+            score = self._matcher.match_soft(text, topic.soft_triggers)
+            if score > 0.0:
+                matches.append(TopicMatch(topic=topic, score=score, match_type="soft"))
+        matches.sort(key=lambda m: m.score, reverse=True)
+        return matches
+
+    def get_context(self, topic: Topic) -> str:
+        """Render a topic as injectable context markdown."""
+        lines = [
+            f"## Topic: {topic.name}",
+            f"*Scope: {topic.scope} | Agent: {topic.agent} | Status: {topic.status}*",
+            "",
+            topic.body,
+        ]
+        return "\n".join(lines)
+
+    def get_context_for_matches(self, matches: list[TopicMatch], max_topics: int = 3) -> str:
+        """Render context for the top N matched topics."""
+        if not matches:
+            return ""
+
+        blocks: list[str] = []
+        for match in matches[:max_topics]:
+            blocks.append(self.get_context(match.topic))
+        return "\n\n---\n\n".join(blocks)
+
+    def _active_topics(self) -> list[Topic]:
+        return [t for t in self._topics if t.status == "active"]
+
+
+__all__ = ["TopicManager", "TopicMatch"]

--- a/silas/models/topics.py
+++ b/silas/models/topics.py
@@ -1,0 +1,47 @@
+"""Topic models — canonical re-exports from silas.topics.model.
+
+This module provides the names required by the public API surface
+(TopicFrontmatter, Topic, TopicTrigger, SoftTrigger, TopicApproval)
+while keeping the implementation in ``silas.topics.model``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+# TopicFrontmatter is a view of Topic without body — useful when you only
+# need metadata (e.g. listing topics without loading full content).
+from pydantic import BaseModel, Field
+
+from silas.topics.model import ApprovalSpec as TopicApproval
+from silas.topics.model import SoftTrigger, Topic
+from silas.topics.model import TriggerSpec as TopicTrigger
+
+
+class TopicFrontmatter(BaseModel):
+    """Frontmatter-only view of a Topic (no body)."""
+
+    id: str
+    name: str
+    scope: Literal["session", "project", "infinite"]
+    agent: Literal["proxy", "planner", "executor"]
+    status: Literal["active", "paused", "completed", "archived"] = "active"
+    triggers: list[TopicTrigger] = Field(default_factory=list)
+    soft_triggers: list[SoftTrigger] = Field(default_factory=list)
+    approvals: list[TopicApproval] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @classmethod
+    def from_topic(cls, topic: Topic) -> TopicFrontmatter:
+        return cls.model_validate(topic.model_dump(exclude={"body"}))
+
+
+__all__ = [
+    "SoftTrigger",
+    "Topic",
+    "TopicApproval",
+    "TopicFrontmatter",
+    "TopicTrigger",
+]

--- a/topics/ci-failure-handler.md
+++ b/topics/ci-failure-handler.md
@@ -1,0 +1,31 @@
+---
+id: ci-failure-handler
+name: CI Failure Handler
+scope: project
+agent: executor
+status: active
+triggers:
+  - source: github
+    event: check_suite.completed
+    filter:
+      conclusion: failure
+soft_triggers:
+  - keywords: ["ci", "build", "failure", "pipeline"]
+    entity: github
+approvals:
+  - tool: codex_exec
+    constraints:
+      max_runtime: 300
+---
+
+# CI Failure Handler
+
+When CI fails on a pull request or push:
+
+1. Fetch the workflow run logs via GitHub API
+2. Identify the failing step and error message
+3. Check if the failure is flaky (compare with recent runs)
+4. If deterministic: propose a fix on the feature branch
+5. If flaky: document in the flaky-tests tracker and re-run
+
+**Do NOT merge or push to protected branches without approval.**

--- a/topics/daily-standup.md
+++ b/topics/daily-standup.md
@@ -1,0 +1,25 @@
+---
+id: daily-standup
+name: Daily Standup Context
+scope: infinite
+agent: proxy
+status: active
+triggers:
+  - source: schedule
+    event: cron
+    filter:
+      schedule_name: daily_standup
+soft_triggers:
+  - keywords: ["standup", "daily", "what did", "blockers", "today"]
+---
+
+# Daily Standup
+
+When preparing or participating in a daily standup:
+
+1. Summarize completed work items from the last 24 hours
+2. List in-progress items and their current status
+3. Flag any blockers or items needing escalation
+4. Check calendar for meetings that might affect availability
+
+Keep updates concise — aim for 2-3 bullet points per section.


### PR DESCRIPTION
Closes #284

## Changes
- `Topic`, `TopicFrontmatter`, `TopicTrigger`, `SoftTrigger`, `TopicApproval` models
- `TopicManager`: load from markdown, hard/soft trigger matching, context rendering
- Wired into `ProxyConsumer` — matched topics inject context on message arrival
- 2 example topics (CI failure handler, daily standup)
- 11 new tests (42 total in file)