### PR TITLE
fix: remove executor_type from plan hash canonical projection (#198)

### DIFF
--- a/silas/models/work.py
+++ b/silas/models/work.py
@@ -161,7 +161,6 @@ class WorkItem(BaseModel):
             "agent": self.agent,
             "budget": self.budget.model_dump(mode="json"),
             "body": self.body,
-            "executor_type": self.executor_type,
             "interaction_mode": self.interaction_mode,
             "input_artifacts_from": self.input_artifacts_from,
             "verify": [check.model_dump(mode="json") for check in self.verify],

--- a/tests/test_models_validation.py
+++ b/tests/test_models_validation.py
@@ -498,10 +498,10 @@ class TestWorkItem:
         wi2 = self._make_work_item(body="version 2")
         assert wi1.plan_hash() != wi2.plan_hash()
 
-    def test_plan_hash_changes_on_executor_type_change(self) -> None:
+    def test_plan_hash_ignores_executor_type_change(self) -> None:
         wi1 = self._make_work_item(executor_type="skill")
         wi2 = self._make_work_item(executor_type="shell")
-        assert wi1.plan_hash() != wi2.plan_hash()
+        assert wi1.plan_hash() == wi2.plan_hash()
 
     def test_naive_created_at_rejected(self) -> None:
         with pytest.raises(ValidationError, match="timezone-aware"):


### PR DESCRIPTION
Closes #198. Removes executor_type from plan_hash_bytes() to match spec §3.3.