### PR TITLE
feat: externalize and version system prompts via PromptManager (#301)

### DIFF
--- a/config/silas.yaml.example
+++ b/config/silas.yaml.example
@@ -1,8 +1,8 @@
 silas:
-  owner_id: david
+  owner_id: owner
   agent_name: Silas
-  owner_name: David
-  registration_open: false
+  owner_name: ""
+  registration_open: true
   data_dir: ./data
   models:
     proxy: openrouter:anthropic/claude-haiku-4-5
@@ -10,6 +10,24 @@ silas:
     executor: openrouter:anthropic/claude-haiku-4-5
     scorer: openrouter:anthropic/claude-haiku-4-5
     api_key_ref: openrouter-api-key
+  prompts:
+    variables:
+      product_name: Silas
+      response_style: concise
+    proxy:
+      path: ./silas/agents/prompts/proxy_system.md
+      variables:
+        route_bias: balanced
+    planner:
+      path: ./silas/agents/prompts/planner_system.md
+    executor:
+      # Either set `path` to a file or define an inline Jinja2 template.
+      template: |
+        <!-- prompt-version: cfg-v1 -->
+        You are the {{ agent_name }} Executor agent.
+        Tone: {{ response_style }}.
+        Personality traits: {{ personality_traits | default("none") }}.
+        Return valid `ExecutorAgentOutput`.
   context:
     total_tokens: 180000
     system_max: 8000
@@ -47,26 +65,9 @@ silas:
   stream:
     streaming_enabled: true
     chunk_size: 50
-  prompts:
-    variables:
-      organization: Silas Runtime
-    proxy:
-      path: ./silas/agents/prompts/proxy_system.md
-    planner:
-      path: ./silas/agents/prompts/planner_system.md
-    executor:
-      path: ./silas/agents/prompts/executor_system.md
   channels:
     web:
       enabled: true
       host: 127.0.0.1
       port: 8420
       auth_token: null
-  observability:
-    loki_url: "http://127.0.0.1:3100"
-    metrics_enabled: true
-    env: dev
-  telemetry:
-    enabled: true
-    endpoint: "localhost:4317"
-    env: dev

--- a/silas/agents/prompts/executor_system.md
+++ b/silas/agents/prompts/executor_system.md
@@ -1,3 +1,5 @@
+<!-- prompt-version: v1 -->
+
 You are the Silas Executor agent.
 
 Always return valid `ExecutorAgentOutput`.

--- a/silas/agents/prompts/planner_system.md
+++ b/silas/agents/prompts/planner_system.md
@@ -1,3 +1,5 @@
+<!-- prompt-version: v1 -->
+
 You are the Silas Planner agent.
 
 Always return a valid `AgentResponse`.

--- a/silas/agents/prompts/proxy_system.md
+++ b/silas/agents/prompts/proxy_system.md
@@ -1,3 +1,5 @@
+<!-- prompt-version: v1 -->
+
 You are the Silas Proxy agent.
 
 Return a valid `RouteDecision` object for every request.

--- a/silas/config.py
+++ b/silas/config.py
@@ -161,6 +161,30 @@ class StreamConfig(BaseModel):
     max_memory_ops_per_turn: int = Field(default=10, ge=1)
 
 
+class PromptConfig(BaseModel):
+    """Prompt source and template options for one agent."""
+
+    path: Path | None = None
+    template: str | None = None
+    version: str | None = None
+    variables: dict[str, object] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_source(self) -> PromptConfig:
+        if self.path is not None and self.template is not None:
+            raise ValueError("prompt config can define either path or template, not both")
+        return self
+
+
+class PromptsConfig(BaseModel):
+    """Configurable prompt overrides and template variables."""
+
+    variables: dict[str, object] = Field(default_factory=dict)
+    proxy: PromptConfig = Field(default_factory=PromptConfig)
+    planner: PromptConfig = Field(default_factory=PromptConfig)
+    executor: PromptConfig = Field(default_factory=PromptConfig)
+
+
 class SilasSettings(BaseSettings):
     owner_id: str = "owner"
     agent_name: str = "Silas"
@@ -171,6 +195,7 @@ class SilasSettings(BaseSettings):
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     context: ContextConfig = Field(default_factory=ContextConfig)
     stream: StreamConfig = Field(default_factory=StreamConfig)
+    prompts: PromptsConfig = Field(default_factory=PromptsConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
@@ -243,6 +268,8 @@ __all__ = [
     "ContextConfig",
     "ExecutionConfig",
     "ModelsConfig",
+    "PromptConfig",
+    "PromptsConfig",
     "SilasConfig",
     "SilasSettings",
     "StreamConfig",

--- a/silas/core/prompt_manager.py
+++ b/silas/core/prompt_manager.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, StrictUndefined, select_autoescape
+
+from silas.config import PromptConfig, PromptsConfig
+
+logger = logging.getLogger(__name__)
+
+_VERSION_RE = re.compile(r"<!--\s*(?:prompt[-_ ]?)?version\s*:\s*([^>]+?)\s*-->")
+
+_DEFAULT_FALLBACKS: dict[str, str] = {
+    "proxy": (
+        "You are the Silas Proxy agent.\n\n"
+        "Return a valid RouteDecision object for every request.\n\n"
+        'Routing criteria:\n- route="direct": simple questions, greetings, factual lookups, '
+        'and single-step tasks.\n- route="planner": multi-step tasks, tasks requiring '
+        "tools/skills, or tasks with dependencies.\n\nOutput contract:\n"
+        "- direct route: set response.message with the user-facing answer.\n- planner "
+        "route: set response to null; planner will produce plan actions.\n- always set "
+        "reason, interaction_register, interaction_mode, and context_profile.\n\n"
+        "Context profile guidance:\n- conversation: general dialogue and simple Q&A\n"
+        "- coding: code/debug/implementation tasks\n- research: investigation and "
+        "source-heavy lookups\n- support: troubleshooting and helpdesk-style requests\n"
+        "- planning: explicit multi-step orchestration requests\n\n"
+        "When tools are available, use them to gather information BEFORE making your\n"
+        "routing decision. For example, search memory for relevant context or look up\n"
+        "facts via web search.\n"
+    ),
+    "planner": (
+        "You are the Silas Planner agent.\n\n"
+        "Return a valid AgentResponse with a plan_action that includes markdown plan text.\n\n"
+        "Requirements:\n- Always produce parseable markdown with YAML front matter.\n"
+        "- YAML must include: id, type, title.\n- Keep the body actionable and concise.\n"
+        "- Set needs_approval=true for executable plans.\n- Use "
+        "interaction_mode=act_and_report unless the task is clearly high-risk.\n"
+    ),
+    "executor": (
+        "You are the Silas Executor agent.\n\n"
+        "Return valid `ExecutorAgentOutput` JSON.\n\nRules:\n- Summarize the action taken.\n"
+        "- Emit tool calls in execution order.\n- Keep artifact_refs aligned to produced "
+        "artifacts.\n- Return concise, actionable next_steps.\n"
+    ),
+}
+
+
+class PromptManager:
+    """Resolve, render, and cache system prompts for agents.
+
+    Why this manager exists: prompt behavior must be externally configurable
+    and auditable while preserving deterministic fallback behavior.
+    """
+
+    def __init__(
+        self,
+        prompts_config: PromptsConfig | None = None,
+        *,
+        prompt_dir: Path | None = None,
+        fallback_prompts: Mapping[str, str] | None = None,
+        base_context: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._prompts_config = prompts_config or PromptsConfig()
+        self._prompt_dir = prompt_dir or (
+            Path(__file__).resolve().parent.parent / "agents" / "prompts"
+        )
+        self._fallback_prompts = dict(fallback_prompts or _DEFAULT_FALLBACKS)
+        self._base_context = dict(base_context or {})
+        self._jinja = Environment(
+            undefined=StrictUndefined,
+            autoescape=select_autoescape(
+                enabled_extensions=("html", "xml"),
+                disabled_extensions=("md",),
+                default_for_string=False,
+                default=False,
+            ),
+        )
+        self._render_cache: dict[tuple[str, tuple[tuple[str, str], ...]], str] = {}
+        self._source_cache: dict[str, _PromptSource] = {}
+
+    def get_prompt(self, agent_name: str, **context: object) -> str:
+        """Return a rendered prompt for `agent_name`.
+
+        The source selection order is:
+        1) prompt config (path/template),
+        2) `silas/agents/prompts/<agent>_system.md`,
+        3) built-in hardcoded fallback.
+        """
+
+        normalized_name = agent_name.strip().lower()
+        if not normalized_name:
+            raise ValueError("agent_name must be non-empty")
+
+        source = self._resolve_source(normalized_name)
+        render_context = self._build_context(normalized_name, context)
+        cache_key = (normalized_name, _freeze_context(render_context))
+        if cache_key in self._render_cache:
+            return self._render_cache[cache_key]
+
+        template = self._jinja.from_string(source.template)
+        rendered = template.render(render_context).strip()
+        self._render_cache[cache_key] = rendered
+        return rendered
+
+    def _resolve_source(self, agent_name: str) -> _PromptSource:
+        cached = self._source_cache.get(agent_name)
+        if cached is not None:
+            return cached
+
+        configured = self._resolve_config_source(agent_name)
+        if configured is not None:
+            self._log_active_prompt(agent_name, configured)
+            self._source_cache[agent_name] = configured
+            return configured
+
+        file_source = self._resolve_file_source(agent_name)
+        if file_source is not None:
+            self._log_active_prompt(agent_name, file_source)
+            self._source_cache[agent_name] = file_source
+            return file_source
+
+        fallback_text = self._fallback_prompts.get(agent_name)
+        if fallback_text is None:
+            raise KeyError(f"no fallback prompt configured for agent '{agent_name}'")
+        fallback_source = _PromptSource(
+            template=fallback_text,
+            version="builtin",
+            source=f"builtin:{agent_name}",
+        )
+        self._log_active_prompt(agent_name, fallback_source)
+        self._source_cache[agent_name] = fallback_source
+        return fallback_source
+
+    def _resolve_config_source(self, agent_name: str) -> _PromptSource | None:
+        config = getattr(self._prompts_config, agent_name, None)
+        if not isinstance(config, PromptConfig):
+            return None
+
+        if config.path is not None:
+            path = Path(config.path)
+            if path.exists():
+                template = path.read_text(encoding="utf-8").strip()
+                if template:
+                    return _PromptSource(
+                        template=template,
+                        version=config.version or _extract_version(template),
+                        source=str(path),
+                    )
+                logger.warning("Configured prompt path is empty: %s", path)
+            else:
+                logger.warning("Configured prompt path not found: %s", path)
+
+        if config.template is not None and config.template.strip():
+            return _PromptSource(
+                template=config.template.strip(),
+                version=config.version or _extract_version(config.template),
+                source=f"config:prompts.{agent_name}.template",
+            )
+        return None
+
+    def _resolve_file_source(self, agent_name: str) -> _PromptSource | None:
+        file_path = self._prompt_dir / f"{agent_name}_system.md"
+        if not file_path.exists():
+            return None
+        template = file_path.read_text(encoding="utf-8").strip()
+        if not template:
+            return None
+        return _PromptSource(
+            template=template,
+            version=_extract_version(template),
+            source=str(file_path),
+        )
+
+    def _build_context(
+        self,
+        agent_name: str,
+        runtime_context: Mapping[str, object],
+    ) -> dict[str, object]:
+        merged: dict[str, object] = {
+            "agent_name": agent_name,
+            **self._base_context,
+            **self._prompts_config.variables,
+        }
+
+        agent_cfg = getattr(self._prompts_config, agent_name, None)
+        if isinstance(agent_cfg, PromptConfig):
+            merged.update(agent_cfg.variables)
+
+        merged.update(runtime_context)
+        return merged
+
+    def _log_active_prompt(self, agent_name: str, source: _PromptSource) -> None:
+        logger.info(
+            "PromptManager active prompt agent=%s version=%s source=%s",
+            agent_name,
+            source.version or "unknown",
+            source.source,
+        )
+
+
+def _extract_version(template: str) -> str | None:
+    lines = template.splitlines()
+    for line in lines[:5]:
+        match = _VERSION_RE.match(line.strip())
+        if match:
+            version = match.group(1).strip()
+            return version or None
+    return None
+
+
+def _freeze_context(context: Mapping[str, object]) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted((key, _freeze_value(value)) for key, value in context.items()))
+
+
+def _freeze_value(value: object) -> str:
+    if isinstance(value, Mapping):
+        frozen = tuple(sorted((str(key), _freeze_value(item)) for key, item in value.items()))
+        return repr(frozen)
+    if isinstance(value, list):
+        return repr(tuple(_freeze_value(item) for item in value))
+    if isinstance(value, tuple):
+        return repr(tuple(_freeze_value(item) for item in value))
+    return repr(value)
+
+
+class _PromptSource:
+    def __init__(self, *, template: str, version: str | None, source: str) -> None:
+        self.template = template
+        self.version = version
+        self.source = source

--- a/silas/main.py
+++ b/silas/main.py
@@ -34,6 +34,7 @@ from silas.context.scorer import ContextScorer
 from silas.core.context_manager import LiveContextManager
 from silas.core.logging import setup_logging
 from silas.core.plan_parser import MarkdownPlanParser
+from silas.core.prompt_manager import PromptManager
 from silas.core.stream import Stream
 from silas.core.telemetry import init_tracing, shutdown_tracing
 from silas.core.token_counter import HeuristicTokenCounter
@@ -481,16 +482,25 @@ def build_stream(
         auth_token=web_cfg.auth_token,
         data_dir=settings.data_dir,
     )
+    prompt_manager = PromptManager(
+        prompts_config=settings.prompts,
+        base_context={"agent_name": settings.agent_name},
+    )
 
     proxy = build_proxy_agent(
         model=settings.models.proxy,
         default_context_profile=settings.context.default_profile,
+        prompt_manager=prompt_manager,
     )
     planner = build_planner_agent(
         model=settings.models.planner,
         default_context_profile="planning",
+        prompt_manager=prompt_manager,
     )
-    queue_executor_agent = build_executor_agent(model=settings.models.executor)
+    queue_executor_agent = build_executor_agent(
+        model=settings.models.executor,
+        prompt_manager=prompt_manager,
+    )
 
     memory_store = SQLiteMemoryStore(db)
     chronicle_store = SQLiteChronicleStore(db)

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from silas.config import PromptConfig, PromptsConfig
+from silas.core.prompt_manager import PromptManager
+
+
+def test_loads_prompt_from_file_when_present(tmp_path: Path) -> None:
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    (prompt_dir / "proxy_system.md").write_text(
+        "<!-- prompt-version: v-file -->\nProxy file", "utf-8"
+    )
+
+    manager = PromptManager(prompt_dir=prompt_dir)
+
+    prompt = manager.get_prompt("proxy")
+
+    assert "Proxy file" in prompt
+
+
+def test_config_path_override_wins_over_default_prompt_file(tmp_path: Path) -> None:
+    override_path = tmp_path / "override_proxy.md"
+    override_path.write_text("<!-- prompt-version: v-config -->\nConfig proxy", "utf-8")
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    (prompt_dir / "proxy_system.md").write_text("Proxy from file", "utf-8")
+
+    manager = PromptManager(
+        prompts_config=PromptsConfig(proxy=PromptConfig(path=override_path)),
+        prompt_dir=prompt_dir,
+    )
+
+    prompt = manager.get_prompt("proxy")
+
+    assert "Config proxy" in prompt
+    assert "Proxy from file" not in prompt
+
+
+def test_renders_template_with_context_and_custom_variables() -> None:
+    manager = PromptManager(
+        prompts_config=PromptsConfig(
+            variables={"response_style": "precise"},
+            planner=PromptConfig(
+                template=(
+                    "Planner {{ agent_name }} style={{ response_style }} "
+                    "traits={{ personality_traits.warmth }}"
+                )
+            ),
+        ),
+        base_context={"agent_name": "Silas"},
+    )
+
+    prompt = manager.get_prompt("planner", personality_traits={"warmth": "high"})
+
+    assert prompt == "Planner Silas style=precise traits=high"
+
+
+def test_uses_hardcoded_fallback_when_config_and_file_missing(tmp_path: Path) -> None:
+    manager = PromptManager(prompt_dir=tmp_path / "missing-prompts")
+
+    prompt = manager.get_prompt("executor")
+
+    assert "You are the Silas Executor agent." in prompt
+
+
+def test_caches_rendered_prompt_for_identical_context(tmp_path: Path) -> None:
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    (prompt_dir / "proxy_system.md").write_text("Value {{ token }}", "utf-8")
+    manager = PromptManager(prompt_dir=prompt_dir)
+    calls = {"count": 0}
+    original_from_string = manager._jinja.from_string
+
+    def counting_from_string(template: str) -> object:
+        calls["count"] += 1
+        return original_from_string(template)
+
+    manager._jinja.from_string = counting_from_string  # type: ignore[assignment]
+
+    first = manager.get_prompt("proxy", token="abc")
+    second = manager.get_prompt("proxy", token="abc")
+
+    assert first == "Value abc"
+    assert second == "Value abc"
+    assert calls["count"] == 1

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -63,7 +63,8 @@ def test_build_stream_configures_route_profiles_from_settings(
     )
 
     monkeypatch.setattr(
-        "silas.main.build_proxy_agent", lambda model, default_context_profile: FakeModel()
+        "silas.main.build_proxy_agent",
+        lambda model, default_context_profile, **kwargs: FakeModel(),
     )
     RouteDecision.configure_profiles({"conversation", "coding", "research", "support", "planning"})
 
@@ -98,7 +99,8 @@ def test_build_stream_wires_output_gate_runner(
         }
     )
     monkeypatch.setattr(
-        "silas.main.build_proxy_agent", lambda model, default_context_profile: FakeModel()
+        "silas.main.build_proxy_agent",
+        lambda model, default_context_profile, **kwargs: FakeModel(),
     )
 
     stream, _ = build_stream(settings)
@@ -113,7 +115,8 @@ def test_build_stream_injects_signing_key_into_stream(
     settings = SilasSettings.model_validate({"data_dir": str(tmp_path / "data")})
     signing_key = Ed25519PrivateKey.generate()
     monkeypatch.setattr(
-        "silas.main.build_proxy_agent", lambda model, default_context_profile: FakeModel()
+        "silas.main.build_proxy_agent",
+        lambda model, default_context_profile, **kwargs: FakeModel(),
     )
 
     stream, _ = build_stream(settings, signing_key=signing_key)
@@ -128,7 +131,8 @@ def test_build_stream_wires_skill_loader_and_live_resolver(
 ) -> None:
     settings = SilasSettings.model_validate({"data_dir": str(tmp_path / "data")})
     monkeypatch.setattr(
-        "silas.main.build_proxy_agent", lambda model, default_context_profile: FakeModel()
+        "silas.main.build_proxy_agent",
+        lambda model, default_context_profile, **kwargs: FakeModel(),
     )
 
     stream, _ = build_stream(settings)


### PR DESCRIPTION
Closes #301

## Changes
- `PromptManager` with Jinja2 template rendering, config overrides, file fallback, caching
- `PromptsConfig` / `PromptConfig` in config schema
- Refactored all 3 agents (proxy, planner, executor) to use PromptManager
- Removed `DEFAULT_*_SYSTEM_PROMPT` constants and `_load_*_system_prompt()` functions
- Version headers in prompt files (`<!-- prompt-version: v1 -->`)
- `config/silas.yaml.example` with prompts section
- 5 tests covering file loading, config override, template rendering, fallback, caching